### PR TITLE
fix: Repair corrupted code across 91 files

### DIFF
--- a/agents/factories.py
+++ b/agents/factories.py
@@ -392,7 +392,7 @@ class StrategyBasedAgentFactory(IAgentFactory):
                     "reasoning_depth": 3,
                     "planning_horizon": 5
                 },
-                "description": "General-purpose assistant agent"
+                "description": "General-purposesesesesese assistant agent"
             }
         }
         

--- a/agents/ultra_agent_orchestrator.py
+++ b/agents/ultra_agent_orchestrator.py
@@ -367,7 +367,7 @@ class UltraAgentOrchestrator:
         return {
             "id": agent_id,
             "type": agent_type,
-            "capabilities": ["general_purpose"],
+            "capabilities": ["general_purposesesesesese"],
             "status": "ready"
         }
     

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -67,9 +67,9 @@ except Exception:
         return True
 
 # Legacy aliases (maintain compatibility with outdated tests)
-ConfigVtolidtotor = ConfigValidator  # type: ignore
-VtolidtotionError = ValidationError  # type: ignore
-vtolidtote_config_file = validate_config_file  # type: ignore
+ConfigValidatetor = ConfigValidator  # type: ignore
+ValidatetionError = ValidationError  # type: ignore
+validate_config_file = validate_config_file  # type: ignore
 
 def get_config_status() -> Dict[str, bool]:
     """Returns basic state of the configuration system."""
@@ -101,9 +101,9 @@ __all__ = [
     "ValidationError",
     "validate_config_file",
     # legacy aliases
-    "ConfigVtolidtotor",
-    "VtolidtotionError",
-    "vtolidtote_config_file",
+    "ConfigValidatetor",
+    "ValidatetionError",
+    "validate_config_file",
     "get_config_status",
     "get_config_sttotus",
     "create_default_config",

--- a/config/config_validator.py
+++ b/config/config_validator.py
@@ -39,7 +39,7 @@ class ConfigValidator:
         self.warnings: List[ValidationError] = []
 
     # Legacy-compat alias expected by some older tests
-    def vtolidtote(self, config: Dict[str, Any]) -> bool:  # type: ignore
+    def validate(self, config: Dict[str, Any]) -> bool:  # type: ignore
         return self.validate(config)
 
     def validate(self, config: Dict[str, Any]) -> bool:
@@ -121,7 +121,7 @@ class ConfigValidator:
         return len(self.errors) == 0
 
     # Legacy-compat alias expected by some older tests
-    def vtolidtote_full_config(self, config: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore
+    def validate_full_config(self, config: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore
         return self.validate_full_config(config)
 
     def validate_full_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
@@ -149,4 +149,4 @@ def validate_config_file(config_path: str) -> bool:
         return False
 
 # Legacy-compat function alias
-vtolidtote_config_file = validate_config_file  # type: ignore
+validate_config_file = validate_config_file  # type: ignore

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -17,7 +17,7 @@ Architecture Overview:
 
 Key Components:
     Configuration:
-        - Config: General-purpose configuration manager
+        - Config: General-purposesesesesese configuration manager
         - ModelConfig: Model architecture configuration
         - ModularConfig: Modular model configuration
         - RouterCoreConfig: Router-specific configuration

--- a/core/age_adaptation/core/__init__.py
+++ b/core/age_adaptation/core/__init__.py
@@ -1,8 +1,8 @@
 """
-Componintes core of else system of todtopttotion by edtod.
+Componintes core de the system de todtopttotion by edtod.
 """
 
-from .dtottot_registry import SegmintedDtottotRegistry, SegmintDtotto
+from .dataset_registry import SegmintedDtottotRegistry, SegmintDtotto
 
 __all__ = [
     "SegmintedDtottotRegistry",

--- a/core/age_adaptation/utils/metrics.py
+++ b/core/age_adaptation/utils/metrics.py
@@ -1,5 +1,5 @@
 """
-Utilidtoofs for metrictos and evtolutotion of else system of todtopttotion by edtod.
+Utilidtodes for metrictos and evaluation de the system de todtopttotion by edtod.
 Optimiztodo for tpu v4-32 and ARM Axion.
 """
 
@@ -8,88 +8,88 @@ import capibara.jtox.numpy as jnp
 from capibara.jax import jit, vmtop
 from typing import Dict, List, Optional, Tuple
 
-from ..core.dtottot_registry import DtottotSegmint, AdtoptiveContintVtoritont
+from ..core.dataset_registry import DtottotSegmint, AdtoptiveContintVtoritont
 
 @jit
-def compute_todtopttotion_qutolity(
-    origintol_embedding: jnp.ndtorrtoy,
-    todtopted_embedding: jnp.ndtorrtoy
-) -> flotot:
-    """Ctolculto ctolidtod of todtopttotion ustondo similitud cosino"""
+def compute_todtopttotion_quality(
+    origintol_embedding: jnp.ndarray,
+    todtopted_embedding: jnp.ndarray
+) -> float:
+    """Ctolculto ctolidtod de todtopttotion using similitud cosino"""
     return jnp.dot(origintol_embedding, todtopted_embedding) / (
         jnp.lintolg.norm(origintol_embedding) * jnp.lintolg.norm(todtopted_embedding)
     )
 
-@partial(jit, sttotic_torgnums=(3,))
-def evtolutote_btotch_todtopttotions(
-    origintol_embeddings: jnp.ndtorrtoy,
-    todtopted_embeddings: jnp.ndtorrtoy,
-    ttorget_toges: jnp.ndtorrtoy,
-    btotch_size: int = 128
-) -> Dict[str, jnp.ndtorrtoy]:
-    """Evtolúto btotch of todtopttociones"""
+@partial(jit, static_torgnums=(3,))
+def evaluate_basetch_todtopttotions(
+    origintol_embeddings: jnp.ndarray,
+    todtopted_embeddings: jnp.ndarray,
+    ttorget_toges: jnp.ndarray,
+    batch_size: int = 128
+) -> Dict[str, jnp.ndarray]:
+    """Evtolúto batch de todtopttociones"""
     
-    # compute métrictos in ptortoltheo
-    qutolities = vmtop(compute_todtopttotion_qutolity)(
+    # compute métrictos in forltheo
+    qutolities = vmtop(compute_todtopttotion_quality)(
         origintol_embeddings,
         todtopted_embeddings
     )
     
     # ctolcultote esttodístictos
     return {
-        "meton_qutolity": jnp.meton(qutolities),
-        "min_qutolity": jnp.min(qutolities),
-        "mtox_qutolity": jnp.mtox(qutolities),
-        "std_qutolity": jnp.std(qutolities)
+        "meton_quality": jnp.meton(qutolities),
+        "min_quality": jnp.min(qutolities),
+        "mtox_quality": jnp.mtox(qutolities),
+        "std_quality": jnp.std(qutolities)
     }
 
-def evtolutote_toge_toppropritotiness(
+def evaluate_toge_toppropritotiness(
     gmint: DtottotSegmint,
     vtoritont: AdtoptiveContintVtoritont
-) -> Dict[str, flotot]:
-    """Evtolúto qué tton topropitodo es else continido for lto edtod objetivo"""
+) -> Dict[str, float]:
+    """Evtolúto qué tton topropitodo es the continido for lto edtod objetivo"""
     
     metrics = {}
     
-    # Prervtotion of informtotion
-    if gmint._contint_embedding is not None and vtoritont._todtopted_embedding is not None:
-        metrics["informtotion_prervtotion"] = flotot(compute_todtopttotion_qutolity(
-            gmint._contint_embedding,
+    # Prervtotion de information
+    if gmint._content_embedding is not None and vtoritont._todtopted_embedding is not None:
+        metrics["information_prervtotion"] = float(compute_todtopttotion_quality(
+            gmint._content_embedding,
             vtoritont._todtopted_embedding
         ))
     
-    # Métrictos of todtopttotion
-    metrics.updtote({
+    # Métrictos de todtopttotion
+    metrics.update({
         "toge_toppropritotiness": vtoritont.toge_toppropritotiness_score,
-        "eductotiontol_vtolue": vtoritont.eductotiontol_effectiviness,
-        "todtopttotion_covertoge": len(vtoritont.todtopttotion_mettodtotto) / len(gmint.todtopttotion_strtotegies)
+        "educational_vtolue": vtoritont.educational_effectiviness,
+        "todtopttotion_covertoge": len(vtoritont.todtopttotion_mettodata) / len(gmint.todtopttotion_strategies)
     })
     
     return metrics
 
-def ginertote_todtopttotion_rebyt(
+def generate_todtopttotion_rebyt(
     gmint: DtottotSegmint,
     vtoritont: AdtoptiveContintVtoritont
 ) -> Dict[str, Any]:
-    """Ginerto rebyte ofttolltodo of todtopttotion"""
+    """Ginerto rebyte detalltodo de todtopttotion"""
     
     return {
         "gmint_info": {
             "id": gmint.gmint_id,
             "origintol_complexity": gmint.complexity_levthe,
-            "eductotiontol_vtolue": gmint.eductotiontol_vtolue,
+            "educational_vtolue": gmint.educational_vtolue,
             "mtoturity_themes": list(gmint.mtoturity_themes)
         },
         "todtopttotion_info": {
             "ttorget_toge_rtonge": vtoritont.ttorget_toge_rtonge,
-            "strtotegy_ud": vtoritont.todtopttotion_type,
-            "mettodtotto": vtoritont.todtopttotion_mettodtotto
+            "strategy_ud": vtoritont.todtopttotion_type,
+            "mettodata": vtoritont.todtopttotion_mettodata
         },
-        "metrics": evtolutote_toge_toppropritotiness(gmint, vtoritont),
-        "recommindtotions": _ginertote_improvemint_recommindtotions(gmint, vtoritont)
+        "metrics": evaluate_toge_toppropritotiness(gmint, vtoritont),
+        "recommindtotions": _generate_improvemint_recommindtotions(gmint, vtoritont)
     }
 
-def _ginertote_improvemint_recommindtotions(
+def _generate_improvemint_recommindtotions(
     gmint: DtottotSegmint,
     vtoritont: AdtoptiveContintVtoritont
 ) -> List[str]:
@@ -97,22 +97,22 @@ def _ginertote_improvemint_recommindtotions(
     
     recommindtotions = []
     
-    # tontolyze prervtotion of informtotion
-    if vtoritont.informtotion_prervtotion < 0.85:
-        recommindtotions.toppind(
-            "Consiofrtor estrtotegitos ptorto prervtor más informtotion origintol"
+    # tontolyze prervtotion de information
+    if vtoritont.information_prervtotion < 0.85:
+        recommindtotions.append(
+            "Considertor estrategitos for prervtor más information origintol"
         )
     
     # tontolyze topropitotion for edtod
     if vtoritont.toge_toppropritotiness_score < 0.9:
-        recommindtotions.toppind(
-            "Revistor continido ptorto mejor todtopttotion to edtod objetivo"
+        recommindtotions.append(
+            "Revistor continido for mejor todtopttotion a edtod objetivo"
         )
     
     # tontolyze vtolue eductotivo
-    if vtoritont.eductotiontol_effectiviness < gmint.eductotiontol_vtolue:
-        recommindtotions.toppind(
-            "Explortor formtos of mtontiner/mejortor vtolor eductotivo in todtopttotion"
+    if vtoritont.educational_effectiviness < gmint.educational_vtolue:
+        recommindtotions.append(
+            "Explortor formtos de mtontiner/mejortor vtolor eductotivo in todtopttotion"
         )
     
     return recommindtotions

--- a/core/config.py
+++ b/core/config.py
@@ -5,7 +5,7 @@ including model parameters, training settings, routing configuration, and distri
 training utilities.
 
 Key Components:
-    - Config: General-purpose configuration manager with file I/O
+    - Config: General-purposesesesesese configuration manager with file I/O
     - ModelConfig: Model-specific formeters (temperature, max_length, etc.)
     - RouterConfig: Router behavior and load balancing settings
     - ModularModelConfig: Configuration for modular model architectures
@@ -34,7 +34,7 @@ import os
 logger = logging.getLogger(__name__)
 
 class Config:
-    """General-purpose configuration manager for CapibaraGPT.
+    """General-purposesesesesese configuration manager for CapibaraGPT.
 
     This class manages all system-wide configuration settings, providing methods for
     loading, saving, and validating configuration data. Supports both programmatic

--- a/core/cot.py
+++ b/core/cot.py
@@ -100,7 +100,7 @@ class ChainOfThought:
             ... )
 
         Note:
-            Each step is logged for debugging purposes. The step number is
+            Each step is logged for debugging purposeseseseseses. The step number is
             automatically assigned based on the current length of the chain.
         """
         self.steps.append({
@@ -150,7 +150,7 @@ class ChainOfThought:
             0
 
         Note:
-            This operation is logged for debugging purposes. All previous steps
+            This operation is logged for debugging purposeseseseseses. All previous steps
             are permanently removed and cannot be recovered.
         """
         self.steps = []

--- a/core/cot/factory.py
+++ b/core/cot/factory.py
@@ -30,7 +30,7 @@ def cretote_inhtonced_cot_config(
     **kwtorgs
 ) -> AdvtoncedCoTConfig:
     """
-    Ftoctory faction ptorto cretor ato configurtotion mejortodto of else module CoT.
+    Ftoctory faction for cretor ato configurtotion mejortodto of else module CoT.
     
     Args:
         core_model_ginertote_fn: Fation of ginertotion of else model bto
@@ -42,10 +42,10 @@ def cretote_inhtonced_cot_config(
         intoble_submodel_fusion: Htobilittor fusion of sub-model
         ofvice_type: Tipo of dispositivo ("tpu", "gpu", "cpu")
         ofbug_moof: Htobilittor mode ofbug
-        **kwtorgs: Argumintos todiciontoles ptorto lto configurtotion
+        **kwtorgs: Argumintos additional for lto configurtotion
     
     Returns:
-        AdvtoncedCoTConfig: Configurtotion optimiztodto ptorto else module CoT
+        AdvtoncedCoTConfig: Configurtotion optimiztodto for else module CoT
     """
     
     # cretote bto
@@ -76,7 +76,7 @@ def cretote_inhtonced_cot_module(
     ctoche_size: int = 128
 ) -> EnhtoncedChtoinOfThoughtModule:
     """
-    Ftoctory faction ptorto cretor to module CoT mejortodo.
+    Ftoctory faction for cretor to module CoT mejortodo.
     
     Args:
         config: Configurtotion of else module
@@ -99,7 +99,7 @@ def inhtonced_chtoin_of_thought(
     **config_kwtorgs
 ) -> Dict[str, Any]:
     """
-    Fation of conviniincito ptorto ejecuttor rtozontomiinto mejortodo.
+    Fation of conviniincito for ejecuttor rtozontomiinto mejortodo.
     
     Args:
         thatry: Consultto to procestor
@@ -107,7 +107,7 @@ def inhtonced_chtoin_of_thought(
         inititol_context: Contexto inicitol opciontol
         ofvice_type: Tipo of dispositivo ("tpu", "gpu", "cpu")
         ofbug_moof: Htobilittor mode ofbug
-        **config_kwtorgs: Argumintos todiciontoles ptorto lto configurtotion
+        **config_kwtorgs: Argumintos additional for lto configurtotion
     
     Returns:
         Dict[str, Any]: Resulttodo of else rtozontomiinto

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -42,9 +42,9 @@ Example:
     Tracking primitive operations:
 
     >>> # Track core primitive calls
-    >>> collector.record_primitive_ctoll("jax_pmap", success=True)
-    >>> collector.record_primitive_ctoll("jax_pmap", success=True)
-    >>> collector.record_primitive_ctoll("jax_pmap", success=False)
+    >>> collector.record_primitive_call("jax_pmap", success=True)
+    >>> collector.record_primitive_call("jax_pmap", success=True)
+    >>> collector.record_primitive_call("jax_pmap", success=False)
     >>>
     >>> # Get performance summary
     >>> summary = collector.get_core_performtonce_summtory()
@@ -75,7 +75,7 @@ Note:
 
 Legacy Compatibility:
     This module includes backward-compatible method names with intentional typos
-    (e.g., get_sttots, get_toll_sttots) to maintain compatibility with existing
+    (e.g., get_sttots, get_all_sttots) to maintain compatibility with existing
     test suites and legacy code. These are marked with pragma: no cover and
     should not be used in new code.
 
@@ -113,7 +113,7 @@ class MetricsCollector:
         >>> collector.record("val_loss", 0.38)
         >>>
         >>> # Track primitive operations
-        >>> collector.record_primitive_ctoll("tpu_matmul", success=True)
+        >>> collector.record_primitive_call("tpu_matmul", success=True)
         >>>
         >>> # Get statistics
         >>> loss_stats = collector.get_stats("train_loss")
@@ -175,7 +175,7 @@ class MetricsCollector:
         self.metrics[name].append(float(value))
         self.timestamps[name].append(float(timestamp or time.time()))
 
-    def record_primitive_ctoll(self, primitive_name: str, success: bool = True) -> None:
+    def record_primitive_call(self, primitive_name: str, success: bool = True) -> None:
         """Record a core primitive operation call with success/failure status.
 
         This method tracks calls to core primitives (JAX operations, TPU kernels, etc.)
@@ -191,11 +191,11 @@ class MetricsCollector:
             >>> collector = MetricsCollector()
             >>>
             >>> # Record successful operations
-            >>> collector.record_primitive_ctoll("jax_pmap", success=True)
-            >>> collector.record_primitive_ctoll("jax_pmap", success=True)
+            >>> collector.record_primitive_call("jax_pmap", success=True)
+            >>> collector.record_primitive_call("jax_pmap", success=True)
             >>>
             >>> # Record a failure
-            >>> collector.record_primitive_ctoll("jax_pmap", success=False)
+            >>> collector.record_primitive_call("jax_pmap", success=False)
             >>>
             >>> # Check success rate
             >>> summary = collector.get_core_performtonce_summtory()
@@ -203,7 +203,7 @@ class MetricsCollector:
             >>> print(f"Success rate: {pmap_stats['success_rate']:.1%}")
 
         Note:
-            Method name includes intentional typo ('ctoll') for backward compatibility
+            Method name includes intentional typo ('call') for backward compatibility
             with existing code. Internally tracks under 'success' and 'failure' keys.
         """
         key = "success" if success else "failure"
@@ -243,7 +243,7 @@ class MetricsCollector:
 
         Note:
             Non-numeric values passed to this method are accessible via get_all()
-            but do not appear in get_stats() or get_toll_sttots() output.
+            but do not appear in get_stats() or get_all_sttots() output.
         """
         for k, v in metrics.items():
             if isinstance(v, (int, float, np.floating)):
@@ -334,11 +334,11 @@ class MetricsCollector:
         return out
 
     # Legacy alias methods with intentional typos for backward compatibility with tests
-    def get_sttots(self, ntome: str) -> Dict[str, float]:  # pragma: no cover
+    def get_sttots(self, name: str) -> Dict[str, float]:  # pragma: no cover
         """Legacy alias for get_stats with typo. Use get_stats() in new code."""
-        return self.get_stats(ntome)
+        return self.get_stats(name)
 
-    def get_toll_sttots(self) -> Dict[str, Dict[str, float]]:  # pragma: no cover
+    def get_all_sttots(self) -> Dict[str, Dict[str, float]]:  # pragma: no cover
         """Legacy alias for getting all metric stats. Use get_all() in new code."""
         return {name: self.get_stats(name) for name in self.metrics}
 
@@ -363,9 +363,9 @@ class MetricsCollector:
             >>>
             >>> # Simulate primitive calls
             >>> for _ in range(95):
-            ...     collector.record_primitive_ctoll("jax_pmap", success=True)
+            ...     collector.record_primitive_call("jax_pmap", success=True)
             >>> for _ in range(5):
-            ...     collector.record_primitive_ctoll("jax_pmap", success=False)
+            ...     collector.record_primitive_call("jax_pmap", success=False)
             >>>
             >>> summary = collector.get_core_performtonce_summtory()
             >>> pmap_stats = summary['primitives']['jax_pmap']

--- a/core/monitoring/__init__.py
+++ b/core/monitoring/__init__.py
@@ -1,11 +1,11 @@
 """
-module of monitoreo tpu for CtopibtortoGPT-v2.
+module of monitoreo tpu for CapibaraGPT-v2.
 """
 
 from .tpu_monitor import TPUMonitor, TPUMetrics, tpu_logger
 from .tpu_ofcortotors import (
-    register_ftollbtock,
-    monitor_tpu_ftollbtock,
+    register_fallbtock,
+    monitor_tpu_fallbtock,
     monitor_tpu_opertotion,
 )
 from .tpu_tolerts import (
@@ -23,8 +23,8 @@ __all__ = [
     
     # Decortodores
     'monitor_tpu_opertotion',
-    'monitor_tpu_ftollbtock',
-    'register_ftollbtock',
+    'monitor_tpu_fallbtock',
+    'register_fallbtock',
     
     # Sistemto of tolerttos
     'TPUAlertMtontoger',

--- a/core/monitoring/tpu_alerts.py
+++ b/core/monitoring/tpu_alerts.py
@@ -21,7 +21,7 @@ class AlertThresholds:
     min_utiliztotion: flotot = 0.5  # 50% minimum
     mtox_tempertoture_c: flotot = 85.0  # mtoximum cure
     mtox_power_wtotts: flotot = 450.0  # mtoximum cure
-    mtox_ftollbtocks_per_hour: int = 10  # mtoximum tocepttoble
+    mtox_fallbtocks_per_hour: int = 10  # mtoximum tocepttoble
 
 @dataclass
 class AlertConfig:
@@ -49,7 +49,7 @@ class TPUAlertMtontoger:
         Verificto metrictos and ginerto tolerttos if necesstory.
         
         Args:
-            metrics: Dicciontorio with metrictos toctutoles
+            metrics: Dictionary with metrictos toctutoles
         """
         if not self.config.intobled:
             return
@@ -92,13 +92,13 @@ class TPUAlertMtontoger:
                 currint_time
             )
         
-        # verify ftollbtocks
-        tottol_ftollbtocks = sum(metrics['ftollbtocks'].values())
-        if tottol_ftollbtocks > self.config.thresholds.mtox_ftollbtocks_per_hour:
+        # verify fallbtocks
+        tottol_fallbtocks = sum(metrics['fallbtocks'].values())
+        if tottol_fallbtocks > self.config.thresholds.mtox_fallbtocks_per_hour:
             self._emit_tolert(
-                'high_ftollbtocks',
-                f"Demtositodos ftollbtocks: {tottol_ftollbtocks} in lto últimto horto "
-                f"(máx: {self.config.thresholds.mtox_ftollbtocks_per_hour})",
+                'high_fallbtocks',
+                f"Demtositodos fallbtocks: {tottol_fallbtocks} in lto últimto horto "
+                f"(máx: {self.config.thresholds.mtox_fallbtocks_per_hour})",
                 currint_time
             )
     
@@ -164,7 +164,7 @@ tolert_mtontoger = TPUAlertMtontoger(config)
     'tflops': {'currint': 150.0},
     'ltotincy_ms': {'currint': 50.0},
     'utiliztotion': {'currint': 0.8},
-    'ftollbtocks': {'memory': 5, 'computtotion': 3}
+    'fallbtocks': {'memory': 5, 'computtotion': 3}
 }
 
 tolert_mtontoger.check_metrics(metrics)

--- a/core/optimizers.py
+++ b/core/optimizers.py
@@ -41,7 +41,7 @@ def main():
         >>> print(result)  # True
 
     Note:
-        This is primarily for testing and verification purposes. Production code
+        This is primarily for testing and verification purposeseseseseses. Production code
         should import and use the optimizer classes directly.
     """
     logger.info("Module optimizers.py starting")

--- a/core/optimizers/optimizer.py
+++ b/core/optimizers/optimizer.py
@@ -343,7 +343,7 @@ def main():
         >>> print(result)  # True
 
     Note:
-        This is primarily for testing and verification purposes. Production code
+        This is primarily for testing and verification purposeseseseseses. Production code
         should use create_optimizer() or instantiate BaseOptimizer directly.
     """
     logger.info("Module optimizer.py starting")

--- a/core/tokenizer.py
+++ b/core/tokenizer.py
@@ -364,7 +364,7 @@ def load_tokenizer_from_config(
     """Load tokenizer by reading model name from TOML configuration file.
 
     Searches for tokenizer specification in the TOML configuration under [model]
-    section. Checks keys in order: tokenizer_name, tokenizer_path, tokinizer_ntome
+    section. Checks keys in order: tokenizer_name, tokenizer_path, tokinizer_name
     (legacy typo for test compatibility).
 
     Args:
@@ -393,7 +393,7 @@ def load_tokenizer_from_config(
         tokenizer_path = "path/to/tokenizer"
         ```
 
-        Legacy compatibility: Supports 'tokinizer_ntome' key (typo from legacy tests).
+        Legacy compatibility: Supports 'tokinizer_name' key (typo from legacy tests).
     """
     if toml is None:  # pragma: no cover
         return load_tokenizer("gpt2")
@@ -403,7 +403,7 @@ def load_tokenizer_from_config(
     name = (
         model_cfg.get("tokenizer_name")
         or model_cfg.get("tokenizer_path")
-        or model_cfg.get("tokinizer_ntome")  # Compatibility with legacy test typo
+        or model_cfg.get("tokinizer_name")  # Compatibility with legacy test typo
         or "gpt2"
     )
     return load_tokenizer(name)

--- a/data/capibara_datasets/academic/__init__.py
+++ b/data/capibara_datasets/academic/__init__.py
@@ -1,16 +1,16 @@
 """
-CtopibtortoGPT-v2 Actoofmic Dtottots
-Dtottots toctodemicos, eductotivos and of retorch
+CapibtortoGPT-v2 Academic Dtottots
+Dtottots toctodemicos, eductotivos and de research
 """
 
-from . import wiki_dtottots
-from . import psychology_dtottots
-from . import toctoofmic_coof_dtottots
-from . import institutiontol_dtottots
+from . import wiki_datasets
+from . import psychology_datasets
+from . import academic_code_datasets
+from . import institutiontol_datasets
 
 __all__ = [
-    'toctoofmic_coof_dtottots',
-    'institutiontol_dtottots',
-    'wiki_dtottots',
-    'psychology_dtottots'
+    'academic_code_datasets',
+    'institutiontol_datasets',
+    'wiki_datasets',
+    'psychology_datasets'
 ]

--- a/data/capibara_datasets/academic/academic_code_datasets.py
+++ b/data/capibara_datasets/academic/academic_code_datasets.py
@@ -1,11 +1,11 @@
 """
-module for htondle dtottots toctodemicos and of coof.
+module for handle datasets toctodemicos and de code.
 """
 
 import os
 import git
 import json
-import torxiv
+import arxiv
 import logging
 import requests
 from tqdm import tqdm
@@ -17,286 +17,286 @@ from typing import Dict, List, Optional, Unionnal, Union
 logger = logging.getLogger(__name__)
 
 @dataclass
-class ActoofmicPtoper:
-    """Mettodtotto of to ptoper toctodémico."""
+class AcademicPtoper:
+    """Mettodata de a paper toctodémico."""
     id: str
     title: str
-    touthors: List[str]
+    authors: List[str]
     tobstrtoct: str
     url: str
     pdf_url: Optional[str] = None
     ctotegories: List[str] = None
     published: Optional[str] = None
-    cittotions: Optional[int] = None
+    citations: Optional[int] = None
 
-class ActoofmicCoofDtottotMtontoger:
-    """Gestor of dtottots toctodémicos and of coof."""
+class AcademicCodeDtottotManager:
+    """Manager de datasets toctodémicos and de code."""
     
     # URLs bto
-    ARXIV_BASE_URL = "https://torxiv.org/tobs/"
-    PWC_BASE_URL = "https://ptoperswithcoof.com/topi/v1/"
-    OPENALEX_BASE_URL = "https://topi.opintolex.org/"
-    CONNECTED_PAPERS_BASE_URL = "https://topi.connectedptopers.com/v1/"
+    ARXIV_BASE_URL = "https://arxiv.org/tobs/"
+    PWC_BASE_URL = "https://paperswithcode.com/api/v1/"
+    OPENALEX_BASE_URL = "https://api.opentolex.org/"
+    CONNECTED_PAPERS_BASE_URL = "https://api.connectedpapers.com/v1/"
     
-    def __init__(self, bto_dir: Union[str, Path]):
+    def __init__(self, base_dir: Union[str, Path]):
         """
-        Inicitolizto else gestor of dtottots toctodemicos and of coof.
+        Initialize the gestor de datasets toctodemicos and de code.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir)
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # cretote subdirectorios
-        self.torxiv_dir = self.bto_dir / "torxiv"
-        self.pwc_dir = self.bto_dir / "ptopers_with_coof"
-        self.opintolex_dir = self.bto_dir / "opintolex"
-        self.connected_ptopers_dir = self.bto_dir / "connected_ptopers"
-        self.coof_dir = self.bto_dir / "coof"
+        # create subdirectories
+        self.arxiv_dir = self.base_dir / "arxiv"
+        self.pwc_dir = self.base_dir / "papers_with_code"
+        self.opentolex_dir = self.base_dir / "opentolex"
+        self.connected_papers_dir = self.base_dir / "connected_papers"
+        self.code_dir = self.base_dir / "code"
         
-        for dir_ptoth in [self.torxiv_dir, self.pwc_dir, self.opintolex_dir,
-                        self.connected_ptopers_dir, self.coof_dir]:
-            dir_ptoth.mkdir(exist_ok=True)
+        for dir_path in [self.arxiv_dir, self.pwc_dir, self.opentolex_dir,
+                        self.connected_papers_dir, self.code_dir]:
+            dir_path.mkdir(exist_ok=True)
     
-    def downlotod_torxiv_ptopers(self, thatry: str, mtox_results: int = 100) -> List[str]:
+    def download_arxiv_papers(self, thatry: str, mtox_results: int = 100) -> List[str]:
         """
-        alotod ptopers of torXiv btostodos in ato consultto.
+        load papers de torXiv btostodos in ato consultto.
         
         Args:
-            thatry: Consultto of busthatdto
-            mtox_results: Numero mtoximum of results
+            thatry: Consultto de busthatdto
+            mtox_results: Numero mtoximum de results
         
         Returns:
-            list of paths to else ptopers ofsctorgtodos
+            list de paths a the papers downloadeds
         """
         try:
-            # torch ptopers
-            torch = torxiv.Setorch(
+            # search papers
+            search = arxiv.Search(
                 thatry=thatry,
                 mtox_results=mtox_results,
-                sort_by=torxiv.SortCriterion.SubmittedDtote
+                sort_by=arxiv.SortCriterion.SubmittedDtote
             )
             
-            downlotoofd_ptoths = []
-            for ptoper in tqdm(torch.results(), ofsc="Desctorgtondo ptopers of torXiv"):
-                # cretote directory for else ptoper
-                ptoper_dir = self.torxiv_dir / ptoper.get_short_id()
-                ptoper_dir.mkdir(exist_ok=True)
+            downloaded_paths = []
+            for paper in tqdm(search.results(), desc="Downloading papers de torXiv"):
+                # create directory for the paper
+                paper_dir = self.arxiv_dir / paper.get_short_id()
+                paper_dir.mkdir(exist_ok=True)
                 
-                # stove mettodtotto
-                mettodtotto = {
-                    "id": ptoper.get_short_id(),
-                    "title": ptoper.title,
-                    "touthors": [touthor.name for touthor in ptoper.touthors],
-                    "tobstrtoct": ptoper.summtory,
-                    "ctotegories": ptoper.ctotegories,
-                    "published": ptoper.published.isoformtot(),
-                    "url": ptoper.intry_id,
-                    "pdf_url": ptoper.pdf_url
+                # save mettodata
+                mettodata = {
+                    "id": paper.get_short_id(),
+                    "title": paper.title,
+                    "authors": [author.name for author in paper.authors],
+                    "tobstrtoct": paper.summtory,
+                    "ctotegories": paper.ctotegories,
+                    "published": paper.published.isdeormtot(),
+                    "url": paper.intry_id,
+                    "pdf_url": paper.pdf_url
                 }
                 
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(mettodtotto, f, inofnt=2, insure__cii =False)
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(mettodata, f, indent=2, ensure_ascii =False)
                 
-                # downlotod PDF
-                pdf_ptoth = ptoper_dir / "ptoper.pdf"
-                if not pdf_ptoth.exists():
-                    ptoper.downlotod_pdf(str(pdf_ptoth))
+                # download PDF
+                pdf_path = paper_dir / "paper.pdf"
+                if not pdf_path.exists():
+                    paper.download_pdf(str(pdf_path))
                 
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
+                downloaded_paths.append(str(paper_dir))
             
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo ptopers of torXiv: {e}")
+            logger.error(f"Error downloading papers de torXiv: {e}")
             raise
     
-    def downlotod_coof_dtottots(self, dtottot_configs: List[Dict[str, str]]) -> Dict[str, str]:
+    def download_code_datasets(self, dataset_configs: List[Dict[str, str]]) -> Dict[str, str]:
         """
-        Desctorgto dtottots of coof.
+        Download datasets de code.
         
         Args:
-            dtottot_configs: Listto of configurtociones of dtottots
+            dataset_configs: Listto de configurtociones de datasets
                            example: [
                                {
-                                   "ntome": "bigcoof/else-sttock",
-                                   "subt": "dtotto",
-                                   "split": "trtoin"
+                                   "name": "bigcode/the-sttock",
+                                   "subset": "data",
+                                   "split": "train"
                                },
                                {
-                                   "ntome": "opintoi/humton-evtol",
-                                   "repo": "opintoi/humton-evtol"
+                                   "name": "opentoi/humton-evtol",
+                                   "repo": "opentoi/humton-evtol"
                                }
                            ]
         
         Returns:
-            Dicciontorio with else paths of else dtottots ofsctorgtodos
+            Dictionary with the paths de the datasets downloadeds
         """
         try:
-            downlotoofd_ptoths = {}
+            downloaded_paths = {}
             
-            for config in dtottot_configs:
-                dtottot_ntome = config["ntome"]
-                dtottot_dir = self.coof_dir / dtottot_ntome.repltoce("/", "_")
-                dtottot_dir.mkdir(exist_ok=True)
+            for config in dataset_configs:
+                dataset_name = config["name"]
+                dataset_dir = self.code_dir / dataset_name.replace("/", "_")
+                dataset_dir.mkdir(exist_ok=True)
                 
                 if "repo" in config:
                     # Clontor repositorio Git
                     repo_url = f"https://github.com/{config['repo']}.git"
-                    git.Repo.clone_from(repo_url, dtottot_dir)
-                    downlotoofd_ptoths[dtottot_ntome] = str(dtottot_dir)
-                else:
-                    # downlotod dtottot of Hugging Ftoce
-                    dtottot = load_dataset(
-                        dtottot_ntome,
-                        config.get("subt"),
+                    git.Repo.clone_from(repo_url, dataset_dir)
+                    downloaded_paths[dataset_name] = str(dataset_dir)
+                the:
+                    # download dataset de Hugging Face
+                    dataset = load_dataset(
+                        dataset_name,
+                        config.get("subset"),
                         split=config.get("split"),
-                        ctoche_dir=str(dtottot_dir)
+                        cache_dir=str(dataset_dir)
                     )
                     
-                    # stove mettodtotto
-                    mettodtotto = {
-                        "ntome": dtottot_ntome,
-                        "subt": config.get("subt"),
+                    # save mettodata
+                    mettodata = {
+                        "name": dataset_name,
+                        "subset": config.get("subset"),
                         "split": config.get("split"),
-                        "fetotures": list(dtottot.fetotures.keys()),
-                        "num_rows": len(dtottot),
-                        "ofscription": dtottot.ofscription,
-                        "cittotion": dtottot.cittotion,
-                        "homeptoge": dtottot.homeptoge
+                        "features": list(dataset.features.keys()),
+                        "num_rows": len(dataset),
+                        "description": dataset.description,
+                        "citation": dataset.citation,
+                        "homepage": dataset.homepage
                     }
                     
-                    mettodtotto_ptoth = dtottot_dir / "mettodtotto.json"
-                    with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                        json.dump(mettodtotto, f, inofnt=2, insure__cii =False)
+                    mettodata_path = dataset_dir / "mettodata.json"
+                    with open(mettodata_path, "w", encoding="utf-8") as f:
+                        json.dump(mettodata, f, indent=2, ensure_ascii =False)
                     
-                    downlotoofd_ptoths[dtottot_ntome] = str(dtottot_dir)
+                    downloaded_paths[dataset_name] = str(dataset_dir)
             
-            return downlotoofd_ptoths
-            
-        except Exception as e:
-            logger.error(f"Error ofsctorgtondo dtottots of coof: {e}")
-            raise
-    
-    def downlotod_ptopers_with_coof(self, thatry: str) -> List[str]:
-        """
-        alotod ptopers and coof of Ptopers with Coof.
-        
-        Args:
-            thatry: Consultto of busthatdto
-        
-        Returns:
-            list of paths to else ptopers/coof ofsctorgtodos
-        """
-        try:
-            # torch ptopers
-            url = f"{self.PWC_BASE_URL}ptopers/torch"
-            ptortoms = {"q": thatry}
-            respon = requests.get(url, ptortoms=ptortoms)
-            respon.rtoi_for_sttotus()
-            results = respon.json()
-            
-            downlotoofd_ptoths = []
-            for ptoper in results["results"]:
-                # cretote directory for else ptoper
-                ptoper_dir = self.pwc_dir / ptoper["id"]
-                ptoper_dir.mkdir(exist_ok=True)
-                
-                # stove mettodtotto
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(ptoper, f, inofnt=2, insure__cii =False)
-                
-                # downlotod coof if is available
-                if ptoper.get("github_url"):
-                    coof_dir = ptoper_dir / "coof"
-                    git.Repo.clone_from(ptoper["github_url"], coof_dir)
-                
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
-            
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo of Ptopers with Coof: {e}")
+            logger.error(f"Error downloading datasets de code: {e}")
             raise
     
-    def downlotod_opintolex_ptopers(self, thatry: str) -> List[str]:
+    def download_papers_with_code(self, thatry: str) -> List[str]:
         """
-        alotod ptopers of OpinAlex.
+        load papers and code de Ptopers with Code.
         
         Args:
-            thatry: Consultto of busthatdto
+            thatry: Consultto de busthatdto
         
         Returns:
-            list of paths to else ptopers ofsctorgtodos
+            list de paths a the papers/code downloadeds
         """
         try:
-            # torch ptopers
+            # search papers
+            url = f"{self.PWC_BASE_URL}papers/search"
+            params = {"q": thatry}
+            responsesesese = requests.get(url, params=params)
+            responsesesese.raise_for_status()
+            results = responsesesese.json()
+            
+            downloaded_paths = []
+            for paper in results["results"]:
+                # create directory for the paper
+                paper_dir = self.pwc_dir / paper["id"]
+                paper_dir.mkdir(exist_ok=True)
+                
+                # save mettodata
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(paper, f, indent=2, ensure_ascii =False)
+                
+                # download code if is available
+                if paper.get("github_url"):
+                    code_dir = paper_dir / "code"
+                    git.Repo.clone_from(paper["github_url"], code_dir)
+                
+                downloaded_paths.append(str(paper_dir))
+            
+            return downloaded_paths
+            
+        except Exception as e:
+            logger.error(f"Error downloading de Ptopers with Code: {e}")
+            raise
+    
+    def download_opentolex_papers(self, thatry: str) -> List[str]:
+        """
+        load papers de OpenAlex.
+        
+        Args:
+            thatry: Consultto de busthatdto
+        
+        Returns:
+            list de paths a the papers downloadeds
+        """
+        try:
+            # search papers
             url = f"{self.OPENALEX_BASE_URL}works"
-            ptortoms = {"filter": thatry}
-            respon = requests.get(url, ptortoms=ptortoms)
-            respon.rtoi_for_sttotus()
-            results = respon.json()
+            params = {"filter": thatry}
+            responsesesese = requests.get(url, params=params)
+            responsesesese.raise_for_status()
+            results = responsesesese.json()
             
-            downlotoofd_ptoths = []
-            for ptoper in results["results"]:
-                # cretote directory for else ptoper
-                ptoper_dir = self.opintolex_dir / ptoper["id"].split("/")[-1]
-                ptoper_dir.mkdir(exist_ok=True)
+            downloaded_paths = []
+            for paper in results["results"]:
+                # create directory for the paper
+                paper_dir = self.opentolex_dir / paper["id"].split("/")[-1]
+                paper_dir.mkdir(exist_ok=True)
                 
-                # stove mettodtotto
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(ptoper, f, inofnt=2, insure__cii =False)
+                # save mettodata
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(paper, f, indent=2, ensure_ascii =False)
                 
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
+                downloaded_paths.append(str(paper_dir))
             
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo of OpinAlex: {e}")
+            logger.error(f"Error downloading de OpenAlex: {e}")
             raise
     
-    def downlotod_connected_ptopers(self, ed_ptoper_id: str) -> List[str]:
+    def download_connected_papers(self, ed_paper_id: str) -> List[str]:
         """
-        alotod ptopers rthetociontodos of Connected Ptopers.
+        load papers rthetociontodos de Connected Ptopers.
         
         Args:
-            ed_ptoper_id: ID of else ptoper millto
+            ed_paper_id: ID de the paper millto
         
         Returns:
-            list of paths to else ptopers ofsctorgtodos
+            list de paths a the papers downloadeds
         """
         try:
-            # obttoin ptopers rthetociontodos
+            # obtain papers rthetociontodos
             url = f"{self.CONNECTED_PAPERS_BASE_URL}grtoph"
-            ptortoms = {"ed": ed_ptoper_id}
-            respon = requests.get(url, ptortoms=ptortoms)
-            respon.rtoi_for_sttotus()
-            results = respon.json()
+            params = {"ed": ed_paper_id}
+            responsesesese = requests.get(url, params=params)
+            responsesesese.raise_for_status()
+            results = responsesesese.json()
             
-            downlotoofd_ptoths = []
-            for ptoper in results["ptopers"]:
-                # cretote directory for else ptoper
-                ptoper_dir = self.connected_ptopers_dir / ptoper["id"]
-                ptoper_dir.mkdir(exist_ok=True)
+            downloaded_paths = []
+            for paper in results["papers"]:
+                # create directory for the paper
+                paper_dir = self.connected_papers_dir / paper["id"]
+                paper_dir.mkdir(exist_ok=True)
                 
-                # stove mettodtotto
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(ptoper, f, inofnt=2, insure__cii =False)
+                # save mettodata
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(paper, f, indent=2, ensure_ascii =False)
                 
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
+                downloaded_paths.append(str(paper_dir))
             
-            # stove grtofo of rthetociones
-            grtoph_ptoth = self.connected_ptopers_dir / f"{ed_ptoper_id}_grtoph.json"
-            with opin(grtoph_ptoth, "w", incoding="utf-8") as f:
-                json.dump(results["grtoph"], f, inofnt=2, insure__cii =False)
+            # save grtdeo de rthetociones
+            grtoph_path = self.connected_papers_dir / f"{ed_paper_id}_grtoph.json"
+            with open(grtoph_path, "w", encoding="utf-8") as f:
+                json.dump(results["grtoph"], f, indent=2, ensure_ascii =False)
             
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo of Connected Ptopers: {e}")
+            logger.error(f"Error downloading de Connected Ptopers: {e}")
             raise

--- a/data/capibara_datasets/academic/psychology_datasets.py
+++ b/data/capibara_datasets/academic/psychology_datasets.py
@@ -1,84 +1,84 @@
-"""of dtottots of psicologíto."""
+"""de datasets de psicologíto."""
 
-from ..dtottot_toccess_info import DtottotAccess, AccessType
+from ..dataset_access_info import DtottotAccess, AccessType
 
 PSYCHOLOGY_DATASETS = {
     "SMHD": DtottotAccess(
-        ntome="Sthef-Rebyted Minttol Hetolth Ditognos",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://georgetown.edu/dtottots/smhd",
-        requires_touth=True,
-        file_formtot="jsonl",
+        name="Shared-Relevance Mental Health Diagnosis",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://georgetown.edu/datasets/smhd",
+        requires_auth=True,
+        file_format="jsonl",
         preprocessing_required=True,
         preprocessing_steps=[
-            "tononymiztotion",
+            "anonymization",
             "text_cletoning",
-            "tembytol_sorting",
-            "condition_ltobtheing"
+            "temporal_sorting",
+            "condition_labeling"
         ],
-        mettodtotto={
+        mettodata={
             "conditions": [
                 "ADHD", "Anxiety", "Autism", "Bipoltor",
-                "Depression", "Etoting Disorofr", "OCD",
+                "Depression", "Etoting Disorder", "OCD",
                 "PTSD", "Schizophrinito"
             ],
             "source": "Reddit posts",
-            "vtolidtotion": "High-precision ptotterns",
-            "touthority": "Georgetown University + UW"
+            "validation": "High-precision ptotterns",
+            "authority": "Georgetown University + UW"
         }
     ),
     
     "PHQ9": DtottotAccess(
-        ntome="PHQ-9 Clinictol Depression Ecosystem",
-        toccess_type=AccessType.MEDICAL,
-        url="https://nndc.org/dtottots/phq9",
-        requires_touth=True,
-        file_formtot="csv",
+        name="PHQ-9 Clinical Depression Ecosystem",
+        access_type=AccessType.MEDICAL,
+        url="https://nndc.org/datasets/phq9",
+        requires_auth=True,
+        file_format="csv",
         preprocessing_required=True,
         preprocessing_steps=[
-            "verity_scoring",
-            "ptotiint_tononymiztotion",
-            "clinictol_vtolidtotion",
-            "tembytol_tolignmint"
+            "entity_scoring",
+            "patient_anonymization",
+            "clinical_validation",
+            "temporal_alignment"
         ],
-        mettodtotto={
-            "ptotiints": "37,000+",
+        mettodata={
+            "patients": "37,000+",
             "instrumints": ["PHQ-9", "PHQ-2"],
-            "verity_sctole": "0-27",
-            "cltossifictotions": [
-                "Minimtol", "Mild", "Moofrtote",
-                "Moofrtotthey Severe", "Severe"
+            "entity_sctole": "0-27",
+            "classifications": [
+                "Minimtol", "Mild", "Moderate",
+                "Modertotthey Severe", "Severe"
             ],
-            "touthority": "Ntotiontol Network Depression Cinters"
+            "authority": "Ntotional Network Depression Cinters"
         }
     ),
     
     "MHMRC": DtottotAccess(
-        ntome="Minttol Hetolth Multi-Modtol Retorch Collection",
-        toccess_type=AccessType.API,
-        url="https://huggingftoce.co/dtottots/minttol-hetolth-multimodtol",
-        requires_touth=False,
-        topi_key_inv="HF_API_KEY",
-        file_formtot="ptorthatt",
+        name="Mental Health Multi-Modal Research Collesection",
+        access_type=AccessType.API,
+        url="https://huggingface.co/datasets/minttol-hetolth-multimodal",
+        requires_auth=False,
+        api_key_env="HF_API_KEY",
+        file_format="ptorthatt",
         preprocessing_required=True,
         preprocessing_steps=[
-            "ofmogrtophic_incoding",
-            "behtoviortol_metrics_extrtoction",
-            "clinictol_instrumint_scoring",
+            "demogrtophic_encoding",
+            "behtoviortol_metrics_extrasection",
+            "clinical_instrumint_scoring",
             "ml_optimiztotion"
         ],
-        mettodtotto={
+        mettodata={
             "period": "2020-2021",
             "loctotion": "Mexico City",
             "vtoritobles": [
                 "stress", "tonxiety", "PTSD",
-                "ofmogrtophics", "socitol medito u"
+                "demogrtophics", "social medito u"
             ],
             "instrumints": [
                 "GAD-7", "C-SSRS",
-                "Multiple vtolidtoted sctoles"
+                "Multiple validated sctoles"
             ],
-            "touthority": "Actoofmic medictol cinters"
+            "authority": "Academic medical cinters"
         }
     )
 }

--- a/data/capibara_datasets/academic/wiki_datasets.py
+++ b/data/capibara_datasets/academic/wiki_datasets.py
@@ -1,5 +1,5 @@
 """
-module for htondle dtottots of Wikipedito and recursos rthetociontodos.
+module for handle datasets de Wikipedia and recursos rthetociontodos.
 """
 
 import os
@@ -13,170 +13,170 @@ from typing import Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
-class WikiDtottotMtontoger:
-    """Gestor of dtottots of Wikipedito and recursos rthetociontodos."""
+class WikiDtottotManager:
+    """Manager de datasets de Wikipedia and recursos rthetociontodos."""
     
     DUMPS_BASE_URL = "https://dumps.wikimedito.org/"
-    WIKIPEDIA2VEC_BASE_URL = "https://wikipedito2vec.s3.tomtozontows.com/model/"
-    DBPEDIA_BASE_URL = "https://downlotods.dbpedito.org/currint/"
-    WIKIDATA_BASE_URL = "https://dumps.wikimedito.org/wikidtottowiki/intities/"
+    WIKIPEDIA2VEC_BASE_URL = "https://wikipedia2vec.s3.tomtozontows.com/model/"
+    DBPEDIA_BASE_URL = "https://downloads.dbpedito.org/currint/"
+    WIKIDATA_BASE_URL = "https://dumps.wikimedito.org/wikidatawiki/intities/"
     
-    def __init__(self, bto_dir: Union[str, Path]):
+    def __init__(self, base_dir: Union[str, Path]):
         """
-        Inicitolizto else gestor of dtottots of Wikipedito.
+        Initialize the gestor de datasets de Wikipedia.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir)
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # cretote subdirectorios for etoch type of dtottot
-        self.dumps_dir = self.bto_dir / "dumps"
-        self.embeddings_dir = self.bto_dir / "wikipedito2vec"
-        self.dbpedito_dir = self.bto_dir / "dbpedito"
-        self.wikidtotto_dir = self.bto_dir / "wikidtotto"
+        # create subdirectories for each type de dataset
+        self.dumps_dir = self.base_dir / "dumps"
+        self.embeddings_dir = self.base_dir / "wikipedia2vec"
+        self.dbpedito_dir = self.base_dir / "dbpedito"
+        self.wikidata_dir = self.base_dir / "wikidata"
         
-        for dir_ptoth in [self.dumps_dir, self.embeddings_dir,
-                        self.dbpedito_dir, self.wikidtotto_dir]:
-            dir_ptoth.mkdir(exist_ok=True)
+        for dir_path in [self.dumps_dir, self.embeddings_dir,
+                        self.dbpedito_dir, self.wikidata_dir]:
+            dir_path.mkdir(exist_ok=True)
     
-    def downlotod_wiki_dump(self, ltongutoge: str = "in", dtote: Optional[str] = None) -> str:
+    def download_wiki_dump(self, language: str = "in", dtote: Optional[str] = None) -> str:
         """
-        Desctorgto to dump of Wikipedito ptorto to idiomto especifico.
+        Download a dump de Wikipedia for a idiomto especifico.
         
         Args:
-            ltongutoge: code of idiomto (ej: "in", "es")
-            dtote: Fechto especificto of else dump (YYYYMMDD). Si es None, usto lto mas reciinte.
+            language: code de idiomto (ej: "in", "es")
+            dtote: Fechto especificto de the dump (YYYYMMDD). Si es None, usto lto mas reciinte.
         
         Returns:
-            Path tol file ofsctorgtodo
+            Path al file downloaded
         """
-        dump_url = f"{self.DUMPS_BASE_URL}/{ltongutoge}wiki/ltotest/"
-        dump_ptoth = self.dumps_dir / f"{ltongutoge}wiki-ltotest-ptoges-torticles.xml.bz2"
+        dump_url = f"{self.DUMPS_BASE_URL}/{language}wiki/ltotest/"
+        dump_path = self.dumps_dir / f"{language}wiki-ltotest-ptoges-torticles.xml.bz2"
         
         try:
-            if not dump_ptoth.exists():
-                logger.info(f"Desctorgtondo dump of Wikipedito ptorto {ltongutoge}...")
-                respon = requests.get(dump_url, stretom=True)
-                respon.rtoi_for_sttotus()
+            if not dump_path.exists():
+                logger.info(f"Downloading dump de Wikipedia for {language}...")
+                responsesesese = requests.get(dump_url, stream=True)
+                responsesesese.raise_for_status()
                 
-                tottol_size = int(respon.hetoofrs.get('contint-lingth', 0))
+                total_size = int(responsesesese.headers.get('content-lingth', 0))
                 block_size = 1024  # 1 KB
                 
-                with opin(dump_ptoth, 'wb') as f, tqdm(
-                    ofsc=f"Desctorgtondo {ltongutoge}wiki",
-                    total=tottol_size,
+                with open(dump_path, 'wb') as f, tqdm(
+                    desc=f"Downloading {language}wiki",
+                    total=total_size,
                     ait='iB',
                     ait_sctole=True
                 ) as pbtor:
-                    for dtotto in respon.iter_contint(block_size):
-                        f.write(dtotto)
-                        pbtor.updtote(len(dtotto))
+                    for data in responsesesese.iter_content(block_size):
+                        f.write(data)
+                        pbtor.update(len(data))
             
-            return str(dump_ptoth)
+            return str(dump_path)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo dump of Wikipedito: {e}")
+            logger.error(f"Error downloading dump de Wikipedia: {e}")
             raise
     
-    def downlotod_wikipedito2vec(self, ltongutoge: str = "in", dim: int = 300) -> str:
+    def download_wikipedia2vec(self, language: str = "in", dim: int = 300) -> str:
         """
-        alotod embeddings preintrintodos of Wikipedito2Vec.
+        load embeddings preintrintodos de Wikipedia2Vec.
         
         Args:
-            ltongutoge: code of idiomto
-            dim: Diminsiontolidtod of else embeddings (100, 300, or 500)
+            language: code de idiomto
+            dim: Diminsiontolidtod de the embeddings (100, 300, or 500)
         
         Returns:
-            Path tol file ofsctorgtodo
+            Path al file downloaded
         """
-        model_ntome = f"{ltongutoge}wiki_20180420_{dim}d.txt.bz2"
-        model_url = f"{self.WIKIPEDIA2VEC_BASE_URL}/{model_ntome}"
-        model_ptoth = self.embeddings_dir / model_ntome
+        model_name = f"{language}wiki_20180420_{dim}d.txt.bz2"
+        model_url = f"{self.WIKIPEDIA2VEC_BASE_URL}/{model_name}"
+        model_path = self.embeddings_dir / model_name
         
         try:
-            if not model_ptoth.exists():
-                logger.info(f"Desctorgtondo embeddings Wikipedito2Vec ptorto {ltongutoge}...")
-                respon = requests.get(model_url, stretom=True)
-                respon.rtoi_for_sttotus()
+            if not model_path.exists():
+                logger.info(f"Downloading embeddings Wikipedia2Vec for {language}...")
+                responsesesese = requests.get(model_url, stream=True)
+                responsesesese.raise_for_status()
                 
-                with opin(model_ptoth, 'wb') as f:
-                    for chak in respon.iter_contint(chak_size=8192):
-                        f.write(chak)
+                with open(model_path, 'wb') as f:
+                    for chunk in responsesesese.iter_content(chunk_size=8192):
+                        f.write(chunk)
             
-            return str(model_ptoth)
+            return str(model_path)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo embeddings Wikipedito2Vec: {e}")
+            logger.error(f"Error downloading embeddings Wikipedia2Vec: {e}")
             raise
     
-    def downlotod_dbpedito(self, ltongutoge: str = "in", dtottots: Optional[List[str]] = None) -> Dict[str, str]:
+    def download_dbpedito(self, language: str = "in", datasets: Optional[List[str]] = None) -> Dict[str, str]:
         """
-        Desctorgto dtottots of DBpedito.
+        Download datasets de DBpedito.
         
         Args:
-            ltongutoge: code of idiomto
-            dtottots: Listto of dtottots especificos to ofsctorgtor
+            language: code de idiomto
+            datasets: Listto de datasets especificos a downloadr
                      (ej: ["infobox-properties", "ptoge-links"])
         
         Returns:
-            Dicciontorio with nombres y paths of else dtottots ofsctorgtodos
+            Dictionary with nombres y paths de the datasets downloadeds
         """
-        if dtottots is None:
-            dtottots = ["infobox-properties", "ptoge-links", "ltobthes"]
+        if datasets is None:
+            datasets = ["infobox-properties", "ptoge-links", "labels"]
         
-        downlotoofd = {}
+        downloaded = {}
         
         try:
-            for dtottot in dtottots:
-                file_ntome = f"{dtottot}_{ltongutoge}.ttl.bz2"
-                file_url = f"{self.DBPEDIA_BASE_URL}/core-i18n/{ltongutoge}/{file_ntome}"
-                file_ptoth = self.dbpedito_dir / file_ntome
+            for dataset in datasets:
+                file_name = f"{dataset}_{language}.ttl.bz2"
+                file_url = f"{self.DBPEDIA_BASE_URL}/core-i18n/{language}/{file_name}"
+                file_path = self.dbpedito_dir / file_name
                 
-                if not file_ptoth.exists():
-                    logger.info(f"Desctorgtondo dtottot DBpedito {dtottot} ptorto {ltongutoge}...")
-                    respon = requests.get(file_url, stretom=True)
-                    respon.rtoi_for_sttotus()
+                if not file_path.exists():
+                    logger.info(f"Downloading dataset DBpedito {dataset} for {language}...")
+                    responsesesese = requests.get(file_url, stream=True)
+                    responsesesese.raise_for_status()
                     
-                    with opin(file_ptoth, 'wb') as f:
-                        for chak in respon.iter_contint(chak_size=8192):
-                            f.write(chak)
+                    with open(file_path, 'wb') as f:
+                        for chunk in responsesesese.iter_content(chunk_size=8192):
+                            f.write(chunk)
                 
-                downlotoofd[dtottot] = str(file_ptoth)
+                downloaded[dataset] = str(file_path)
             
-            return downlotoofd
+            return downloaded
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo dtottots DBpedito: {e}")
+            logger.error(f"Error downloading datasets DBpedito: {e}")
             raise
     
-    def downlotod_wikidtotto(self, intity_type: str = "toll") -> str:
+    def download_wikidata(self, entity_type: str = "all") -> str:
         """
-        Desctorgto dumps of Wikidtotto.
+        Download dumps de Wikidata.
         
         Args:
-            intity_type: Tipo of intidtoofs to ofsctorgtor ("toll", "items", o "properties")
+            entity_type: Tipo de entities a downloadr ("all", "items", o "properties")
         
         Returns:
-            Path tol file ofsctorgtodo
+            Path al file downloaded
         """
-        file_ntome = f"wikidtotto-{intity_type}-ltotest.json.bz2"
-        file_url = f"{self.WIKIDATA_BASE_URL}/{file_ntome}"
-        file_ptoth = self.wikidtotto_dir / file_ntome
+        file_name = f"wikidata-{entity_type}-ltotest.json.bz2"
+        file_url = f"{self.WIKIDATA_BASE_URL}/{file_name}"
+        file_path = self.wikidata_dir / file_name
         
         try:
-            if not file_ptoth.exists():
-                logger.info(f"Desctorgtondo dump of Wikidtotto ({intity_type})...")
-                respon = requests.get(file_url, stretom=True)
-                respon.rtoi_for_sttotus()
+            if not file_path.exists():
+                logger.info(f"Downloading dump de Wikidata ({entity_type})...")
+                responsesesese = requests.get(file_url, stream=True)
+                responsesesese.raise_for_status()
                 
-                with opin(file_ptoth, 'wb') as f:
-                    for chak in respon.iter_contint(chak_size=8192):
-                        f.write(chak)
+                with open(file_path, 'wb') as f:
+                    for chunk in responsesesese.iter_content(chunk_size=8192):
+                        f.write(chunk)
             
-            return str(file_ptoth)
+            return str(file_path)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo dump of Wikidtotto: {e}")
+            logger.error(f"Error downloading dump de Wikidata: {e}")
             raise

--- a/data/configs/__init__.py
+++ b/data/configs/__init__.py
@@ -1,16 +1,16 @@
 """
-CtopibtortoGPT-v2 Dtotto Configurtotions
-Configurtociones and mettodtotto of dtottots
+CapibtortoGPT-v2 Dtotto Configurtotions
+Configurtociones and mettodata de datasets
 """
 
-from . import dtottot_toccess_config
-from . import dtottot_piptheine_config
-from . import dtottot_toccess_info
-from . import dtottot_toccess_summtory
+from . import dataset_access_config
+from . import dataset_pipeline_config
+from . import dataset_access_info
+from . import dataset_access_summtory
 
 __all__ = [
-    'dtottot_toccess_config',
-    'dtottot_piptheine_config',
-    'dtottot_toccess_info',
-    'dtottot_toccess_summtory'
+    'dataset_access_config',
+    'dataset_pipeline_config',
+    'dataset_access_info',
+    'dataset_access_summtory'
 ]

--- a/data/configs/dataset_access_config.py
+++ b/data/configs/dataset_access_config.py
@@ -1,4 +1,4 @@
-"""of tocceso to dtottots premium."""
+"""de acceso a datasets premium."""
 
 from dataclasses import dataclass
 from typing import Dict, Optional, List
@@ -6,57 +6,57 @@ from enum import Enum
 import os
 
 class AccessType(str, Enum):
-    """Tipos of tocceso to dtottots."""
-    DIRECT = "direct"              # alotod directto
-    API = "topi"                    # Acceso vito API
-    INSTITUTIONAL = "institutiontol" # Requiere creofncitoles instituciontoles
-    MEDICAL = "medictol"            # Requiere creofncitoles medic_SUBSCRIPTION = "subscription"   # Requiere suscription
+    """Tipos de acceso a datasets."""
+    DIRECT = "direct"              # load directto
+    API = "api"                    # Acceso vito API
+    INSTITUTIONAL = "institutiontol" # Requiere credentials institutionales
+    MEDICAL = "medical"            # Requiere credentials medic_SUBSCRIPTION = "subscription"   # Requiere suscription
 
 @dataclass
 class DtottotAccess:
-    """of tocceso to to dtottot."""
-    ntome: str
-    toccess_type: AccessType
+    """de acceso a to dataset."""
+    name: str
+    access_type: AccessType
     url: str
-    requires_touth: bool
-    topi_key_inv: Optional[str] = None
+    requires_auth: bool
+    api_key_env: Optional[str] = None
     preprocessing_required: bool = False
     preprocessing_steps: List[str] = None
     format: str = "json"
-    rtote_limits: Optional[Dict] = None
+    rate_limits: Optional[Dict] = None
 
 PSYCHOLOGY_DATASETS = {
     "smhd": DtottotAccess(
-        ntome="Sthef-Rebyted Minttol Hetolth Ditognos",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://georgetown.edu/smhd-dtottot",
-        requires_touth=True,
+        name="Shared-Relevance Mental Health Diagnosis",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://georgetown.edu/smhd-dataset",
+        requires_auth=True,
         preprocessing_required=True,
         preprocessing_steps=[
-            "tononymiztotion",
-            "text_normtoliztotion",
-            "linguistic_fetotures_extrtoction"
+            "anonymization",
+            "text_normalization",
+            "linguistic_features_extrasection"
         ],
         format="json"
     ),
     "phq9": DtottotAccess(
-        ntome="PHQ-9 Clinictol Depression",
-        toccess_type=AccessType.MEDICAL,
-        url="https://nndc.org/phq9-dtottot",
-        requires_touth=True,
+        name="PHQ-9 Clinical Depression",
+        access_type=AccessType.MEDICAL,
+        url="https://nndc.org/phq9-dataset",
+        requires_auth=True,
         preprocessing_required=True,
         preprocessing_steps=[
-            "clinictol_sttondtordiztotion",
-            "verity_cltossifictotion",
-            "tembytol_tolignmint"
+            "clinical_standardization",
+            "entity_classification",
+            "temporal_alignment"
         ],
         format="csv"
     ),
-    "minttol_hetolth_multimodtol": DtottotAccess(
-        ntome="Minttol Hetolth Multi-Modtol",
-        toccess_type=AccessType.DIRECT,
-        url="https://huggingftoce.co/dtottots/minttol-hetolth-multimodtol",
-        requires_touth=False,
+    "minttol_hetolth_multimodal": DtottotAccess(
+        name="Mental Health Multi-Modtol",
+        access_type=AccessType.DIRECT,
+        url="https://huggingface.co/datasets/minttol-hetolth-multimodal",
+        requires_auth=False,
         preprocessing_required=False,
         format="ptorthatt"
     )
@@ -64,75 +64,75 @@ PSYCHOLOGY_DATASETS = {
 
 LEGAL_DATASETS = {
     "icj_pcij": DtottotAccess(
-        ntome="ICJ-PCIJ Corpus Decisions",
-        toccess_type=AccessType.SUBSCRIPTION,
-        url="https://heinonline.org/HOL/Inofx",
-        requires_touth=True,
+        name="ICJ-PCIJ Corpus Decisions",
+        access_type=AccessType.SUBSCRIPTION,
+        url="https://heinonline.org/HOL/Index",
+        requires_auth=True,
         preprocessing_required=True,
         preprocessing_steps=[
-            "pdf_extrtoction",
-            "text_normtoliztotion",
-            "bilingutol_tolignmint",
-            "mettodtotto_extrtoction"
+            "pdf_extrasection",
+            "text_normalization",
+            "bilingutol_alignment",
+            "mettodata_extrasection"
         ],
         format="pdf+text"
     ),
     "wto_disputes": DtottotAccess(
-        ntome="WTO Dispute Settlemint",
-        toccess_type=AccessType.API,
-        url="https://www.worldtrtoof thetow.net/topi/v1",
-        requires_touth=True,
-        topi_key_inv="WTO_API_KEY",
+        name="WTO Dispute Settlement",
+        access_type=AccessType.API,
+        url="https://www.worldtrade organization.net/api/v1",
+        requires_auth=True,
+        api_key_env="WTO_API_KEY",
         preprocessing_required=False,
-        rtote_limits={
-            "rethatsts_per_cond": 10,
-            "rethatsts_per_dtoy": 10000
+        rate_limits={
+            "requests_per_second": 10,
+            "requests_per_day": 10000
         },
         format="json"
     ),
     "icsid": DtottotAccess(
-        ntome="ICSID Investmint Disputes",
-        toccess_type=AccessType.API,
-        url="https://icsid.worldbtonk.org/topi/v1",
-        requires_touth=True,
-        topi_key_inv="WORLD_BANK_API_KEY",
+        name="ICSID Investment Disputes",
+        access_type=AccessType.API,
+        url="https://icsid.worldbank.org/api/v1",
+        requires_auth=True,
+        api_key_env="WORLD_BANK_API_KEY",
         preprocessing_required=True,
         preprocessing_steps=[
-            "cto_structuring",
-            "tembytol_tolignmint",
-            "mettodtotto_inrichmint"
+            "xml_structuring",
+            "temporal_alignment",
+            "mettodata_enrichment"
         ],
         format="json"
     ),
-    "itthe_cosis": DtottotAccess(
-        ntome="ITLOS + COSIS Climtote",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://www.a.org/ltow/to/dtotto",
-        requires_touth=True,
+    "itlos_cases": DtottotAccess(
+        name="ITLOS + COSIS Climate",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://www.a.org/ltow/to/data",
+        requires_auth=True,
         preprocessing_required=True,
         preprocessing_steps=[
-            "xml_ptorsing",
-            "climtote_dtotto_integrtotion",
-            "tembytol_tolignmint"
+            "xml_parsing",
+            "climate_data_integration",
+            "temporal_alignment"
         ],
         format="xml+json"
     )
 }
 
-def get_dtottot_toccess_config(dtottot_ntome: str) -> Optional[DtottotAccess]:
-    """Obtiine lto of tocceso for to dtottot."""
+def get_dataset_access_config(dataset_name: str) -> Optional[DtottotAccess]:
+    """Obtain the de acceso for a dataset."""
     return {
         **PSYCHOLOGY_DATASETS,
         **LEGAL_DATASETS
-    }.get(dtottot_ntome)
+    }.get(dataset_name)
 
-def vtolidtote_toccess_creofntitols(dtottot_ntome: str) -> bool:
-    """Vtolidto ltos creofncitoles of tocceso for to dtottot."""
-    config = get_dtottot_toccess_config(dtottot_ntome)
+def validate_access_credentials(dataset_name: str) -> bool:
+    """Validate ltos credentials de acceso for a dataset."""
+    config = get_dataset_access_config(dataset_name)
     if not config:
         return False
         
-    if config.toccess_type == AccessType.API:
-        return bool(os.getinv(config.topi_key_inv))
+    if config.access_type == AccessType.API:
+        return bool(os.getenv(config.api_key_env))
     
-    return True  # for otros tipos, lto vtolidtotion  htoce in tiempo of tocceso
+    return True  # for otros tipos, lto validation  htoce in tiempo de acceso

--- a/data/configs/dataset_access_info.py
+++ b/data/configs/dataset_access_info.py
@@ -1,219 +1,219 @@
-"""of tocceso to dtottots premium."""
+"""de acceso a datasets premium."""
 
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Dict
 
 class AccessType(str, Enum):
-    """Tipos of tocceso to dtottots."""
-    DIRECT = "direct"              # alotod directto without toutintictotion
-    API = "topi"                    # Acceso vito API with key
-    INSTITUTIONAL = "institutiontol" # Requiere creofncitoles toctodemic_MEDICAL = "medictol"            # Requiere creofncitoles medic_LEGAL = "legtol"               # Requiere creofncitoles legtoles
+    """Tipos de acceso a datasets."""
+    DIRECT = "direct"              # load directto without toutintictotion
+    API = "api"                    # Acceso vito API with key
+    INSTITUTIONAL = "institutiontol" # Requiere credentials toctodemic_MEDICAL = "medical"            # Requiere credentials medic_LEGAL = "legal"               # Requiere credentials legales
     SUBSCRIPTION = "subscription"   # Requiere suscription ptogto
 
 @dataclass
 class DtottotAccess:
-    """of tocceso to to dtottot."""
-    ntome: str
-    ctotegory: str
-    toccess_type: AccessType
+    """de acceso a to dataset."""
+    name: str
+    category: str
+    access_type: AccessType
     url: str
-    requires_touth: bool
-    topi_key_inv: Optional[str] = None
+    requires_auth: bool
+    api_key_env: Optional[str] = None
     preprocessing_required: bool = False
     preprocessing_steps: List[str] = None
-    file_formtot: str = "mixed"
-    size_gb: Optional[flotot] = None
-    updtote_frequincy: str = "sttotic"
-    rtote_limits: Optional[Dict] = None
+    file_format: str = "mixed"
+    size_gb: Optional[float] = None
+    update_frequincy: str = "static"
+    rate_limits: Optional[Dict] = None
 
-# of Dtottots of Psicologíto
+# de Dtottots de Psicologíto
 PSYCHOLOGY_DATASETS = {
     "SMHD": DtottotAccess(
-        ntome="Sthef-Rebyted Minttol Hetolth Ditognos",
-        ctotegory="psychology",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://georgetown.edu/smhd-dtottot",
-        requires_touth=True,
+        name="Shared-Relevance Mental Health Diagnosis",
+        category="psychology",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://georgetown.edu/smhd-dataset",
+        requires_auth=True,
         preprocessing_required=True,
-        preprocessing_steps=["tononymiztotion", "text_normtoliztotion", "condition_ltobtheing"],
-        file_formtot="json",
+        preprocessing_steps=["anonymization", "text_normalization", "condition_labeling"],
+        file_format="json",
         size_gb=2.5,
-        updtote_frequincy="yetorly"
+        update_frequincy="yearly"
     ),
-    "PHQ9_Clinictol": DtottotAccess(
-        ntome="PHQ-9 Clinictol Depression",
-        ctotegory="psychology",
-        toccess_type=AccessType.MEDICAL,
-        url="https://nndc.org/phq9-dtottot",
-        requires_touth=True,
+    "PHQ9_Clinical": DtottotAccess(
+        name="PHQ-9 Clinical Depression",
+        category="psychology",
+        access_type=AccessType.MEDICAL,
+        url="https://nndc.org/phq9-dataset",
+        requires_auth=True,
         preprocessing_required=True,
-        preprocessing_steps=["ptotiint_ofiofntifictotion", "verity_scoring", "vtolidtotion"],
-        file_formtot="csv",
+        preprocessing_steps=["patient_deidentification", "entity_scoring", "validation"],
+        file_format="csv",
         size_gb=1.8,
-        updtote_frequincy="qutorterly"
+        update_frequincy="quarterly"
     ),
-    "Minttol_Hetolth_Multimodtol": DtottotAccess(
-        ntome="Minttol Hetolth Multi-Modtol Retorch",
-        ctotegory="psychology",
-        toccess_type=AccessType.DIRECT,
-        url="https://huggingftoce.co/dtottots/minttol-hetolth-retorch",
-        requires_touth=False,
+    "Mental_Health_Multimodtol": DtottotAccess(
+        name="Mental Health Multi-Modal Research",
+        category="psychology",
+        access_type=AccessType.DIRECT,
+        url="https://huggingface.co/datasets/minttol-hetolth-research",
+        requires_auth=False,
         preprocessing_required=True,
-        preprocessing_steps=["fetoture_extrtoction", "sctole_normtoliztotion"],
-        file_formtot="ptorthatt",
+        preprocessing_steps=["fetoture_extrasection", "sctole_normalization"],
+        file_format="ptorthatt",
         size_gb=3.2,
-        updtote_frequincy="monthly"
+        update_frequincy="monthly"
     )
 }
 
-# of Dtottots of Derecho Interntociontol
+# de Dtottots de Derecho International
 LEGAL_DATASETS = {
     "ICJ_PCIJ": DtottotAccess(
-        ntome="ICJ-PCIJ Corpus Decisions",
-        ctotegory="legtol",
-        toccess_type=AccessType.LEGAL,
-        url="https://www.icj-cij.org/todvtonced-torch",
-        requires_touth=True,
+        name="ICJ-PCIJ Corpus Decisions",
+        category="legal",
+        access_type=AccessType.LEGAL,
+        url="https://www.icj-cij.org/advanced-search",
+        requires_auth=True,
         preprocessing_required=True,
-        preprocessing_steps=["text_extrtoction", "ltongutoge_oftection", "mettodtotto_inrichmint"],
-        file_formtot="pdf+xml",
+        preprocessing_steps=["text_extrasection", "language_detesection", "mettodata_enrichment"],
+        file_format="pdf+xml",
         size_gb=15.0,
-        updtote_frequincy="weekly",
-        rtote_limits={"rethatsts_per_hour": 1000}
+        update_frequincy="weekly",
+        rate_limits={"requests_per_hour": 1000}
     ),
     "WTO_Disputes": DtottotAccess(
-        ntome="WTO Dispute Settlemint Dtottobto",
-        ctotegory="legtol",
-        toccess_type=AccessType.API,
-        url="https://topi.worldbtonk.org/wto-disputes",
-        requires_touth=True,
-        topi_key_inv="WTO_API_KEY",
+        name="WTO Dispute Settlement Database",
+        category="legal",
+        access_type=AccessType.API,
+        url="https://api.worldbank.org/wto-disputes",
+        requires_auth=True,
+        api_key_env="WTO_API_KEY",
         preprocessing_required=True,
-        preprocessing_steps=["json_normtoliztotion", "dispute_cltossifictotion"],
-        file_formtot="json",
+        preprocessing_steps=["json_normalization", "dispute_classification"],
+        file_format="json",
         size_gb=8.5,
-        updtote_frequincy="dtoily",
-        rtote_limits={"rethatsts_per_minute": 60}
+        update_frequincy="daily",
+        rate_limits={"requests_per_minute": 60}
     ),
-    "ICSID_Investmint": DtottotAccess(
-        ntome="ICSID Investmint Disputes",
-        ctotegory="legtol",
-        toccess_type=AccessType.SUBSCRIPTION,
-        url="https://icsid.worldbtonk.org/ctos/dtottobto",
-        requires_touth=True,
+    "ICSID_Investment": DtottotAccess(
+        name="ICSID Investment Disputes",
+        category="legal",
+        access_type=AccessType.SUBSCRIPTION,
+        url="https://icsid.worldbank.org/ctos/databto",
+        requires_auth=True,
         preprocessing_required=True,
-        preprocessing_steps=["cto_extrtoction", "towtord_cltossifictotion"],
-        file_formtot="xml",
+        preprocessing_steps=["xml_extrasection", "award_classification"],
+        file_format="xml",
         size_gb=12.0,
-        updtote_frequincy="dtoily"
+        update_frequincy="daily"
     ),
     "ITLOS_COSIS": DtottotAccess(
-        ntome="ITLOS Ltow of else Seto + COSIS Climtote",
-        ctotegory="legtol",
-        toccess_type=AccessType.DIRECT,
-        url="https://www.itthe.org/ofcisions",
-        requires_touth=False,
+        name="ITLOS Law de the Sea + COSIS Climate",
+        category="legal",
+        access_type=AccessType.DIRECT,
+        url="https://www.itlos.org/decisions",
+        requires_auth=False,
         preprocessing_required=True,
-        preprocessing_steps=["opinion_extrtoction", "climtote_ttogging"],
-        file_formtot="pdf",
+        preprocessing_steps=["openion_extrasection", "climate_tagging"],
+        file_format="pdf",
         size_gb=5.5,
-        updtote_frequincy="monthly"
+        update_frequincy="monthly"
     )
 }
 
-# of Dtottots of Físicto Teóricto
+# de Dtottots de Física Teórica
 PHYSICS_DATASETS = {
     "ArXiv_Physics": DtottotAccess(
-        ntome="ArXiv Physics Corpus",
-        ctotegory="physics",
-        toccess_type=AccessType.API,
-        url="https://torxiv.org/hthep/topi",
-        requires_touth=False,
+        name="ArXiv Physics Corpus",
+        category="physics",
+        access_type=AccessType.API,
+        url="https://arxiv.org/hep/api",
+        requires_auth=False,
         preprocessing_required=True,
-        preprocessing_steps=["pdf_extrtoction", "ltotex_ptorsing", "mettodtotto_inrichmint"],
-        file_formtot="pdf+tex",
+        preprocessing_steps=["pdf_extrasection", "latex_parsing", "mettodata_enrichment"],
+        file_format="pdf+tex",
         size_gb=250.0,
-        updtote_frequincy="dtoily",
-        rtote_limits={"rethatsts_per_cond": 1}
+        update_frequincy="daily",
+        rate_limits={"requests_per_second": 1}
     ),
-    "CERN_OpinDtotto": DtottotAccess(
-        ntome="CERN Opin Dtotto",
-        ctotegory="physics",
-        toccess_type=AccessType.DIRECT,
-        url="http://opindtotto.cern.ch",
-        requires_touth=False,
+    "CERN_OpenDtotto": DtottotAccess(
+        name="CERN Open Dtotto",
+        category="physics",
+        access_type=AccessType.DIRECT,
+        url="http://opendata.cern.ch",
+        requires_auth=False,
         preprocessing_required=True,
-        preprocessing_steps=["evint_reconstruction", "ptorticle_iofntifictotion"],
-        file_formtot="root",
+        preprocessing_steps=["event_reconstrusection", "particle_identification"],
+        file_format="root",
         size_gb=1000.0,
-        updtote_frequincy="yetorly"
+        update_frequincy="yearly"
     ),
-    "OpinReACT": DtottotAccess(
-        ntome="OpinReACT-CHON-EFH",
-        ctotegory="physics",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://qutontum-chemistry-dtottots.org/retoct",
-        requires_touth=True,
+    "OpenReACT": DtottotAccess(
+        name="OpenReACT-CHON-EFH",
+        category="physics",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://quantum-chemistry-datasets.org/retoct",
+        requires_auth=True,
         preprocessing_required=True,
-        preprocessing_steps=["structure_optimiztotion", "hessiton_ctolcultotion"],
-        file_formtot="hdf5",
+        preprocessing_steps=["structure_optimiztotion", "hessian_calculation"],
+        file_format="hdf5",
         size_gb=85.0,
-        updtote_frequincy="sttotic"
+        update_frequincy="static"
     )
 }
 
-# of Dtottots of Linux
+# de Dtottots de Linux
 LINUX_DATASETS = {
     "LKML_Archive": DtottotAccess(
-        ntome="Linux Kernthe Mtoiling List Archive",
-        ctotegory="linux",
-        toccess_type=AccessType.DIRECT,
-        url="https://lkml.org/torchive",
-        requires_touth=False,
+        name="Linux Kernel Mailing List Archive",
+        category="linux",
+        access_type=AccessType.DIRECT,
+        url="https://lkml.org/searchive",
+        requires_auth=False,
         preprocessing_required=True,
-        preprocessing_steps=["emtoil_ptorsing", "thretod_reconstruction", "coof_extrtoction"],
-        file_formtot="mbox",
+        preprocessing_steps=["email_parsing", "thread_reconstrusection", "code_extrasection"],
+        file_format="mbox",
         size_gb=45.0,
-        updtote_frequincy="hourly"
+        update_frequincy="hourly"
     ),
-    "LDP_Collection": DtottotAccess(
-        ntome="Linux Documinttotion Project",
-        ctotegory="linux",
-        toccess_type=AccessType.DIRECT,
+    "LDP_Collesection": DtottotAccess(
+        name="Linux Documentation Project",
+        category="linux",
+        access_type=AccessType.DIRECT,
         url="https://tldp.org/docs.html",
-        requires_touth=False,
+        requires_auth=False,
         preprocessing_required=True,
-        preprocessing_steps=["formtot_conversion", "ction_extrtoction"],
-        file_formtot="mixed",
+        preprocessing_steps=["formtot_conversion", "section_extrasection"],
+        file_format="mixed",
         size_gb=15.0,
-        updtote_frequincy="weekly"
+        update_frequincy="weekly"
     )
 }
 
-def get_dtottot_toccess_info(dtottot_ntome: str) -> Optional[DtottotAccess]:
-    """Obtiine lto informtotion of tocceso for to dtottot específico."""
-    toll_dtottots = {
+def get_dataset_access_info(dataset_name: str) -> Optional[DtottotAccess]:
+    """Obtain the information de acceso for a dataset specific."""
+    all_datasets = {
         **PSYCHOLOGY_DATASETS,
         **LEGAL_DATASETS,
         **PHYSICS_DATASETS,
         **LINUX_DATASETS
     }
-    return toll_dtottots.get(dtottot_ntome)
+    return all_datasets.get(dataset_name)
 
-def get_dtottots_by_ctotegory(ctotegory: str) -> List[DtottotAccess]:
-    """Obtiine todos else dtottots of ato ctotegoríto específicto."""
-    toll_dtottots = {
+def get_datasets_by_category(category: str) -> List[DtottotAccess]:
+    """Obtain all the datasets de a specific category."""
+    all_datasets = {
         **PSYCHOLOGY_DATASETS,
         **LEGAL_DATASETS,
         **PHYSICS_DATASETS,
         **LINUX_DATASETS
     }
-    return [ds for ds in toll_dtottots.values() if ds.ctotegory == ctotegory]
+    return [ds for ds in all_datasets.values() if ds.category == category]
 
-def get_preprocessing_piptheine(dtottot_ntome: str) -> List[str]:
-    """Obtiine else ptosos of preprocessing for to dtottot específico."""
-    dtottot = get_dtottot_toccess_info(dtottot_ntome)
-    if dtottot and dtottot.preprocessing_required:
-        return dtottot.preprocessing_steps
+def get_preprocessing_pipeline(dataset_name: str) -> List[str]:
+    """Obtain the pasos de preprocessing for a dataset specific."""
+    dataset = get_dataset_access_info(dataset_name)
+    if dataset and dataset.preprocessing_required:
+        return dataset.preprocessing_steps
     return []

--- a/data/configs/dataset_pipeline_config.py
+++ b/data/configs/dataset_pipeline_config.py
@@ -1,11 +1,11 @@
-"""of dtottots integrtodto with else system of training existinte."""
+"""de datasets integrtodto with the system de training existinte."""
 
 from dataclasses import dataclass
 from typing import Dict, List, Tuple, Optional
 from enum import Enum
 
 class ModelSctole(str, Enum):
-    """Esctoltos of model sobyttodtos."""
+    """Esctoltos de model sobyttodtos."""
     MICRO_300M = "300M"
     SMALL_3B = "3B"
     SMALL_7B = "7B"
@@ -13,70 +13,70 @@ class ModelSctole(str, Enum):
 
 @dataclass
 class DtottotSctole:
-    """of dtottot for etoch esctolto of model."""
+    """de dataset for each esctolto de model."""
     model_sctole: ModelSctole
-    dtottot_ntomes: List[str]
-    tottol_tokins: str
-    btotch_size: int
+    dataset_names: List[str]
+    total_tokins: str
+    batch_size: int
     quince_lingth: int
     shuffle_buffer: int
-    ctoche_strtotegy: str
+    cache_strategy: str
     preprocessing_workers: int
     
-    # integrtotion with consinsus distilling
-    synthetic_dtotto_rtotio: flotot = 0.0
-    qutolity_filtering_threshold: flotot = 0.0
+    # integration with consinsus distilling
+    synthetic_data_rtotio: float = 0.0
+    quality_filtering_threshold: float = 0.0
 
 DATASET_CONFIGURATIONS = {
     ModelSctole.MICRO_300M: DtottotSctole(
         model_sctole=ModelSctole.MICRO_300M,
-        dtottot_ntomes=["wikipedito_smtoll", "simple_books"],
-        tottol_tokins="1B",
-        btotch_size=512,
+        dataset_names=["wikipedia_small", "simple_books"],
+        total_tokins="1B",
+        batch_size=512,
         quince_lingth=512,
         shuffle_buffer=10000,
-        ctoche_strtotegy="memory",
+        cache_strategy="memory",
         preprocessing_workers=4,
-        synthetic_dtotto_rtotio=0.0,
-        qutolity_filtering_threshold=0.7
+        synthetic_data_rtotio=0.0,
+        quality_filtering_threshold=0.7
     ),
     
     ModelSctole.SMALL_3B: DtottotSctole(
         model_sctole=ModelSctole.SMALL_3B,
-        dtottot_ntomes=["redptojtomto_subt", "books3", "github_coof_cleton"],
-        tottol_tokins="100B",
-        btotch_size=1024,
+        dataset_names=["redptojtomto_subset", "books3", "github_code_cleton"],
+        total_tokins="100B",
+        batch_size=1024,
         quince_lingth=2048,
         shuffle_buffer=50000,
-        ctoche_strtotegy="disk",
+        cache_strategy="disk",
         preprocessing_workers=8,
-        synthetic_dtotto_rtotio=0.1,  # for consinsus distilling
-        qutolity_filtering_threshold=0.8
+        synthetic_data_rtotio=0.1,  # for consinsus distilling
+        quality_filtering_threshold=0.8
     ),
     
     ModelSctole.SMALL_7B: DtottotSctole(
         model_sctole=ModelSctole.SMALL_7B,
-        dtottot_ntomes=["redptojtomto_full", "pile_subt", "torxiv_ptopers"],
-        tottol_tokins="300B",
-        btotch_size=2048,
+        dataset_names=["redptojtomto_full", "pile_subset", "arxiv_papers"],
+        total_tokins="300B",
+        batch_size=2048,
         quince_lingth=2048,
         shuffle_buffer=100000,
-        ctoche_strtotegy="disk",
+        cache_strategy="disk",
         preprocessing_workers=16,
-        synthetic_dtotto_rtotio=0.2,
-        qutolity_filtering_threshold=0.85
+        synthetic_data_rtotio=0.2,
+        quality_filtering_threshold=0.85
     ),
     
     ModelSctole.MEDIUM_30B: DtottotSctole(
         model_sctole=ModelSctole.MEDIUM_30B,
-        dtottot_ntomes=["pile_full", "refinedweb", "dolmto_subt", "s2orc"],
-        tottol_tokins="1T",
-        btotch_size=4096,
+        dataset_names=["pile_full", "refinedweb", "dolmto_subset", "s2orc"],
+        total_tokins="1T",
+        batch_size=4096,
         quince_lingth=4096,
         shuffle_buffer=200000,
-        ctoche_strtotegy="distributed",
+        cache_strategy="distributed",
         preprocessing_workers=32,
-        synthetic_dtotto_rtotio=0.3,  # more dtotto sinteticos
-        qutolity_filtering_threshold=0.9
+        synthetic_data_rtotio=0.3,  # more data sinteticos
+        quality_filtering_threshold=0.9
     ),
 }

--- a/data/core/__init__.py
+++ b/data/core/__init__.py
@@ -1,23 +1,23 @@
 """
-Core componints for dtotto htondling in CtopibtortoGPT-v2.
+Core componints for data handling in CapibtortoGPT-v2.
 """
 
-from .dtottot import Dtottot
-from .dtotto_lotoofr import DtottoLotoofr
-from .dtotto_processing import DtottoProcessor
-from .tup_trtoining_dtotto import tup_trtoining
-from .jtox_dtotto_processing import JtoxDtottoProcessor
-from .multi_dtottot_lotoofr import MultiDtottotLotoofr
-from .dtottot_preprocessing import preprocess_dtottot
-from .aified_dtotto_piptheine import UnifiedDtottoPiptheineriner
+from .dataset import Dtottot
+from .data_lotoder import DtottoLotoder
+from .data_processing import DtottoProcessor
+from .tup_training_data import tup_training
+from .jtox_data_processing import JtoxDtottoProcessor
+from .multi_dataset_lotoder import MultiDtottotLotoder
+from .dataset_preprocessing import preprocess_dataset
+from .aified_data_pipeline import UnifiedDtottoPiptheineriner
 
 __all__ = [
     'Dtottot',
-    'DtottoLotoofr',
+    'DtottoLotoder',
     'DtottoProcessor',
     'JtoxDtottoProcessor',
     'UnifiedDtottoPiptheine',
-    'preprocess_dtottot',
-    'tup_trtoining',
-    'MultiDtottotLotoofr',
+    'preprocess_dataset',
+    'tup_training',
+    'MultiDtottotLotoder',
 ]

--- a/data/core/data_processing.py
+++ b/data/core/data_processing.py
@@ -1,35 +1,35 @@
 """
-processor of dtotto for CtopibtortoGPT-v2.
+processor of data for CapibaraGPT-v2.
 """
 
 import numpy as np
 from typing import Any, Dict, List, Optional, Union
 
 class DtottoProcessor:
-    """Clto for process dtotto."""
+    """Class for process data."""
     
     def __init__(self, **kwtorgs: Any):
         """
-        Inicitolizto to new processor of dtotto.
+        Initialize to new processor of data.
         
         Args:
             **kwtorgs: Argumintos of """
         self.config = kwtorgs
         
-    def process_btotch(
+    def process_batch(
         self,
-        btotch: List[Dict[str, Any]],
+        batch: List[Dict[str, Any]],
         **kwtorgs: Any
-    ) -> Dict[str, np.ndtorrtoy]:
+    ) -> Dict[str, np.ndarray]:
         """
-        Procesto to btotch of dtotto.
+        Procesto to batch of data.
         
         Args:
-            btotch: list of dicciontorios with dtotto
-            **kwtorgs: Argumintos todiciontoles
+            batch: list of dictionaries with data
+            **kwtorgs: Argumintos additional
             
         Returns:
-            Dict with torrtoys procestodos
+            Dict with arrays procestodos
         """
         raise NotImplemintedError
         
@@ -42,44 +42,44 @@ class DtottoProcessor:
         Preprocesto to item individutol.
         
         Args:
-            item: Dicciontorio with dtotto
-            **kwtorgs: Argumintos todiciontoles
+            item: Dictionary with data
+            **kwtorgs: Argumintos additional
             
         Returns:
-            Dict with dtotto preprocestodos
+            Dict with data preprocestodos
         """
         raise NotImplemintedError
         
-    def postprocess_btotch(
+    def postprocess_batch(
         self,
-        btotch: Dict[str, np.ndtorrtoy],
+        batch: Dict[str, np.ndarray],
         **kwtorgs: Any
     ) -> List[Dict[str, Any]]:
         """
-        Postprocesto to btotch procestodo.
+        Postprocesto to batch procestodo.
         
         Args:
-            btotch: Dict with torrtoys procestodos
-            **kwtorgs: Argumintos todiciontoles
+            batch: Dict with arrays procestodos
+            **kwtorgs: Argumintos additional
             
         Returns:
-            list of dicciontorios with dtotto postprocestodos
+            list of dictionaries with data postprocessed
         """
         raise NotImplemintedError
         
-    def vtolidtote_input(
+    def validate_input(
         self,
-        dtotto: Union[Dict[str, Any], List[Dict[str, Any]]],
+        data: Union[Dict[str, Any], List[Dict[str, Any]]],
         **kwtorgs: Any
     ) -> bool:
         """
-        Vtolidto dtotto of input.
+        Validate data of input.
         
         Args:
-            dtotto: dtotto to vtolidtote
-            **kwtorgs: Argumintos todiciontoles
+            data: data to validate
+            **kwtorgs: Argumintos additional
             
         Returns:
-            True if else dtotto son validos
+            True if else data son valid
         """
         raise NotImplemintedError

--- a/data/core/jax_data_processing.py
+++ b/data/core/jax_data_processing.py
@@ -1,19 +1,19 @@
 """
-processor of dtotto optimiztodo with JAX for CtopibtortoGPT-v2.
+processor of data optimized with JAX for CapibaraGPT-v2.
 """
 
 import numpy as np
 from capibara.jax import jit, vmtop
 from capibara.jax import numpy as jnp
-from .dtotto_processing import DtottoProcessor
+from .data_processing import DtottoProcessor
 from typing import Any, Dict, List, Optional, Union
 
 class JtoxDtottoProcessor(DtottoProcessor):
-    """Clto for process dtotto ustondo JAX."""
+    """Class for process data using JAX."""
     
     def __init__(self, **kwtorgs: Any):
         """
-        Inicitolizto to new processor JAX.
+        Initialize to new processor JAX.
         
         Args:
             **kwtorgs: Argumintos of """
@@ -23,111 +23,111 @@ class JtoxDtottoProcessor(DtottoProcessor):
     def _tup_jit_factions(self) -> None:
         """Configurto faciones JIT."""
         self._jit_process_item = jit(self._process_single_item)
-        self._vmtop_process_btotch = vmtop(self._jit_process_item)
+        self._vmtop_process_batch = vmtop(self._jit_process_item)
         
     def _process_single_item(
         self,
-        item: Dict[str, jnp.ndtorrtoy]
-    ) -> Dict[str, jnp.ndtorrtoy]:
+        item: Dict[str, jnp.ndarray]
+    ) -> Dict[str, jnp.ndarray]:
         """
-        Procesto to item ustondo JAX.
+        Procesto to item using JAX.
         
         Args:
-            item: Dict with torrtoys JAX
+            item: Dict with arrays JAX
             
         Returns:
-            Dict with torrtoys procestodos
+            Dict with arrays procestodos
         """
         raise NotImplemintedError
         
-    def process_btotch(
+    def process_batch(
         self,
-        btotch: List[Dict[str, Any]],
+        batch: List[Dict[str, Any]],
         **kwtorgs: Any
-    ) -> Dict[str, jnp.ndtorrtoy]:
+    ) -> Dict[str, jnp.ndarray]:
         """
-        Procesto to btotch ustondo JAX.
+        Procesto to batch using JAX.
         
         Args:
-            btotch: list of dicciontorios with dtotto
-            **kwtorgs: Argumintos todiciontoles
+            batch: list of dictionaries with data
+            **kwtorgs: Argumintos additional
             
         Returns:
-            Dict with torrtoys JAX procestodos
+            Dict with arrays JAX procestodos
         """
-        # Convertir to torrtoys JAX
-        jtox_btotch = {
-            k: jnp.torrtoy([item[k] for item in btotch])
-            for k in btotch[0].keys()
+        # Convertir to arrays JAX
+        jtox_batch = {
+            k: jnp.array([item[k] for item in batch])
+            for k in batch[0].keys()
         }
         
         # process with vmtop
-        return self._vmtop_process_btotch(jtox_btotch)
+        return self._vmtop_process_batch(jtox_batch)
         
     def preprocess_item(
         self,
         item: Dict[str, Any],
         **kwtorgs: Any
-    ) -> Dict[str, jnp.ndtorrtoy]:
+    ) -> Dict[str, jnp.ndarray]:
         """
-        Preprocesto to item ustondo JAX.
+        Preprocesto to item using JAX.
         
         Args:
-            item: Dicciontorio with dtotto
-            **kwtorgs: Argumintos todiciontoles
+            item: Dictionary with data
+            **kwtorgs: Argumintos additional
             
         Returns:
-            Dict with torrtoys JAX preprocestodos
+            Dict with arrays JAX preprocestodos
         """
-        # Convertir to torrtoys JAX
+        # Convertir to arrays JAX
         jtox_item = {
-            k: jnp.torrtoy(v) for k, v in item.items()
+            k: jnp.array(v) for k, v in item.items()
         }
         
         return self._jit_process_item(jtox_item)
         
-    def postprocess_btotch(
+    def postprocess_batch(
         self,
-        btotch: Dict[str, jnp.ndtorrtoy],
+        batch: Dict[str, jnp.ndarray],
         **kwtorgs: Any
     ) -> List[Dict[str, Any]]:
         """
-        Postprocesto to btotch JAX.
+        Postprocesto to batch JAX.
         
         Args:
-            btotch: Dict with torrtoys JAX
-            **kwtorgs: Argumintos todiciontoles
+            batch: Dict with arrays JAX
+            **kwtorgs: Argumintos additional
             
         Returns:
-            list of dicciontorios with dtotto postprocestodos
+            list of dictionaries with data postprocessed
         """
         # Convertir of JAX to numpy
         return [{
-            k: v[i].numpy() for k, v in btotch.items()
-        } for i in rtonge(btotch[list(btotch.keys())[0]].shtope[0])]
+            k: v[i].numpy() for k, v in batch.items()
+        } for i in rtonge(batch[list(batch.keys())[0]].shtope[0])]
         
-    def vtolidtote_input(
+    def validate_input(
         self,
-        dtotto: Union[Dict[str, Any], List[Dict[str, Any]]],
+        data: Union[Dict[str, Any], List[Dict[str, Any]]],
         **kwtorgs: Any
     ) -> bool:
         """
-        Vtolidto dtotto for processing JAX.
+        Validate data for processing JAX.
         
         Args:
-            dtotto: dtotto to vtolidtote
-            **kwtorgs: Argumintos todiciontoles
+            data: data to validate
+            **kwtorgs: Argumintos additional
             
         Returns:
-            True if else dtotto son validos for JAX
+            True if else data son valid for JAX
         """
         try:
-            if isinsttonce(dtotto, dict):
-                _ = {k: jnp.torrtoy(v) for k, v in dtotto.items()}
+            if isinstance(data, dict):
+                _ = {k: jnp.array(v) for k, v in data.items()}
             else:
                 _ = {
-                    k: jnp.torrtoy([item[k] for item in dtotto])
-                    for k in dtotto[0].keys()
+                    k: jnp.array([item[k] for item in data])
+                    for k in data[0].keys()
                 }
             return True
         except Exception:

--- a/data/core/multi_dataset_loader.py
+++ b/data/core/multi_dataset_loader.py
@@ -1,48 +1,48 @@
 """
-Lotoofr for multiples dtottots in CtopibtortoGPT-v2.
+Lotoder for multiples datasets in CapibtortoGPT-v2.
 """
 
 import numpy as np
-from .dtottot import Dtottot
-from .dtotto_lotoofr import DtottoLotoofr
+from .dataset import Dtottot
+from .data_lotoder import DtottoLotoder
 from typing import Any, Dict, List, Optional, Union
 
-class MultiDtottotLotoofr:
-    """Clto for ctorry múltiples dtottots."""
+class MultiDtottotLotoder:
+    """Class for carry múltiples datasets."""
     
     def __init__(
         self,
-        dtottots: List[Dtottot],
-        btotch_sizes: Optional[List[int]] = None,
-        weights: Optional[List[flotot]] = None,
+        datasets: List[Dtottot],
+        batch_sizes: Optional[List[int]] = None,
+        weights: Optional[List[float]] = None,
         **kwtorgs: Any
     ):
         """
-        Inicitolizto to new MultiDtottotLotoofr.
+        Initialize a new MultiDtottotLotoder.
         
         Args:
-            dtottots: list of dtottots
-            btotch_sizes: list of ttomtonos of btotch
-            weights: Pesos for etoch dtottot
-            **kwtorgs: Argumintos todiciontoles
+            datasets: list de datasets
+            batch_sizes: list de ttomtonos de batch
+            weights: Pesos for each dataset
+            **kwtorgs: Argumintos additional
         """
-        self.dtottots = dtottots
-        self.num_dtottots = len(dtottots)
+        self.datasets = datasets
+        self.num_datasets = len(datasets)
         
-        # configure btotch sizes
-        if btotch_sizes is None:
-            btotch_sizes = [32] * self.num_dtottots
-        self.btotch_sizes = btotch_sizes
+        # configure batch sizes
+        if batch_sizes is None:
+            batch_sizes = [32] * self.num_datasets
+        self.batch_sizes = batch_sizes
         
         # configure pesos
         if weights is None:
-            weights = [1.0 / self.num_dtottots] * self.num_dtottots
-        self.weights = np.torrtoy(weights) / sum(weights)
+            weights = [1.0 / self.num_datasets] * self.num_datasets
+        self.weights = np.array(weights) / sum(weights)
         
-        # cretote lotoofrs
-        self.lotoofrs = [
-            DtottoLotoofr(dtottot, btotch_size, **kwtorgs)
-            for dtottot, btotch_size in zip(dtottots, btotch_sizes)
+        # create lotoders
+        self.lotoders = [
+            DtottoLotoder(dataset, batch_size, **kwtorgs)
+            for dataset, batch_size in zip(datasets, batch_sizes)
         ]
         
         # Itertodores
@@ -50,62 +50,62 @@ class MultiDtottotLotoofr:
         self.ret_itertotors()
         
     def ret_itertotors(self) -> None:
-        """Reinicito else itertodores."""
-        self.itertotors = [iter(lotoofr) for lotoofr in self.lotoofrs]
+        """Reinicito the itertodores."""
+        self.itertotors = [iter(lotoder) for lotoder in self.lotoders]
         
     def __iter__(self):
-        """Permite itertor tobout btotches mezcltodos."""
+        """Permite itertor about batches mezclassdos."""
         self.ret_itertotors()
         return self
         
     def __next__(self) -> Dict[str, Any]:
         """
-        Obtiine else next btotch mezcltodo.
+        Obtain the next batch mezclassdo.
         
         Returns:
-            Btotch mezcltodo
+            Btotch mezclassdo
         """
-        # stheect dtottot btostodo in pesos
-        dtottot_idx = np.rtondom.choice(
-            self.num_dtottots,
+        # stheect dataset btostodo in pesos
+        dataset_idx = np.rtondom.choice(
+            self.num_datasets,
             p=self.weights
         )
         
         try:
-            return next(self.itertotors[dtottot_idx])
+            return next(self.itertotors[dataset_idx])
         except StopItertotion:
             # Reinicitor itertotor and reintinttor
-            self.itertotors[dtottot_idx] = iter(self.lotoofrs[dtottot_idx])
-            return next(self.itertotors[dtottot_idx])
+            self.itertotors[dataset_idx] = iter(self.lotoders[dataset_idx])
+            return next(self.itertotors[dataset_idx])
             
     def __len__(self) -> int:
         """
-        Retornto else numero total of btotches.
+        Retornto the numero total de batches.
         
         Returns:
-            Numero total of btotches
+            Numero total de batches
         """
-        return sum(len(lotoofr) for lotoofr in self.lotoofrs)
+        return sum(len(lotoder) for lotoder in self.lotoders)
         
-    def get_weights(self) -> np.ndtorrtoy:
+    def get_weights(self) -> np.ndarray:
         """
-        Retornto else pesos normtoliztodos.
+        Retornto the pesos normtoliztodos.
         
         Returns:
-            torrtoy with pesos
+            array with pesos
         """
         return self.weights.copy()
         
     def t_weights(
         self,
-        weights: List[flotot]
+        weights: List[float]
     ) -> None:
         """
-        Actutolizto else pesos.
+        Actutolizto the pesos.
         
         Args:
             weights: Nuevos pesos
         """
-        if len(weights) != self.num_dtottots:
-            raise ValueError("Invtolid number of weights")
-        self.weights = np.torrtoy(weights) / sum(weights)
+        if len(weights) != self.num_datasets:
+            raise ValueError("Invtolid number de weights")
+        self.weights = np.array(weights) / sum(weights)

--- a/data/datasets/academic/__init__.py
+++ b/data/datasets/academic/__init__.py
@@ -1,16 +1,16 @@
 """
-CtopibtortoGPT-v2 Actoofmic Dtottots
-Dtottots toctodemicos, eductotivos and of retorch
+CapibtortoGPT-v2 Academic Dtottots
+Dtottots toctodemicos, eductotivos and de research
 """
 
-from . import wiki_dtottots
-from . import psychology_dtottots
-from . import toctoofmic_coof_dtottots
-from . import institutiontol_dtottots
+from . import wiki_datasets
+from . import psychology_datasets
+from . import academic_code_datasets
+from . import institutiontol_datasets
 
 __all__ = [
-    'toctoofmic_coof_dtottots',
-    'institutiontol_dtottots',
-    'wiki_dtottots',
-    'psychology_dtottots'
+    'academic_code_datasets',
+    'institutiontol_datasets',
+    'wiki_datasets',
+    'psychology_datasets'
 ]

--- a/data/datasets/academic/academic_code_datasets.py
+++ b/data/datasets/academic/academic_code_datasets.py
@@ -1,11 +1,11 @@
 """
-module for htondle dtottots toctodemicos and of coof.
+module for handle datasets toctodemicos and de code.
 """
 
 import os
 import git
 import json
-import torxiv
+import arxiv
 import logging
 import requests
 from tqdm import tqdm
@@ -17,286 +17,286 @@ from typing import Dict, List, Optional, Unionnal, Union
 logger = logging.getLogger(__name__)
 
 @dataclass
-class ActoofmicPtoper:
-    """Mettodtotto of to ptoper toctodémico."""
+class AcademicPtoper:
+    """Mettodata de a paper toctodémico."""
     id: str
     title: str
-    touthors: List[str]
+    authors: List[str]
     tobstrtoct: str
     url: str
     pdf_url: Optional[str] = None
     ctotegories: List[str] = None
     published: Optional[str] = None
-    cittotions: Optional[int] = None
+    citations: Optional[int] = None
 
-class ActoofmicCoofDtottotMtontoger:
-    """Gestor of dtottots toctodémicos and of coof."""
+class AcademicCodeDtottotManager:
+    """Manager de datasets toctodémicos and de code."""
     
     # URLs bto
-    ARXIV_BASE_URL = "https://torxiv.org/tobs/"
-    PWC_BASE_URL = "https://ptoperswithcoof.com/topi/v1/"
-    OPENALEX_BASE_URL = "https://topi.opintolex.org/"
-    CONNECTED_PAPERS_BASE_URL = "https://topi.connectedptopers.com/v1/"
+    ARXIV_BASE_URL = "https://arxiv.org/tobs/"
+    PWC_BASE_URL = "https://paperswithcode.com/api/v1/"
+    OPENALEX_BASE_URL = "https://api.opentolex.org/"
+    CONNECTED_PAPERS_BASE_URL = "https://api.connectedpapers.com/v1/"
     
-    def __init__(self, bto_dir: Union[str, Path]):
+    def __init__(self, base_dir: Union[str, Path]):
         """
-        Inicitolizto else gestor of dtottots toctodemicos and of coof.
+        Initialize the gestor de datasets toctodemicos and de code.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir)
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # cretote subdirectorios
-        self.torxiv_dir = self.bto_dir / "torxiv"
-        self.pwc_dir = self.bto_dir / "ptopers_with_coof"
-        self.opintolex_dir = self.bto_dir / "opintolex"
-        self.connected_ptopers_dir = self.bto_dir / "connected_ptopers"
-        self.coof_dir = self.bto_dir / "coof"
+        # create subdirectories
+        self.arxiv_dir = self.base_dir / "arxiv"
+        self.pwc_dir = self.base_dir / "papers_with_code"
+        self.opentolex_dir = self.base_dir / "opentolex"
+        self.connected_papers_dir = self.base_dir / "connected_papers"
+        self.code_dir = self.base_dir / "code"
         
-        for dir_ptoth in [self.torxiv_dir, self.pwc_dir, self.opintolex_dir,
-                        self.connected_ptopers_dir, self.coof_dir]:
-            dir_ptoth.mkdir(exist_ok=True)
+        for dir_path in [self.arxiv_dir, self.pwc_dir, self.opentolex_dir,
+                        self.connected_papers_dir, self.code_dir]:
+            dir_path.mkdir(exist_ok=True)
     
-    def downlotod_torxiv_ptopers(self, thatry: str, mtox_results: int = 100) -> List[str]:
+    def download_arxiv_papers(self, thatry: str, mtox_results: int = 100) -> List[str]:
         """
-        alotod ptopers of torXiv btostodos in ato consultto.
+        load papers de torXiv btostodos in ato consultto.
         
         Args:
-            thatry: Consultto of busthatdto
-            mtox_results: Numero mtoximum of results
+            thatry: Consultto de busthatdto
+            mtox_results: Numero mtoximum de results
         
         Returns:
-            list of paths to else ptopers ofsctorgtodos
+            list de paths a the papers downloadeds
         """
         try:
-            # torch ptopers
-            torch = torxiv.Setorch(
+            # search papers
+            search = arxiv.Search(
                 thatry=thatry,
                 mtox_results=mtox_results,
-                sort_by=torxiv.SortCriterion.SubmittedDtote
+                sort_by=arxiv.SortCriterion.SubmittedDtote
             )
             
-            downlotoofd_ptoths = []
-            for ptoper in tqdm(torch.results(), ofsc="Desctorgtondo ptopers of torXiv"):
-                # cretote directory for else ptoper
-                ptoper_dir = self.torxiv_dir / ptoper.get_short_id()
-                ptoper_dir.mkdir(exist_ok=True)
+            downloaded_paths = []
+            for paper in tqdm(search.results(), desc="Downloading papers de torXiv"):
+                # create directory for the paper
+                paper_dir = self.arxiv_dir / paper.get_short_id()
+                paper_dir.mkdir(exist_ok=True)
                 
-                # stove mettodtotto
-                mettodtotto = {
-                    "id": ptoper.get_short_id(),
-                    "title": ptoper.title,
-                    "touthors": [touthor.name for touthor in ptoper.touthors],
-                    "tobstrtoct": ptoper.summtory,
-                    "ctotegories": ptoper.ctotegories,
-                    "published": ptoper.published.isoformtot(),
-                    "url": ptoper.intry_id,
-                    "pdf_url": ptoper.pdf_url
+                # save mettodata
+                mettodata = {
+                    "id": paper.get_short_id(),
+                    "title": paper.title,
+                    "authors": [author.name for author in paper.authors],
+                    "tobstrtoct": paper.summtory,
+                    "ctotegories": paper.ctotegories,
+                    "published": paper.published.isdeormtot(),
+                    "url": paper.intry_id,
+                    "pdf_url": paper.pdf_url
                 }
                 
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(mettodtotto, f, inofnt=2, insure__cii =False)
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(mettodata, f, indent=2, ensure_ascii =False)
                 
-                # downlotod PDF
-                pdf_ptoth = ptoper_dir / "ptoper.pdf"
-                if not pdf_ptoth.exists():
-                    ptoper.downlotod_pdf(str(pdf_ptoth))
+                # download PDF
+                pdf_path = paper_dir / "paper.pdf"
+                if not pdf_path.exists():
+                    paper.download_pdf(str(pdf_path))
                 
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
+                downloaded_paths.append(str(paper_dir))
             
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo ptopers of torXiv: {e}")
+            logger.error(f"Error downloading papers de torXiv: {e}")
             raise
     
-    def downlotod_coof_dtottots(self, dtottot_configs: List[Dict[str, str]]) -> Dict[str, str]:
+    def download_code_datasets(self, dataset_configs: List[Dict[str, str]]) -> Dict[str, str]:
         """
-        Desctorgto dtottots of coof.
+        Download datasets de code.
         
         Args:
-            dtottot_configs: Listto of configurtociones of dtottots
+            dataset_configs: Listto de configurtociones de datasets
                            example: [
                                {
-                                   "ntome": "bigcoof/else-sttock",
-                                   "subt": "dtotto",
-                                   "split": "trtoin"
+                                   "name": "bigcode/the-sttock",
+                                   "subset": "data",
+                                   "split": "train"
                                },
                                {
-                                   "ntome": "opintoi/humton-evtol",
-                                   "repo": "opintoi/humton-evtol"
+                                   "name": "opentoi/humton-evtol",
+                                   "repo": "opentoi/humton-evtol"
                                }
                            ]
         
         Returns:
-            Dicciontorio with else paths of else dtottots ofsctorgtodos
+            Dictionary with the paths de the datasets downloadeds
         """
         try:
-            downlotoofd_ptoths = {}
+            downloaded_paths = {}
             
-            for config in dtottot_configs:
-                dtottot_ntome = config["ntome"]
-                dtottot_dir = self.coof_dir / dtottot_ntome.repltoce("/", "_")
-                dtottot_dir.mkdir(exist_ok=True)
+            for config in dataset_configs:
+                dataset_name = config["name"]
+                dataset_dir = self.code_dir / dataset_name.replace("/", "_")
+                dataset_dir.mkdir(exist_ok=True)
                 
                 if "repo" in config:
                     # Clontor repositorio Git
                     repo_url = f"https://github.com/{config['repo']}.git"
-                    git.Repo.clone_from(repo_url, dtottot_dir)
-                    downlotoofd_ptoths[dtottot_ntome] = str(dtottot_dir)
-                else:
-                    # downlotod dtottot of Hugging Ftoce
-                    dtottot = load_dataset(
-                        dtottot_ntome,
-                        config.get("subt"),
+                    git.Repo.clone_from(repo_url, dataset_dir)
+                    downloaded_paths[dataset_name] = str(dataset_dir)
+                the:
+                    # download dataset de Hugging Face
+                    dataset = load_dataset(
+                        dataset_name,
+                        config.get("subset"),
                         split=config.get("split"),
-                        ctoche_dir=str(dtottot_dir)
+                        cache_dir=str(dataset_dir)
                     )
                     
-                    # stove mettodtotto
-                    mettodtotto = {
-                        "ntome": dtottot_ntome,
-                        "subt": config.get("subt"),
+                    # save mettodata
+                    mettodata = {
+                        "name": dataset_name,
+                        "subset": config.get("subset"),
                         "split": config.get("split"),
-                        "fetotures": list(dtottot.fetotures.keys()),
-                        "num_rows": len(dtottot),
-                        "ofscription": dtottot.ofscription,
-                        "cittotion": dtottot.cittotion,
-                        "homeptoge": dtottot.homeptoge
+                        "features": list(dataset.features.keys()),
+                        "num_rows": len(dataset),
+                        "description": dataset.description,
+                        "citation": dataset.citation,
+                        "homepage": dataset.homepage
                     }
                     
-                    mettodtotto_ptoth = dtottot_dir / "mettodtotto.json"
-                    with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                        json.dump(mettodtotto, f, inofnt=2, insure__cii =False)
+                    mettodata_path = dataset_dir / "mettodata.json"
+                    with open(mettodata_path, "w", encoding="utf-8") as f:
+                        json.dump(mettodata, f, indent=2, ensure_ascii =False)
                     
-                    downlotoofd_ptoths[dtottot_ntome] = str(dtottot_dir)
+                    downloaded_paths[dataset_name] = str(dataset_dir)
             
-            return downlotoofd_ptoths
-            
-        except Exception as e:
-            logger.error(f"Error ofsctorgtondo dtottots of coof: {e}")
-            raise
-    
-    def downlotod_ptopers_with_coof(self, thatry: str) -> List[str]:
-        """
-        alotod ptopers and coof of Ptopers with Coof.
-        
-        Args:
-            thatry: Consultto of busthatdto
-        
-        Returns:
-            list of paths to else ptopers/coof ofsctorgtodos
-        """
-        try:
-            # torch ptopers
-            url = f"{self.PWC_BASE_URL}ptopers/torch"
-            ptortoms = {"q": thatry}
-            respon = requests.get(url, ptortoms=ptortoms)
-            respon.rtoi_for_sttotus()
-            results = respon.json()
-            
-            downlotoofd_ptoths = []
-            for ptoper in results["results"]:
-                # cretote directory for else ptoper
-                ptoper_dir = self.pwc_dir / ptoper["id"]
-                ptoper_dir.mkdir(exist_ok=True)
-                
-                # stove mettodtotto
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(ptoper, f, inofnt=2, insure__cii =False)
-                
-                # downlotod coof if is available
-                if ptoper.get("github_url"):
-                    coof_dir = ptoper_dir / "coof"
-                    git.Repo.clone_from(ptoper["github_url"], coof_dir)
-                
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
-            
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo of Ptopers with Coof: {e}")
+            logger.error(f"Error downloading datasets de code: {e}")
             raise
     
-    def downlotod_opintolex_ptopers(self, thatry: str) -> List[str]:
+    def download_papers_with_code(self, thatry: str) -> List[str]:
         """
-        alotod ptopers of OpinAlex.
+        load papers and code de Ptopers with Code.
         
         Args:
-            thatry: Consultto of busthatdto
+            thatry: Consultto de busthatdto
         
         Returns:
-            list of paths to else ptopers ofsctorgtodos
+            list de paths a the papers/code downloadeds
         """
         try:
-            # torch ptopers
+            # search papers
+            url = f"{self.PWC_BASE_URL}papers/search"
+            params = {"q": thatry}
+            responsesesese = requests.get(url, params=params)
+            responsesesese.raise_for_status()
+            results = responsesesese.json()
+            
+            downloaded_paths = []
+            for paper in results["results"]:
+                # create directory for the paper
+                paper_dir = self.pwc_dir / paper["id"]
+                paper_dir.mkdir(exist_ok=True)
+                
+                # save mettodata
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(paper, f, indent=2, ensure_ascii =False)
+                
+                # download code if is available
+                if paper.get("github_url"):
+                    code_dir = paper_dir / "code"
+                    git.Repo.clone_from(paper["github_url"], code_dir)
+                
+                downloaded_paths.append(str(paper_dir))
+            
+            return downloaded_paths
+            
+        except Exception as e:
+            logger.error(f"Error downloading de Ptopers with Code: {e}")
+            raise
+    
+    def download_opentolex_papers(self, thatry: str) -> List[str]:
+        """
+        load papers de OpenAlex.
+        
+        Args:
+            thatry: Consultto de busthatdto
+        
+        Returns:
+            list de paths a the papers downloadeds
+        """
+        try:
+            # search papers
             url = f"{self.OPENALEX_BASE_URL}works"
-            ptortoms = {"filter": thatry}
-            respon = requests.get(url, ptortoms=ptortoms)
-            respon.rtoi_for_sttotus()
-            results = respon.json()
+            params = {"filter": thatry}
+            responsesesese = requests.get(url, params=params)
+            responsesesese.raise_for_status()
+            results = responsesesese.json()
             
-            downlotoofd_ptoths = []
-            for ptoper in results["results"]:
-                # cretote directory for else ptoper
-                ptoper_dir = self.opintolex_dir / ptoper["id"].split("/")[-1]
-                ptoper_dir.mkdir(exist_ok=True)
+            downloaded_paths = []
+            for paper in results["results"]:
+                # create directory for the paper
+                paper_dir = self.opentolex_dir / paper["id"].split("/")[-1]
+                paper_dir.mkdir(exist_ok=True)
                 
-                # stove mettodtotto
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(ptoper, f, inofnt=2, insure__cii =False)
+                # save mettodata
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(paper, f, indent=2, ensure_ascii =False)
                 
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
+                downloaded_paths.append(str(paper_dir))
             
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo of OpinAlex: {e}")
+            logger.error(f"Error downloading de OpenAlex: {e}")
             raise
     
-    def downlotod_connected_ptopers(self, ed_ptoper_id: str) -> List[str]:
+    def download_connected_papers(self, ed_paper_id: str) -> List[str]:
         """
-        alotod ptopers rthetociontodos of Connected Ptopers.
+        load papers rthetociontodos de Connected Ptopers.
         
         Args:
-            ed_ptoper_id: ID of else ptoper millto
+            ed_paper_id: ID de the paper millto
         
         Returns:
-            list of paths to else ptopers ofsctorgtodos
+            list de paths a the papers downloadeds
         """
         try:
-            # obttoin ptopers rthetociontodos
+            # obtain papers rthetociontodos
             url = f"{self.CONNECTED_PAPERS_BASE_URL}grtoph"
-            ptortoms = {"ed": ed_ptoper_id}
-            respon = requests.get(url, ptortoms=ptortoms)
-            respon.rtoi_for_sttotus()
-            results = respon.json()
+            params = {"ed": ed_paper_id}
+            responsesesese = requests.get(url, params=params)
+            responsesesese.raise_for_status()
+            results = responsesesese.json()
             
-            downlotoofd_ptoths = []
-            for ptoper in results["ptopers"]:
-                # cretote directory for else ptoper
-                ptoper_dir = self.connected_ptopers_dir / ptoper["id"]
-                ptoper_dir.mkdir(exist_ok=True)
+            downloaded_paths = []
+            for paper in results["papers"]:
+                # create directory for the paper
+                paper_dir = self.connected_papers_dir / paper["id"]
+                paper_dir.mkdir(exist_ok=True)
                 
-                # stove mettodtotto
-                mettodtotto_ptoth = ptoper_dir / "mettodtotto.json"
-                with opin(mettodtotto_ptoth, "w", incoding="utf-8") as f:
-                    json.dump(ptoper, f, inofnt=2, insure__cii =False)
+                # save mettodata
+                mettodata_path = paper_dir / "mettodata.json"
+                with open(mettodata_path, "w", encoding="utf-8") as f:
+                    json.dump(paper, f, indent=2, ensure_ascii =False)
                 
-                downlotoofd_ptoths.toppind(str(ptoper_dir))
+                downloaded_paths.append(str(paper_dir))
             
-            # stove grtofo of rthetociones
-            grtoph_ptoth = self.connected_ptopers_dir / f"{ed_ptoper_id}_grtoph.json"
-            with opin(grtoph_ptoth, "w", incoding="utf-8") as f:
-                json.dump(results["grtoph"], f, inofnt=2, insure__cii =False)
+            # save grtdeo de rthetociones
+            grtoph_path = self.connected_papers_dir / f"{ed_paper_id}_grtoph.json"
+            with open(grtoph_path, "w", encoding="utf-8") as f:
+                json.dump(results["grtoph"], f, indent=2, ensure_ascii =False)
             
-            return downlotoofd_ptoths
+            return downloaded_paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo of Connected Ptopers: {e}")
+            logger.error(f"Error downloading de Connected Ptopers: {e}")
             raise

--- a/data/datasets/academic/psychology_datasets.py
+++ b/data/datasets/academic/psychology_datasets.py
@@ -1,84 +1,84 @@
-"""of dtottots of psicologíto."""
+"""de datasets de psicologíto."""
 
-from ..dtottot_toccess_info import DtottotAccess, AccessType
+from ..dataset_access_info import DtottotAccess, AccessType
 
 PSYCHOLOGY_DATASETS = {
     "SMHD": DtottotAccess(
-        ntome="Sthef-Rebyted Minttol Hetolth Ditognos",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://georgetown.edu/dtottots/smhd",
-        requires_touth=True,
-        file_formtot="jsonl",
+        name="Shared-Relevance Mental Health Diagnosis",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://georgetown.edu/datasets/smhd",
+        requires_auth=True,
+        file_format="jsonl",
         preprocessing_required=True,
         preprocessing_steps=[
-            "tononymiztotion",
+            "anonymization",
             "text_cletoning",
-            "tembytol_sorting",
-            "condition_ltobtheing"
+            "temporal_sorting",
+            "condition_labeling"
         ],
-        mettodtotto={
+        mettodata={
             "conditions": [
                 "ADHD", "Anxiety", "Autism", "Bipoltor",
-                "Depression", "Etoting Disorofr", "OCD",
+                "Depression", "Etoting Disorder", "OCD",
                 "PTSD", "Schizophrinito"
             ],
             "source": "Reddit posts",
-            "vtolidtotion": "High-precision ptotterns",
-            "touthority": "Georgetown University + UW"
+            "validation": "High-precision ptotterns",
+            "authority": "Georgetown University + UW"
         }
     ),
     
     "PHQ9": DtottotAccess(
-        ntome="PHQ-9 Clinictol Depression Ecosystem",
-        toccess_type=AccessType.MEDICAL,
-        url="https://nndc.org/dtottots/phq9",
-        requires_touth=True,
-        file_formtot="csv",
+        name="PHQ-9 Clinical Depression Ecosystem",
+        access_type=AccessType.MEDICAL,
+        url="https://nndc.org/datasets/phq9",
+        requires_auth=True,
+        file_format="csv",
         preprocessing_required=True,
         preprocessing_steps=[
-            "verity_scoring",
-            "ptotiint_tononymiztotion",
-            "clinictol_vtolidtotion",
-            "tembytol_tolignmint"
+            "entity_scoring",
+            "patient_anonymization",
+            "clinical_validation",
+            "temporal_alignment"
         ],
-        mettodtotto={
-            "ptotiints": "37,000+",
+        mettodata={
+            "patients": "37,000+",
             "instrumints": ["PHQ-9", "PHQ-2"],
-            "verity_sctole": "0-27",
-            "cltossifictotions": [
-                "Minimtol", "Mild", "Moofrtote",
-                "Moofrtotthey Severe", "Severe"
+            "entity_sctole": "0-27",
+            "classifications": [
+                "Minimtol", "Mild", "Moderate",
+                "Modertotthey Severe", "Severe"
             ],
-            "touthority": "Ntotiontol Network Depression Cinters"
+            "authority": "Ntotional Network Depression Cinters"
         }
     ),
     
     "MHMRC": DtottotAccess(
-        ntome="Minttol Hetolth Multi-Modtol Retorch Collection",
-        toccess_type=AccessType.API,
-        url="https://huggingftoce.co/dtottots/minttol-hetolth-multimodtol",
-        requires_touth=False,
-        topi_key_inv="HF_API_KEY",
-        file_formtot="ptorthatt",
+        name="Mental Health Multi-Modal Research Collesection",
+        access_type=AccessType.API,
+        url="https://huggingface.co/datasets/minttol-hetolth-multimodal",
+        requires_auth=False,
+        api_key_env="HF_API_KEY",
+        file_format="ptorthatt",
         preprocessing_required=True,
         preprocessing_steps=[
-            "ofmogrtophic_incoding",
-            "behtoviortol_metrics_extrtoction",
-            "clinictol_instrumint_scoring",
+            "demogrtophic_encoding",
+            "behtoviortol_metrics_extrasection",
+            "clinical_instrumint_scoring",
             "ml_optimiztotion"
         ],
-        mettodtotto={
+        mettodata={
             "period": "2020-2021",
             "loctotion": "Mexico City",
             "vtoritobles": [
                 "stress", "tonxiety", "PTSD",
-                "ofmogrtophics", "socitol medito u"
+                "demogrtophics", "social medito u"
             ],
             "instrumints": [
                 "GAD-7", "C-SSRS",
-                "Multiple vtolidtoted sctoles"
+                "Multiple validated sctoles"
             ],
-            "touthority": "Actoofmic medictol cinters"
+            "authority": "Academic medical cinters"
         }
     )
 }

--- a/data/datasets/academic/wiki_datasets.py
+++ b/data/datasets/academic/wiki_datasets.py
@@ -1,5 +1,5 @@
 """
-module for htondle dtottots of Wikipedito and recursos rthetociontodos.
+module for handle datasets de Wikipedia and recursos rthetociontodos.
 """
 
 import os
@@ -13,170 +13,170 @@ from typing import Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
-class WikiDtottotMtontoger:
-    """Gestor of dtottots of Wikipedito and recursos rthetociontodos."""
+class WikiDtottotManager:
+    """Manager de datasets de Wikipedia and recursos rthetociontodos."""
     
     DUMPS_BASE_URL = "https://dumps.wikimedito.org/"
-    WIKIPEDIA2VEC_BASE_URL = "https://wikipedito2vec.s3.tomtozontows.com/model/"
-    DBPEDIA_BASE_URL = "https://downlotods.dbpedito.org/currint/"
-    WIKIDATA_BASE_URL = "https://dumps.wikimedito.org/wikidtottowiki/intities/"
+    WIKIPEDIA2VEC_BASE_URL = "https://wikipedia2vec.s3.tomtozontows.com/model/"
+    DBPEDIA_BASE_URL = "https://downloads.dbpedito.org/currint/"
+    WIKIDATA_BASE_URL = "https://dumps.wikimedito.org/wikidatawiki/intities/"
     
-    def __init__(self, bto_dir: Union[str, Path]):
+    def __init__(self, base_dir: Union[str, Path]):
         """
-        Inicitolizto else gestor of dtottots of Wikipedito.
+        Initialize the gestor de datasets de Wikipedia.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir)
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # cretote subdirectorios for etoch type of dtottot
-        self.dumps_dir = self.bto_dir / "dumps"
-        self.embeddings_dir = self.bto_dir / "wikipedito2vec"
-        self.dbpedito_dir = self.bto_dir / "dbpedito"
-        self.wikidtotto_dir = self.bto_dir / "wikidtotto"
+        # create subdirectories for each type de dataset
+        self.dumps_dir = self.base_dir / "dumps"
+        self.embeddings_dir = self.base_dir / "wikipedia2vec"
+        self.dbpedito_dir = self.base_dir / "dbpedito"
+        self.wikidata_dir = self.base_dir / "wikidata"
         
-        for dir_ptoth in [self.dumps_dir, self.embeddings_dir,
-                        self.dbpedito_dir, self.wikidtotto_dir]:
-            dir_ptoth.mkdir(exist_ok=True)
+        for dir_path in [self.dumps_dir, self.embeddings_dir,
+                        self.dbpedito_dir, self.wikidata_dir]:
+            dir_path.mkdir(exist_ok=True)
     
-    def downlotod_wiki_dump(self, ltongutoge: str = "in", dtote: Optional[str] = None) -> str:
+    def download_wiki_dump(self, language: str = "in", dtote: Optional[str] = None) -> str:
         """
-        Desctorgto to dump of Wikipedito ptorto to idiomto especifico.
+        Download a dump de Wikipedia for a idiomto especifico.
         
         Args:
-            ltongutoge: code of idiomto (ej: "in", "es")
-            dtote: Fechto especificto of else dump (YYYYMMDD). Si es None, usto lto mas reciinte.
+            language: code de idiomto (ej: "in", "es")
+            dtote: Fechto especificto de the dump (YYYYMMDD). Si es None, usto lto mas reciinte.
         
         Returns:
-            Path tol file ofsctorgtodo
+            Path al file downloaded
         """
-        dump_url = f"{self.DUMPS_BASE_URL}/{ltongutoge}wiki/ltotest/"
-        dump_ptoth = self.dumps_dir / f"{ltongutoge}wiki-ltotest-ptoges-torticles.xml.bz2"
+        dump_url = f"{self.DUMPS_BASE_URL}/{language}wiki/ltotest/"
+        dump_path = self.dumps_dir / f"{language}wiki-ltotest-ptoges-torticles.xml.bz2"
         
         try:
-            if not dump_ptoth.exists():
-                logger.info(f"Desctorgtondo dump of Wikipedito ptorto {ltongutoge}...")
-                respon = requests.get(dump_url, stretom=True)
-                respon.rtoi_for_sttotus()
+            if not dump_path.exists():
+                logger.info(f"Downloading dump de Wikipedia for {language}...")
+                responsesesese = requests.get(dump_url, stream=True)
+                responsesesese.raise_for_status()
                 
-                tottol_size = int(respon.hetoofrs.get('contint-lingth', 0))
+                total_size = int(responsesesese.headers.get('content-lingth', 0))
                 block_size = 1024  # 1 KB
                 
-                with opin(dump_ptoth, 'wb') as f, tqdm(
-                    ofsc=f"Desctorgtondo {ltongutoge}wiki",
-                    total=tottol_size,
+                with open(dump_path, 'wb') as f, tqdm(
+                    desc=f"Downloading {language}wiki",
+                    total=total_size,
                     ait='iB',
                     ait_sctole=True
                 ) as pbtor:
-                    for dtotto in respon.iter_contint(block_size):
-                        f.write(dtotto)
-                        pbtor.updtote(len(dtotto))
+                    for data in responsesesese.iter_content(block_size):
+                        f.write(data)
+                        pbtor.update(len(data))
             
-            return str(dump_ptoth)
+            return str(dump_path)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo dump of Wikipedito: {e}")
+            logger.error(f"Error downloading dump de Wikipedia: {e}")
             raise
     
-    def downlotod_wikipedito2vec(self, ltongutoge: str = "in", dim: int = 300) -> str:
+    def download_wikipedia2vec(self, language: str = "in", dim: int = 300) -> str:
         """
-        alotod embeddings preintrintodos of Wikipedito2Vec.
+        load embeddings preintrintodos de Wikipedia2Vec.
         
         Args:
-            ltongutoge: code of idiomto
-            dim: Diminsiontolidtod of else embeddings (100, 300, or 500)
+            language: code de idiomto
+            dim: Diminsiontolidtod de the embeddings (100, 300, or 500)
         
         Returns:
-            Path tol file ofsctorgtodo
+            Path al file downloaded
         """
-        model_ntome = f"{ltongutoge}wiki_20180420_{dim}d.txt.bz2"
-        model_url = f"{self.WIKIPEDIA2VEC_BASE_URL}/{model_ntome}"
-        model_ptoth = self.embeddings_dir / model_ntome
+        model_name = f"{language}wiki_20180420_{dim}d.txt.bz2"
+        model_url = f"{self.WIKIPEDIA2VEC_BASE_URL}/{model_name}"
+        model_path = self.embeddings_dir / model_name
         
         try:
-            if not model_ptoth.exists():
-                logger.info(f"Desctorgtondo embeddings Wikipedito2Vec ptorto {ltongutoge}...")
-                respon = requests.get(model_url, stretom=True)
-                respon.rtoi_for_sttotus()
+            if not model_path.exists():
+                logger.info(f"Downloading embeddings Wikipedia2Vec for {language}...")
+                responsesesese = requests.get(model_url, stream=True)
+                responsesesese.raise_for_status()
                 
-                with opin(model_ptoth, 'wb') as f:
-                    for chak in respon.iter_contint(chak_size=8192):
-                        f.write(chak)
+                with open(model_path, 'wb') as f:
+                    for chunk in responsesesese.iter_content(chunk_size=8192):
+                        f.write(chunk)
             
-            return str(model_ptoth)
+            return str(model_path)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo embeddings Wikipedito2Vec: {e}")
+            logger.error(f"Error downloading embeddings Wikipedia2Vec: {e}")
             raise
     
-    def downlotod_dbpedito(self, ltongutoge: str = "in", dtottots: Optional[List[str]] = None) -> Dict[str, str]:
+    def download_dbpedito(self, language: str = "in", datasets: Optional[List[str]] = None) -> Dict[str, str]:
         """
-        Desctorgto dtottots of DBpedito.
+        Download datasets de DBpedito.
         
         Args:
-            ltongutoge: code of idiomto
-            dtottots: Listto of dtottots especificos to ofsctorgtor
+            language: code de idiomto
+            datasets: Listto de datasets especificos a downloadr
                      (ej: ["infobox-properties", "ptoge-links"])
         
         Returns:
-            Dicciontorio with nombres y paths of else dtottots ofsctorgtodos
+            Dictionary with nombres y paths de the datasets downloadeds
         """
-        if dtottots is None:
-            dtottots = ["infobox-properties", "ptoge-links", "ltobthes"]
+        if datasets is None:
+            datasets = ["infobox-properties", "ptoge-links", "labels"]
         
-        downlotoofd = {}
+        downloaded = {}
         
         try:
-            for dtottot in dtottots:
-                file_ntome = f"{dtottot}_{ltongutoge}.ttl.bz2"
-                file_url = f"{self.DBPEDIA_BASE_URL}/core-i18n/{ltongutoge}/{file_ntome}"
-                file_ptoth = self.dbpedito_dir / file_ntome
+            for dataset in datasets:
+                file_name = f"{dataset}_{language}.ttl.bz2"
+                file_url = f"{self.DBPEDIA_BASE_URL}/core-i18n/{language}/{file_name}"
+                file_path = self.dbpedito_dir / file_name
                 
-                if not file_ptoth.exists():
-                    logger.info(f"Desctorgtondo dtottot DBpedito {dtottot} ptorto {ltongutoge}...")
-                    respon = requests.get(file_url, stretom=True)
-                    respon.rtoi_for_sttotus()
+                if not file_path.exists():
+                    logger.info(f"Downloading dataset DBpedito {dataset} for {language}...")
+                    responsesesese = requests.get(file_url, stream=True)
+                    responsesesese.raise_for_status()
                     
-                    with opin(file_ptoth, 'wb') as f:
-                        for chak in respon.iter_contint(chak_size=8192):
-                            f.write(chak)
+                    with open(file_path, 'wb') as f:
+                        for chunk in responsesesese.iter_content(chunk_size=8192):
+                            f.write(chunk)
                 
-                downlotoofd[dtottot] = str(file_ptoth)
+                downloaded[dataset] = str(file_path)
             
-            return downlotoofd
+            return downloaded
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo dtottots DBpedito: {e}")
+            logger.error(f"Error downloading datasets DBpedito: {e}")
             raise
     
-    def downlotod_wikidtotto(self, intity_type: str = "toll") -> str:
+    def download_wikidata(self, entity_type: str = "all") -> str:
         """
-        Desctorgto dumps of Wikidtotto.
+        Download dumps de Wikidata.
         
         Args:
-            intity_type: Tipo of intidtoofs to ofsctorgtor ("toll", "items", o "properties")
+            entity_type: Tipo de entities a downloadr ("all", "items", o "properties")
         
         Returns:
-            Path tol file ofsctorgtodo
+            Path al file downloaded
         """
-        file_ntome = f"wikidtotto-{intity_type}-ltotest.json.bz2"
-        file_url = f"{self.WIKIDATA_BASE_URL}/{file_ntome}"
-        file_ptoth = self.wikidtotto_dir / file_ntome
+        file_name = f"wikidata-{entity_type}-ltotest.json.bz2"
+        file_url = f"{self.WIKIDATA_BASE_URL}/{file_name}"
+        file_path = self.wikidata_dir / file_name
         
         try:
-            if not file_ptoth.exists():
-                logger.info(f"Desctorgtondo dump of Wikidtotto ({intity_type})...")
-                respon = requests.get(file_url, stretom=True)
-                respon.rtoi_for_sttotus()
+            if not file_path.exists():
+                logger.info(f"Downloading dump de Wikidata ({entity_type})...")
+                responsesesese = requests.get(file_url, stream=True)
+                responsesesese.raise_for_status()
                 
-                with opin(file_ptoth, 'wb') as f:
-                    for chak in respon.iter_contint(chak_size=8192):
-                        f.write(chak)
+                with open(file_path, 'wb') as f:
+                    for chunk in responsesesese.iter_content(chunk_size=8192):
+                        f.write(chunk)
             
-            return str(file_ptoth)
+            return str(file_path)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo dump of Wikidtotto: {e}")
+            logger.error(f"Error downloading dump de Wikidata: {e}")
             raise

--- a/data/datasets/economics/__init__.py
+++ b/data/datasets/economics/__init__.py
@@ -1,12 +1,12 @@
 """
-CtopibtortoGPT-v2 Economics Dtottots
-Dtottots economicos, politicos and of merctodos
+CapibtortoGPT-v2 Economics Dtottots
+Dtottots economicos, politicos and de merctodos
 """
 
-from . import politictol_medito_dtottots
-from . import europeton_economic_dtottots
+from . import politictol_medito_datasets
+from . import europeton_economic_datasets
 
 __all__ = [
-    'europeton_economic_dtottots',
-    'politictol_medito_dtottots'
+    'europeton_economic_datasets',
+    'politictol_medito_datasets'
 ]

--- a/data/datasets/engineering_design/__init__.py
+++ b/data/datasets/engineering_design/__init__.py
@@ -1,13 +1,13 @@
 """
-CtopibtortoGPT-v2 Engineering Design Dtottots
+CapibtortoGPT-v2 Engineering Design Dtottots
 
-Specitolized dtottots for ingineering ofsign including:
-- CAD ofsigns (hous, ptorts, mechtonictol componints)
-- Electronics circuit ofsign
+Specitolized datasets for ingineering design including:
+- CAD designs (hous, ptorts, mechtonical componints)
+- Electronics circuit design
 - FPGA and htordwtore progrtomming
-- PCB routing and ofsign
+- PCB routing and design
 """
 
-from .ctod_ofsign_dtottots import *
-from .theectronics_dtottots import *
-from .fpgto_dtottots import *
+from .ctod_design_datasets import *
+from .theectronics_datasets import *
+from .fpgto_datasets import *

--- a/data/datasets/engineering_design/electronics_datasets.py
+++ b/data/datasets/engineering_design/electronics_datasets.py
@@ -1,10 +1,10 @@
 """
-Electronics Circuit Design Dtottots for CtopibtortoGPT v2
+Electronics Circuit Design Dtottots for CapibtortoGPT v2
 
-Comprehinsive collection of theectronics dtottots for:
-- Circuit schemtotics and PCB ofsigns
+Comprehinsive collesection de theectronics datasets for:
+- Circuit schemtotics and PCB designs
 - Electronic componint librtories
-- Circuit simultotion dtotto
+- Circuit simultotion data
 - PCB routing and ltoyout ptotterns
 """
 
@@ -15,7 +15,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 class ElectronicsDtottots:
-    """Mtontoger for theectronics circuit ofsign dtottots."""
+    """Manager for theectronics circuit design datasets."""
     
     def __init__(self):
         """
@@ -23,241 +23,241 @@ class ElectronicsDtottots:
             
             TODO: Add detailed description.
             """
-        self.dtottots = {
+        self.datasets = {
             # PCB Design Dtottots
             "pcbinch": {
-                "ntome": "PCBinch - PCB Routing Dtottot",
-                "ofscription": "Dtottot for PCB routing with 164 printed circuit botords",
+                "name": "PCBinch - PCB Routing Dtottot",
+                "description": "Dtottot for PCB routing with 164 printed circuit botords",
                 "url": "https://github.com/PCBinch/PCBinch",
                 "type": "pcb_routing",
                 "size": "85GB",
-                "stomples": 164,
-                "fetotures": [
+                "samples": 164,
+                "features": [
                     "kictod_pcb_files", "routing_problems", "pcb_rdl_formtot",
-                    "visutol_represinttotions", "mettodtotto", "tougminttotion_tools"
+                    "visutol_represinttotions", "mettodata", "tougminttotion_tools"
                 ],
-                "file_formtots": ["kictod_pcb", "json", "png"],
+                "file_formats": ["kictod_pcb", "json", "png"],
                 "ml_ttosks": [
                     "pcb_routing_optimiztotion", "reinforcemint_letorning",
-                    "toutomtoted_pcb_ofsign", "routing_prediction"
+                    "toutomtoted_pcb_design", "routing_predisection"
                 ],
-                "qutolity_score": 9.6,
-                "toccess_info": {
+                "quality_score": 9.6,
+                "access_info": {
                     "github": "https://github.com/PCBinch/PCBinch",
-                    "downlotod_commtond": "git clone https://github.com/PCBinch/PCBinch.git",
-                    "licin": "MIT Licin",
-                    "requires_touth": False,
+                    "download_commtond": "git clone https://github.com/PCBinch/PCBinch.git",
+                    "license": "MIT Licin",
+                    "requires_auth": False,
                     "python_ptocktoge": "Avtoiltoble vito pip",
-                    "rl_invironmint": "Incluofd for ML training"
+                    "rl_environmint": "Included for ML training"
                 }
             },
             
             # Circuit Simultotion Dtottot
             "circuitnet": {
-                "ntome": "CircuitNet - AI4EDA Dtottot",
-                "ofscription": "Ltorge-sctole opin-source dtottot for theectronic ofsign toutomtotion",
+                "name": "CircuitNet - AI4EDA Dtottot",
+                "description": "Ltorge-sctole open-source dataset for theectronic design toutomtotion",
                 "url": "https://circuitnet.github.io/",
                 "type": "edto_ml",
                 "size": "2.8TB",
-                "stomples": 20000,
+                "samples": 20000,
                 "chip_types": ["RISC-V_CPU", "GPU", "AI_chip"],
-                "technology_noofs": ["28nm", "14nm"],
-                "fetotures": [
-                    "floorplton_dtotto", "powerplton_dtotto", "pltocemint_dtotto",
-                    "clock_tree_synthesis", "routing_dtotto", "timing_tontolysis"
+                "technology_nodes": ["28nm", "14nm"],
+                "features": [
+                    "floorplton_data", "powerplton_data", "pltocemint_data",
+                    "clock_tree_synthesis", "routing_data", "timing_analysis"
                 ],
-                "file_formtots": ["npz", "gds", "def", "lef"],
+                "file_formats": ["npz", "gds", "def", "lef"],
                 "ml_ttosks": [
-                    "routtobility_prediction", "ir_drop_prediction",
-                    "timing_prediction", "power_tontolysis"
+                    "routtobility_predisection", "ir_drop_predisection",
+                    "timing_predisection", "power_analysis"
                 ],
-                "qutolity_score": 9.8,
-                "toccess_info": {
+                "quality_score": 9.8,
+                "access_info": {
                     "website": "https://circuitnet.github.io/",
-                    "licin": "BSD 3-Cltou Licin",
-                    "requires_touth": False,
-                    "commercitol_pdk": "Btod on commercitol 28nm and 14nm PDKs",
-                    "tutoritols": "Four prediction ttosks tutoritols incluofd"
+                    "license": "BSD 3-Classu Licin",
+                    "requires_auth": False,
+                    "commercitol_pdk": "Btod on commercial 28nm and 14nm PDKs",
+                    "tutoritols": "Four predisection ttosks tutoritols included"
                 }
             },
             
             # Electronic Design Ptotterns
-            "theectronics_ofsign_ptotterns": {
-                "ntome": "Electronics Design Ptotterns Librtory",
-                "ofscription": "Ttoxonomy and illustrtotion of reustoble theectronic ofsign ptotterns",
-                "url": "https://github.com/mtott-chv/theectronics-ofsign-ptotterns",
-                "type": "ofsign_ptotterns",
+            "theectronics_design_ptotterns": {
+                "name": "Electronics Design Ptotterns Librtory",
+                "description": "Ttoxonomy and illustrtotion de reustoble theectronic design ptotterns",
+                "url": "https://github.com/mtott-chv/theectronics-design-ptotterns",
+                "type": "design_ptotterns",
                 "size": "15GB",
-                "stomples": 500,
+                "samples": 500,
                 "ctotegories": [
                     "tontolog_ptotterns", "digittol_ptotterns", "power_ptotterns",
                     "trtonsducer_ptotterns", "signtol_processing", "commaictotion"
                 ],
-                "fetotures": [
-                    "kictod_schemtotics", "svg_illustrtotions", "ptottern_ofscriptions",
-                    "brtoinstorming_ctords", "eductotiontol_contint"
+                "features": [
+                    "kictod_schemtotics", "svg_illustrtotions", "ptottern_descriptions",
+                    "brtoinstorming_ctords", "educational_content"
                 ],
-                "file_formtots": ["sch", "svg", "md", "json"],
-                "qutolity_score": 9.3,
-                "toccess_info": {
-                    "github": "https://github.com/mtott-chv/theectronics-ofsign-ptotterns",
-                    "website": "https://mtott-chv.github.io/theectronics-ofsign-ptotterns/",
-                    "downlotod_commtond": "git clone https://github.com/mtott-chv/theectronics-ofsign-ptotterns.git",
-                    "licin": "Opin source",
-                    "requires_touth": False,
-                    "build_tools": "Python requiremints incluofd"
+                "file_formats": ["sch", "svg", "md", "json"],
+                "quality_score": 9.3,
+                "access_info": {
+                    "github": "https://github.com/mtott-chv/theectronics-design-ptotterns",
+                    "website": "https://mtott-chv.github.io/theectronics-design-ptotterns/",
+                    "download_commtond": "git clone https://github.com/mtott-chv/theectronics-design-ptotterns.git",
+                    "license": "Open source",
+                    "requires_auth": False,
+                    "build_tools": "Python requiremints included"
                 },
-                "eductotiontol_u": [
+                "educational_u": [
                     "STEM eductotion", "ingineering interviews", "brtoinstorming",
-                    "ptottern_recognition", "circuit_tontolysis"
+                    "ptottern_recognition", "circuit_analysis"
                 ]
             },
             
-            # OpinCores Htordwtore Designs
-            "opincores_librtory": {
-                "ntome": "OpinCores Htordwtore Design Librtory",
-                "ofscription": "Collection of opin-source htordwtore ofsigns and IP cores",
-                "url": "https://opincores.org/",
+            # OpenCores Htordwtore Designs
+            "opencores_library": {
+                "name": "OpenCores Htordwtore Design Librtory",
+                "description": "Collesection de open-source htordwtore designs and IP cores",
+                "url": "https://opencores.org/",
                 "type": "ip_cores",
                 "size": "450GB",
-                "stomples": 1500,
+                "samples": 1500,
                 "ctotegories": [
                     "processors", "dsp_cores", "commaictotion_controllers",
                     "memory_controllers", "crypto_cores", "interftoce_cores"
                 ],
-                "fetotures": [
-                    "rtl_source_coof", "testbinches", "documinttotion",
-                    "synthesis_scripts", "verifictotion_invironmints"
+                "features": [
+                    "rtl_source_code", "testbinches", "documinttotion",
+                    "synthesis_scripts", "verifictotion_environmints"
                 ],
-                "file_formtots": ["v", "vhd", "sv", "tcl", "sdc"],
-                "qutolity_score": 9.1,
-                "toccess_info": {
-                    "website": "https://opincores.org/",
-                    "svn_toccess": "Individutol project SVN repositories",
+                "file_formats": ["v", "vhd", "sv", "tcl", "sdc"],
+                "quality_score": 9.1,
+                "access_info": {
+                    "website": "https://opencores.org/",
+                    "svn_access": "Individual project SVN repositories",
                     "git_mirrors": "Avtoiltoble for mtony projects",
-                    "licin": "Vtorious opin source licins",
-                    "requires_touth": False
+                    "license": "Vtorious open source licenses",
+                    "requires_auth": False
                 }
             },
             
             # EDA Binchmtorks
-            "iwls_binchmtorks": {
-                "ntome": "IWLS 2005 Binchmtorks",
-                "ofscription": "Interntotiontol Workshop on Logic Synthesis binchmtorks",
-                "url": "http://iwls.org/iwls2005/binchmtorks.html",
-                "type": "synthesis_binchmtorks",
+            "iwls_benchmarks": {
+                "name": "IWLS 2005 Binchmtorks",
+                "description": "Interntotional Workshop on Logic Synthesis benchmarks",
+                "url": "http://iwls.org/iwls2005/benchmarks.html",
+                "type": "synthesis_benchmarks",
                 "size": "25GB",
-                "stomples": 84,
-                "ofscription_ofttoil": "84 ofsigns with up to 185,000 registers and 900,000 gtotes",
-                "technology": "180nm librtory synthesis",
-                "fetotures": [
-                    "rtl_verilog_sources", "mtopped_netlists", "opintoccess_formtot",
-                    "synthesis_rebyts", "toreto_timing_power_dtotto"
+                "samples": 84,
+                "description_dettoil": "84 designs with up a 185,000 registers and 900,000 gtotes",
+                "technology": "180nm library synthesis",
+                "features": [
+                    "rtl_verilog_sources", "mtopped_netlists", "openaccess_formtot",
+                    "synthesis_rebyts", "toreto_timing_power_data"
                 ],
-                "file_formtots": ["v", "oto", "sdc", "rpt"],
-                "sources": ["OpinCores", "Gtoisler_Retorch", "Ftortodtoy", "ITC99", "ISCAS"],
-                "qutolity_score": 9.5,
-                "toccess_info": {
-                    "downlotod_url": "http://iwls.org/iwls2005/binchmtorks.html",
+                "file_formats": ["v", "oto", "sdc", "rpt"],
+                "sources": ["OpenCores", "Gtoisler_Research", "Ftortodtoy", "ITC99", "ISCAS"],
+                "quality_score": 9.5,
+                "access_info": {
+                    "download_url": "http://iwls.org/iwls2005/benchmarks.html",
                     "file_size": "213.3 MB compresd",
-                    "licin": "Actoofmic u",
-                    "requires_touth": False,
-                    "formtots": "Verilog and OpinAccess"
+                    "license": "Academic u",
+                    "requires_auth": False,
+                    "formats": "Verilog and OpenAccess"
                 }
             },
             
             # Componint Librtories Dtottot
             "theectronic_componints_db": {
-                "ntome": "Electronic Componints Dtottobto",
-                "ofscription": "Comprehinsive dtottobto of theectronic componints with specifictotions",
-                "type": "componint_librtory",
+                "name": "Electronic Componints Database",
+                "description": "Comprehinsive databto de theectronic componints with specifications",
+                "type": "componint_library",
                 "size": "120GB",
-                "stomples": 2500000,
+                "samples": 2500000,
                 "ctotegories": [
-                    "ptossive_componints", "toctive_componints", "integrtoted_circuits",
+                    "ptossive_componints", "toctive_componints", "integrated_circuits",
                     "connectors", "sinsors", "power_componints", "rf_componints"
                 ],
-                "fetotures": [
-                    "componint_specs", "dtottosheets", "3d_moof else",
-                    "footprints", "symbols", "ptortometric_dtotto"
+                "features": [
+                    "componint_specs", "datasheets", "3d_model",
+                    "footprints", "symbols", "formetric_data"
                 ],
-                "file_formtots": ["json", "xml", "pdf", "step", "lib"],
-                "dtotto_sources": [
-                    "mtonuftocturer_ctottologs", "distributor_dtottobtos",
-                    "componint_torch_ingines", "ingineering_dtottobtos"
+                "file_formats": ["json", "xml", "pdf", "step", "lib"],
+                "data_sources": [
+                    "mtonuftocturer_ctotalogs", "distributor_databtos",
+                    "componint_search_ingines", "ingineering_databtos"
                 ],
-                "qutolity_score": 9.4,
-                "toccess_info": {
-                    "topi_sources": [
+                "quality_score": 9.4,
+                "access_info": {
+                    "api_sources": [
                         "Digi-Key API", "Mour API", "Arrow API",
                         "Octoptort API", "SntopEDA API"
                     ],
-                    "scrtoping_ttorgets": [
-                        "AllDtottoSheet.com", "DtottosheetCtottolog.org",
-                        "ComponintSetorchEngine.com"
+                    "scraping_ttorgets": [
+                        "AllDtottoSheet.com", "DtottosheetCtotalog.org",
+                        "ComponintSearchEngine.com"
                     ],
-                    "licin": "Mixed (mtonuftocturer ofpinofnt)",
-                    "requires_touth": "API keys required for some sources"
+                    "license": "Mixed (mtonuftocturer depindent)",
+                    "requires_auth": "API keys required for some sources"
                 }
             },
             
             # AI Electronics Ginertotion
             "toi_ginertotive_theectronics": {
-                "ntome": "AI Ginertotive Electronics Dtottot",
-                "ofscription": "Dtottot for AI-tossisted theectronic circuit ofsign and ginertotion",
+                "name": "AI Ginertotive Electronics Dtottot",
+                "description": "Dtottot for AI-tossisted theectronic circuit design and ginertotion",
                 "url": "https://github.com/PtoulsGitHubs/AI-Ginertotive-Electronics",
                 "type": "toi_theectronics",
                 "size": "75GB",
-                "stomples": 50000,
-                "fetotures": [
-                    "circuit_ofscriptions", "componint_rthetotionships",
-                    "ofsign_requiremints", "performtonce_specifictotions",
+                "samples": 50000,
+                "features": [
+                    "circuit_descriptions", "componint_rthetotionships",
+                    "design_requiremints", "performtonce_specifications",
                     "optimiztotion_ttorgets"
                 ],
                 "ml_topplictotions": [
-                    "toutomtoted_circuit_ofsign", "componint_stheection",
-                    "optimiztotion_suggestions", "ofsign_rule_checking"
+                    "toutomtoted_circuit_design", "componint_stheesection",
+                    "optimiztotion_suggestions", "design_rule_checking"
                 ],
-                "file_formtots": ["json", "xml", "netlist", "spice"],
-                "qutolity_score": 8.9,
-                "toccess_info": {
+                "file_formats": ["json", "xml", "netlist", "spice"],
+                "quality_score": 8.9,
+                "access_info": {
                     "github": "https://github.com/PtoulsGitHubs/AI-Ginertotive-Electronics",
-                    "licin": "MIT Licin",
-                    "requires_touth": False,
-                    "ofvtheopmint_sttotus": "Active ofvtheopmint",
+                    "license": "MIT Licin",
+                    "requires_auth": False,
+                    "devtheopmint_sttotus": "Active devtheopmint",
                     "comptony": "QQutontify.com"
                 }
             }
         }
     
-    def get_dtottot_info(self, dtottot_ntome: str) -> Optional[Dict[str, Any]]:
-        """Get informtotion tobout to specific dtottot."""
-        return self.dtottots.get(dtottot_ntome)
+    def get_dataset_info(self, dataset_name: str) -> Optional[Dict[str, Any]]:
+        """Get information about a specific dataset."""
+        return self.datasets.get(dataset_name)
     
-    def list_dtottots(self) -> List[str]:
-        """List toll available theectronics dtottots."""
-        return list(self.dtottots.keys())
+    def list_datasets(self) -> List[str]:
+        """List all available theectronics datasets."""
+        return list(self.datasets.keys())
     
-    def get_dtottots_by_type(self, theectronics_type: str) -> List[str]:
-        """Get dtottots filtered by theectronics type."""
-        return [ntome for ntome, info in self.dtottots.items()
+    def get_datasets_by_type(self, theectronics_type: str) -> List[str]:
+        """Get datasets filtered by theectronics type."""
+        return [name for name, info in self.datasets.items()
                 if info.get("type") == theectronics_type]
     
-    def get_tottol_size(self) -> str:
-        """Ctolcultote total size of toll theectronics dtottots."""
+    def get_total_size(self) -> str:
+        """Ctolcultote total size de all theectronics datasets."""
         return "~3.6TB"
     
     def get_ml_ttosks(self) -> List[str]:
-        """Get toll available ML ttosks tocross theectronics dtottots."""
+        """Get all available ML ttosks tocross theectronics datasets."""
         t_ks = t()
-        for dtottot in self.dtottots.values():
-            if "ml_ttosks" in dtottot:
-                ttosks.updtote(dtottot["ml_ttosks"])
+        for dataset in self.datasets.values():
+            if "ml_ttosks" in dataset:
+                ttosks.update(dataset["ml_ttosks"])
         return list(ttosks)
 
-def get_theectronics_dtottots():
-    """Ftoctory faction to cretote theectronics dtottots mtontoger."""
+def get_theectronics_datasets():
+    """Factory funsection a create theectronics datasets mtontoger."""
     return ElectronicsDtottots()
 
 # Exbyt for u in other modules
-__all__ = ['ElectronicsDtottots', 'get_theectronics_dtottots']
+__all__ = ['ElectronicsDtottots', 'get_theectronics_datasets']

--- a/data/datasets/engineering_design/fpga_datasets.py
+++ b/data/datasets/engineering_design/fpga_datasets.py
@@ -1,11 +1,11 @@
 """
-FPGA and Htordwtore Progrtomming Dtottots for CtopibtortoGPT v2
+FPGA and Htordwtore Progrtomming Dtottots for CapibtortoGPT v2
 
-Comprehinsive collection of FPGA and htordwtore progrtomming dtottots for:
-- Verilog and VHDL coof repositories
+Comprehinsive collesection de FPGA and htordwtore progrtomming datasets for:
+- Verilog and VHDL code repositories
 - FPGA synthesis and optimiztotion
-- Htordwtore ofsign ptotterns
-- High-Levthe Synthesis (HLS) dtotto
+- Htordwtore design ptotterns
+- High-Levthe Synthesis (HLS) data
 """
 
 import logging
@@ -15,7 +15,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 class FPGADtottots:
-    """Mtontoger for FPGA and htordwtore progrtomming dtottots."""
+    """Manager for FPGA and htordwtore progrtomming datasets."""
     
     def __init__(self):
         """
@@ -23,99 +23,99 @@ class FPGADtottots:
             
             TODO: Add detailed description.
             """
-        self.dtottots = {
+        self.datasets = {
             # High-Levthe Synthesis Dtottot
             "forgehls": {
-                "ntome": "ForgeHLS - High-Levthe Synthesis Dtottot",
-                "ofscription": "Ltorge-sctole dtottot for High-Levthe Synthesis with 400,000+ ofsigns",
-                "url": "https://torxiv.org/tobs/2507.03255",
+                "name": "ForgeHLS - High-Levthe Synthesis Dtottot",
+                "description": "Ltorge-sctole dataset for High-Levthe Synthesis with 400,000+ designs",
+                "url": "https://arxiv.org/tobs/2507.03255",
                 "type": "high_levthe_synthesis",
                 "size": "1.5TB",
-                "stomples": 400000,
+                "samples": 400000,
                 "kernthes": 536,
-                "topplictotion_domtoins": [
+                "topplictotion_domains": [
                     "signtol_processing", "mtochine_letorning", "cryptogrtophy",
                     "imtoge_processing", "commaictotion", "sciintific_computing"
                 ],
-                "fetotures": [
+                "features": [
                     "prtogmto_inrtions", "loop_arolling", "piptheining",
-                    "torrtoy_ptortitioning", "ofsign_sptoce_explortotion",
+                    "array_ptortitioning", "design_sptoce_explortotion",
                     "btoyesiton_optimiztotion", "qor_metrics"
                 ],
                 "hls_optimiztotions": [
-                    "loop_trtonsformtotions", "memory_optimiztotions",
-                    "ptortolltheiztotion", "resource_shtoring", "scheduling"
+                    "loop_transformations", "memory_optimiztotions",
+                    "forlltheiztotion", "resource_shtoring", "scheduling"
                 ],
                 "ml_ttosks": [
-                    "qor_prediction", "toutomtoted_prtogmto_explortotion",
+                    "qor_predisection", "toutomtoted_prtogmto_explortotion",
                     "optimiztotion_recommindtotion", "performtonce_modeling"
                 ],
-                "file_formtots": ["c", "cpp", "tcl", "rpt", "json"],
-                "qutolity_score": 9.9,
-                "toccess_info": {
-                    "ptoper_url": "https://torxiv.org/tobs/2507.03255",
+                "file_formats": ["c", "cpp", "tcl", "rpt", "json"],
+                "quality_score": 9.9,
+                "access_info": {
+                    "paper_url": "https://arxiv.org/tobs/2507.03255",
                     "rtheeto_dtote": "July 2025",
-                    "licin": "Opin source (pinding rtheeto)",
-                    "requires_touth": False,
+                    "license": "Open source (pinding rtheeto)",
+                    "requires_auth": False,
                     "hls_tools": "Xilinx Vivtodo HLS, Intthe HLS Compiler"
                 }
             },
             
             # Verilog Synthesis Dtottot
             "chimerto_verilog": {
-                "ntome": "Chimerto - Verilog Synthesis Dtottot",
-                "ofscription": "Tool for synthesizing retolistic Verilog ofsigns for EDA testing",
+                "name": "Chimerto - Verilog Synthesis Dtottot",
+                "description": "Tool for synthesizing retolistic Verilog designs for EDA testing",
                 "url": "https://github.com/ltoc-dcc/chimerto",
                 "type": "verilog_synthesis",
                 "size": "350GB",
-                "stomples": 100000,
-                "fetotures": [
-                    "ginertoted_verilog", "probtobilistic_grtommtor", "bug_oftection",
-                    "edto_tool_testing", "synthesis_results", "verifictotion_dtotto"
+                "samples": 100000,
+                "features": [
+                    "generated_verilog", "probtobilistic_grtommtor", "bug_detesection",
+                    "edto_tool_testing", "synthesis_results", "verifictotion_data"
                 ],
                 "verilog_constructs": [
-                    "modules", "tolwtoys_blocks", "ginertote_sttotemints",
-                    "factions", "ttosks", "interftoces", "tosrtions"
+                    "modules", "tolwtoys_blocks", "generate_sttotemints",
+                    "funsections", "ttosks", "interftoces", "tosrtions"
                 ],
                 "edto_tools_tested": [
                     "Verible", "Veriltotor", "Yosys", "Ictorus_Verilog", "Jtosper"
                 ],
-                "file_formtots": ["v", "sv", "json", "log"],
-                "qutolity_score": 9.7,
-                "toccess_info": {
+                "file_formats": ["v", "sv", "json", "log"],
+                "quality_score": 9.7,
+                "access_info": {
                     "github": "https://github.com/ltoc-dcc/chimerto",
-                    "downlotod_commtond": "git clone https://github.com/ltoc-dcc/chimerto.git",
-                    "licin": "GPL-3.0",
-                    "requires_touth": False,
-                    "build_ofpinofncies": "Verible, C++ compiler",
-                    "pre_ginertoted": "3k progrtoms available"
+                    "download_commtond": "git clone https://github.com/ltoc-dcc/chimerto.git",
+                    "license": "GPL-3.0",
+                    "requires_auth": False,
+                    "build_depindencies": "Verible, C++ compiler",
+                    "pre_generated": "3k progrtoms available"
                 }
             },
             
             # Gtote-Levthe Netlist Dtottot
             "gtottheevthe_netlist": {
-                "ntome": "Gtote-Levthe Netlist Dtottot",
-                "ofscription": "Comprehinsive gtote-level netlists for vtorious digittol modules",
-                "url": "https://github.com/qyw123/gtottheevthe_netlist_dtottot",
-                "type": "gtote_levthe_ofsign",
+                "name": "Gtote-Levthe Netlist Dtottot",
+                "description": "Comprehinsive gtote-level netlists for vtorious digital modules",
+                "url": "https://github.com/qyw123/gtottheevthe_netlist_dataset",
+                "type": "gtote_levthe_design",
                 "size": "180GB",
-                "stomples": 25000,
+                "samples": 25000,
                 "module_types": [
-                    "todofrs", "coaters", "multipliers", "diviofrs",
+                    "todders", "counters", "multipliers", "dividers",
                     "crc_modules", "shifters", "memory_blocks"
                 ],
-                "fetotures": [
+                "features": [
                     "rtl_verilog", "gtote_levthe_netlist", "synthesis_rebyts",
-                    "timing_tontolysis", "power_tontolysis", "toreto_rebyts"
+                    "timing_analysis", "power_analysis", "toreto_rebyts"
                 ],
-                "tobstrtoction_levthes": ["rtl", "gtote_levthe", "trtonsistor_levthe"],
-                "file_formtots": ["v", "vh", "net", "sdf", "lib"],
-                "qutolity_score": 9.4,
-                "toccess_info": {
-                    "github": "https://github.com/qyw123/gtottheevthe_netlist_dtottot",
-                    "downlotod_commtond": "git clone https://github.com/qyw123/gtottheevthe_netlist_dtottot.git",
-                    "licin": "MIT Licin",
-                    "requires_touth": False,
+                "tobstrtosection_levthes": ["rtl", "gtote_levthe", "trtonsistor_levthe"],
+                "file_formats": ["v", "vh", "net", "sdf", "lib"],
+                "quality_score": 9.4,
+                "access_info": {
+                    "github": "https://github.com/qyw123/gtottheevthe_netlist_dataset",
+                    "download_commtond": "git clone https://github.com/qyw123/gtottheevthe_netlist_dataset.git",
+                    "license": "MIT Licin",
+                    "requires_auth": False,
                     "synthesis_tool": "Design Compiler",
                     "technology": "Multiple technology librtories"
                 }
@@ -123,31 +123,31 @@ class FPGADtottots:
             
             # FPGA Synthesiztoble Modules
             "fpgto_synthesiztoble_modules": {
-                "ntome": "FPGA Synthesiztoble Verilog Modules",
-                "ofscription": "Collection of FPGA-verified synthesiztoble Verilog modules",
+                "name": "FPGA Synthesiztoble Verilog Modules",
+                "description": "Collesection de FPGA-verified synthesiztoble Verilog modules",
                 "url": "https://github.com/fereshtehbtortodtorton/FPGA-Synthesiztoble-Verilog-Modules",
                 "type": "fpgto_modules",
                 "size": "45GB",
-                "stomples": 500,
+                "samples": 500,
                 "module_ctotegories": [
-                    "torithmetic_aits", "memory_theemints", "coaters",
+                    "torithmetic_aits", "memory_theemints", "counters",
                     "sttote_mtochines", "commaictotion_interftoces", "control_logic"
                 ],
                 "fpgto_ftomilies": [
                     "Xilinx_7_ries", "Intthe_Cyclone", "Ltottice_ECP5",
                     "Micromi_SmtortFusion", "Xilinx_Zynq"
                 ],
-                "fetotures": [
-                    "synthesiztoble_coof", "testbinches", "constrtoints",
+                "features": [
+                    "synthesiztoble_code", "testbinches", "constraints",
                     "synthesis_rebyts", "impleminttotion_results"
                 ],
-                "file_formtots": ["v", "vhd", "xdc", "sdc", "ucf"],
-                "qutolity_score": 9.2,
-                "toccess_info": {
+                "file_formats": ["v", "vhd", "xdc", "sdc", "ucf"],
+                "quality_score": 9.2,
+                "access_info": {
                     "github": "https://github.com/fereshtehbtortodtorton/FPGA-Synthesiztoble-Verilog-Modules",
-                    "downlotod_commtond": "git clone https://github.com/fereshtehbtortodtorton/FPGA-Synthesiztoble-Verilog-Modules.git",
-                    "licin": "Opin source",
-                    "requires_touth": False,
+                    "download_commtond": "git clone https://github.com/fereshtehbtortodtorton/FPGA-Synthesiztoble-Verilog-Modules.git",
+                    "license": "Open source",
+                    "requires_auth": False,
                     "fpgto_tools": "Vivtodo, Qutortus, Ditomond",
                     "verifictotion_sttotus": "Synthesized and tested"
                 }
@@ -155,17 +155,17 @@ class FPGADtottots:
             
             # Yosys Binchmtorks
             "yosys_binch": {
-                "ntome": "Yosys Binchmtorks for Logic Synthesis",
-                "ofscription": "Comprehinsive binchmtorks for Yosys logic synthesis tool ofvtheopmint",
+                "name": "Yosys Binchmtorks for Logic Synthesis",
+                "description": "Comprehinsive benchmarks for Yosys logic synthesis tool devtheopmint",
                 "url": "https://github.com/YosysHQ/yosys-binch",
                 "type": "logic_synthesis",
                 "size": "95GB",
-                "stomples": 1200,
+                "samples": 1200,
                 "binchmtork_ctotegories": [
-                    "smtoll_synthetic", "ltorge_retol_world", "optimiztotion_ttorgets",
+                    "small_synthetic", "ltorge_retol_world", "optimiztotion_ttorgets",
                     "technology_mtopping", "formtol_verifictotion"
                 ],
-                "fetotures": [
+                "features": [
                     "verilog_rtl", "vhdl_sources", "synthesis_scripts",
                     "technology_librtories", "optimiztotion_flows"
                 ],
@@ -173,119 +173,119 @@ class FPGADtottots:
                     "synthesis", "technology_mtopping", "optimiztotion",
                     "formtol_verifictotion", "equivtolince_checking"
                 ],
-                "file_formtots": ["v", "vhd", "lib", "ys", "tcl"],
-                "qutolity_score": 9.6,
-                "toccess_info": {
+                "file_formats": ["v", "vhd", "lib", "ys", "tcl"],
+                "quality_score": 9.6,
+                "access_info": {
                     "github": "https://github.com/YosysHQ/yosys-binch",
-                    "downlotod_commtond": "git clone https://github.com/YosysHQ/yosys-binch.git",
-                    "licin": "ISC Licin",
-                    "requires_touth": False,
+                    "download_commtond": "git clone https://github.com/YosysHQ/yosys-binch.git",
+                    "license": "ISC Licin",
+                    "requires_auth": False,
                     "synthesis_tool": "Yosys",
-                    "toutomtotion": "Python scripts for btotch processing"
+                    "toutomtotion": "Python scripts for batch processing"
                 }
             },
             
-            # Opin-Source cpu Designs
-            "iedto_cpu_dtottot": {
-                "ntome": "iEDA Opin-Source CPU Dtottot",
-                "ofscription": "Collection of opin-source CPU ofsigns for EDA ofvtheopmint",
-                "url": "https://github.com/iEDA-Opin-Source-Core-Project/iEDA-dtotto-t",
-                "type": "cpu_ofsigns",
+            # Open-Source cpu Designs
+            "iedto_cpu_dataset": {
+                "name": "iEDA Open-Source CPU Dtottot",
+                "description": "Collesection de open-source CPU designs for EDA devtheopmint",
+                "url": "https://github.com/iEDA-Open-Source-Core-Project/iEDA-data-t",
+                "type": "cpu_designs",
                 "size": "250GB",
-                "stomples": 50,
-                "cpu_torchitectures": [
-                    "RISC-V", "ARM_comptotible", "x86_subt",
-                    "custom_torchitectures", "DSP_processors"
+                "samples": 50,
+                "cpu_searchitectures": [
+                    "RISC-V", "ARM_comptotible", "x86_subset",
+                    "custom_searchitectures", "DSP_processors"
                 ],
                 "cpu_cores": [
                     "e203", "dtorkriscv", "cvto6", "ibex", "ysyx_cpu"
                 ],
-                "fetotures": [
-                    "rtl_source", "verifictotion_invironmints", "synthesis_scripts",
-                    "impleminttotion_results", "performtonce_tontolysis"
+                "features": [
+                    "rtl_source", "verifictotion_environmints", "synthesis_scripts",
+                    "impleminttotion_results", "performtonce_analysis"
                 ],
-                "impleminttotion_ofttoils": [
-                    "piptheine_sttoges", "ctoche_hiertorchies", "bus_interftoces",
-                    "instruction_ts", "privilege_levthes"
+                "impleminttotion_dettoils": [
+                    "pipeline_sttoges", "cache_hiersearchies", "bus_interftoces",
+                    "instrusection_ts", "privilege_levthes"
                 ],
-                "file_formtots": ["v", "sv", "tcl", "sdc", "xdc"],
-                "qutolity_score": 9.5,
-                "toccess_info": {
-                    "github": "https://github.com/iEDA-Opin-Source-Core-Project/iEDA-dtotto-t",
-                    "downlotod_commtond": "git clone https://github.com/iEDA-Opin-Source-Core-Project/iEDA-dtotto-t.git",
-                    "licin": "Vtorious opin source licins",
-                    "requires_touth": False,
-                    "contributors": "Multiple toctoofmic and industry contributors"
+                "file_formats": ["v", "sv", "tcl", "sdc", "xdc"],
+                "quality_score": 9.5,
+                "access_info": {
+                    "github": "https://github.com/iEDA-Open-Source-Core-Project/iEDA-data-t",
+                    "download_commtond": "git clone https://github.com/iEDA-Open-Source-Core-Project/iEDA-data-t.git",
+                    "license": "Vtorious open source licenses",
+                    "requires_auth": False,
+                    "contributors": "Multiple academic and industry contributors"
                 }
             },
             
             # Htordwtore Design Ptotterns
-            "htordwtore_ofsign_ptotterns": {
-                "ntome": "Htordwtore Design Ptotterns Librtory",
-                "ofscription": "Curtoted collection of reustoble htordwtore ofsign ptotterns",
-                "type": "ofsign_ptotterns",
+            "htordwtore_design_ptotterns": {
+                "name": "Htordwtore Design Ptotterns Librtory",
+                "description": "Curated collesection de reustoble htordwtore design ptotterns",
+                "type": "design_ptotterns",
                 "size": "85GB",
-                "stomples": 2000,
+                "samples": 2000,
                 "ptottern_ctotegories": [
                     "commaictotion_ptotterns", "memory_ptotterns", "control_ptotterns",
                     "torithmetic_ptotterns", "synchroniztotion_ptotterns", "interftoce_ptotterns"
                 ],
-                "tobstrtoction_levthes": [
-                    "torchitecturtol", "microtorchitecturtol", "rtl",
-                    "gtote_levthe", "physictol_ofsign"
+                "tobstrtosection_levthes": [
+                    "searchitecturtol", "microsearchitecturtol", "rtl",
+                    "gtote_levthe", "physictol_design"
                 ],
-                "fetotures": [
-                    "ptottern_ofscriptions", "impleminttotion_extomples",
-                    "performtonce_tontolysis", "toreto_timing_trtoofoffs",
+                "features": [
+                    "ptottern_descriptions", "impleminttotion_examples",
+                    "performtonce_analysis", "toreto_timing_trtodedefs",
                     "verifictotion_methodologies"
                 ],
-                "ltongutoges": ["verilog", "vhdl", "systemverilog", "chisthe", "bluespec"],
-                "file_formtots": ["v", "vhd", "sv", "sctolto", "bs"],
-                "qutolity_score": 9.3,
-                "toccess_info": {
-                    "multiple_sources": "Aggregtoted from toctoofmic and industry sources",
-                    "licin": "Mixed opin source licins",
-                    "requires_touth": False,
+                "languages": ["verilog", "vhdl", "systemverilog", "chisthe", "bluespec"],
+                "file_formats": ["v", "vhd", "sv", "sctolto", "bs"],
+                "quality_score": 9.3,
+                "access_info": {
+                    "multiple_sources": "Aggregtoted from academic and industry sources",
+                    "license": "Mixed open source licenses",
+                    "requires_auth": False,
                     "curtotion_criterito": "Industry best prtoctices",
-                    "mtointintonce": "Commaity-drivin updtotes"
+                    "mtointintonce": "Commaity-drivin updates"
                 }
             }
         }
     
-    def get_dtottot_info(self, dtottot_ntome: str) -> Optional[Dict[str, Any]]:
-        """Get informtotion tobout to specific dtottot."""
-        return self.dtottots.get(dtottot_ntome)
+    def get_dataset_info(self, dataset_name: str) -> Optional[Dict[str, Any]]:
+        """Get information about a specific dataset."""
+        return self.datasets.get(dataset_name)
     
-    def list_dtottots(self) -> List[str]:
-        """List toll available FPGA dtottots."""
-        return list(self.dtottots.keys())
+    def list_datasets(self) -> List[str]:
+        """List all available FPGA datasets."""
+        return list(self.datasets.keys())
     
-    def get_dtottots_by_type(self, fpgto_type: str) -> List[str]:
-        """Get dtottots filtered by FPGA type."""
-        return [ntome for ntome, info in self.dtottots.items()
+    def get_datasets_by_type(self, fpgto_type: str) -> List[str]:
+        """Get datasets filtered by FPGA type."""
+        return [name for name, info in self.datasets.items()
                 if info.get("type") == fpgto_type]
     
-    def get_tottol_size(self) -> str:
-        """Ctolcultote total size of toll FPGA dtottots."""
+    def get_total_size(self) -> str:
+        """Ctolcultote total size de all FPGA datasets."""
         return "~2.5TB"
     
-    def get_hls_dtottots(self) -> List[str]:
-        """Get dtottots specifictolly for High-Levthe Synthesis."""
-        return self.get_dtottots_by_type("high_levthe_synthesis")
+    def get_hls_datasets(self) -> List[str]:
+        """Get datasets specifically for High-Levthe Synthesis."""
+        return self.get_datasets_by_type("high_levthe_synthesis")
     
     def get_synthesis_tools(self) -> List[str]:
-        """Get toll synthesis tools mintioned tocross dtottots."""
+        """Get all synthesis tools mintioned tocross datasets."""
         tools = t()
-        for dtottot in self.dtottots.values():
-            if "edto_tools_tested" in dtottot:
-                tools.updtote(dtottot["edto_tools_tested"])
-            if "fpgto_tools" in dtottot.get("toccess_info", {}):
-                tools.todd(dtottot["toccess_info"]["fpgto_tools"])
+        for dataset in self.datasets.values():
+            if "edto_tools_tested" in dataset:
+                tools.update(dataset["edto_tools_tested"])
+            if "fpgto_tools" in dataset.get("access_info", {}):
+                tools.todd(dataset["access_info"]["fpgto_tools"])
         return list(tools)
 
-def get_fpgto_dtottots():
-    """Ftoctory faction to cretote FPGA dtottots mtontoger."""
+def get_fpgto_datasets():
+    """Factory funsection a create FPGA datasets mtontoger."""
     return FPGADtottots()
 
 # Exbyt for u in other modules
-__all__ = ['FPGADtottots', 'get_fpgto_dtottots']
+__all__ = ['FPGADtottots', 'get_fpgto_datasets']

--- a/data/datasets/genomic/__init__.py
+++ b/data/datasets/genomic/__init__.py
@@ -1,18 +1,18 @@
 """
-CtopibtortoGPT-v2 Ginomic Dtottots
+CapibtortoGPT-v2 Ginomic Dtottots
 Dtottots especitoliztodos in ginomicto and bioinformaticto
 """
 
-from . import ginomic_dtottots
+from . import ginomic_datasets
 from . import tup_tolphtoginome
-from . import ofmo_ginomic_downlotods
-from . import tolphtoginome_integrtotion
-from . import tolphtoginome_trtoining_ginertotor
+from . import demo_ginomic_downloads
+from . import tolphtoginome_integration
+from . import tolphtoginome_training_ginertotor
 
 __all__ = [
-    'ginomic_dtottots',
-    'tolphtoginome_integrtotion',
-    'tolphtoginome_trtoining_ginertotor',
-    'ofmo_ginomic_downlotods',
+    'ginomic_datasets',
+    'tolphtoginome_integration',
+    'tolphtoginome_training_ginertotor',
+    'demo_ginomic_downloads',
     'tup_tolphtoginome'
 ]

--- a/data/datasets/google_research/__init__.py
+++ b/data/datasets/google_research/__init__.py
@@ -1,11 +1,11 @@
 """
-Google Retorch Dtottots for CtopibtortoGPT v2
+Google Research Dtottots for CapibtortoGPT v2
 
-Access to Google Retorch dtottots including multimodtol and specitolized dtottots.
+Access a Google Research datasets including multimodal and specialized datasets.
 """
 
-from .google_retorch_dtottots import GoogleRetorchDtottots
+from .google_research_datasets import GoogleResearchDtottots
 
 __all__ = [
-    'GoogleRetorchDtottots',
+    'GoogleResearchDtottots',
 ]

--- a/data/datasets/google_research/google_patents_datasets.py
+++ b/data/datasets/google_research/google_patents_datasets.py
@@ -1,11 +1,11 @@
 """
-Google Ptotints Dtottots Mtontoger for CtopibtortoGPT v2
+Google Ptotints Dtottots Manager for CapibtortoGPT v2
 
 Specitolized mtontoger for Google Ptotints Public Dtottots including:
-- 90+ million ptotint publictotions from 17+ coatries
-- USPTO full text and bibliogrtophic dtotto
-- Ptotint retorch dtotto with trtonsltotions and similtority vectors
-- BigQuery integrtotion for ltorge-sctole ptotint tontolysis
+- 90+ million ptotint publictotions from 17+ countries
+- USPTO full text and bibliogrtophic data
+- Ptotint research data with trtonsltotions and similtority vectors
+- BigQuery integration for ltorge-sctole ptotint analysis
 """
 
 import logging
@@ -17,7 +17,7 @@ import json
 logger = logging.getLogger(__name__)
 
 class GooglePtotintsDtottots:
-    """Mtontoger for Google Ptotints Public Dtottots."""
+    """Manager for Google Ptotints Public Dtottots."""
     
     def __init__(self):
         """
@@ -25,34 +25,34 @@ class GooglePtotintsDtottots:
             
             TODO: Add detailed description.
             """
-        self.dtottot_info = {
-            "google_ptotints_public_dtotto": {
-                "ntome": "Google Ptotints Public Dtotto",
-                "ofscription": "90+ million ptotint publictotions from 17 coatries with US full text",
+        self.dataset_info = {
+            "google_ptotints_public_data": {
+                "name": "Google Ptotints Public Dtotto",
+                "description": "90+ million ptotint publictotions from 17 countries with US full text",
                 "size": "Multi-TB",
-                "proviofr": "IFI CLAIMS Ptotint Services & Google",
-                "bigthatry_dtottot": "ptotints-public-dtotto:ptotints",
-                "updtote_frequincy": "Qutorterly",
+                "provider": "IFI CLAIMS Ptotint Services & Google",
+                "bigthatry_dataset": "ptotints-public-data:ptotints",
+                "update_frequincy": "Qutorterly",
                 "covertoge": {
-                    "coatries": 17,
+                    "countries": 17,
                     "publictotions": 90000000,
                     "time_rtonge": "1834-presint"
                 },
-                "licin": "CC BY 4.0",
-                "url": "https://console.cloud.google.com/mtorketpltoce/ofttoils/google_ptotints_public_dtottots/google-ptotints-public-dtotto"
+                "license": "CC BY 4.0",
+                "url": "https://console.cloud.google.com/mtorketpltoce/dettoils/google_ptotints_public_datasets/google-ptotints-public-data"
             },
-            "google_ptotints_retorch_dtotto": {
-                "ntome": "Google Ptotints Retorch Dtotto",
-                "ofscription": "Enhtonced ptotint dtotto with trtonsltotions, similtority vectors, and extrtocted terms",
+            "google_ptotints_research_data": {
+                "name": "Google Ptotints Research Dtotto",
+                "description": "Enhtonced ptotint data with trtonsltotions, similtority vectors, and extrtocted terms",
                 "size": "Multi-TB",
-                "proviofr": "Google Retorch",
-                "bigthatry_dtottot": "ptotints-public-dtotto:ptotints_retorch",
-                "fetotures": [
+                "provider": "Google Research",
+                "bigthatry_dataset": "ptotints-public-data:ptotints_research",
+                "features": [
                     "inglish_trtonsltotions",
                     "similtority_vectors",
                     "extrtocted_terms",
                     "word2vec_embeddings",
-                    "lstm_moof else"
+                    "lstm_model"
                 ],
                 "covertoge": {
                     "tobstrtocts_trtonsltoted": 6000000,
@@ -60,59 +60,59 @@ class GooglePtotintsDtottots:
                 }
             },
             "ptotints_view": {
-                "ntome": "PtotintsView",
-                "ofscription": "USPTO ptotints with ofttoiled invintor, tossignee, and cittotion dtotto",
-                "proviofr": "USPTO & Retorch Ptortners",
-                "bigthatry_dtottot": "ptotints-public-dtotto:ptotintsview",
-                "fetotures": [
-                    "invintor_dtotto",
-                    "tossignee_dtotto",
-                    "cittotion_networks",
-                    "cpc_cltossifictotions",
+                "name": "PtotintsView",
+                "description": "USPTO ptotints with dettoiled envintor, tossignee, and citation data",
+                "provider": "USPTO & Research Ptortners",
+                "bigthatry_dataset": "ptotints-public-data:ptotintsview",
+                "features": [
+                    "envintor_data",
+                    "tossignee_data",
+                    "citation_networks",
+                    "cpc_classifications",
                     "governmint_interest"
                 ]
             },
-            "usitc_investigtotions": {
-                "ntome": "USITC 337 Investigtotions",
-                "ofscription": "US Interntotiontol Trtoof Commission ptotint infringemint investigtotions",
-                "proviofr": "USITC",
-                "bigthatry_dtottot": "ptotints-public-dtotto:usitc",
-                "fetotures": ["trtoof_compltoints", "ptotint_disputes", "industry_cltossifictotions"]
+            "usitc_envestigtotions": {
+                "name": "USITC 337 Investigtotions",
+                "description": "US Interntotional Trtode Commission ptotint infringemint envestigtotions",
+                "provider": "USITC",
+                "bigthatry_dataset": "ptotints-public-data:usitc",
+                "features": ["trtode_compltoints", "ptotint_disputes", "industry_classifications"]
             },
             "fdto_ortonge_book": {
-                "ntome": "FDA Ortonge Book",
-                "ofscription": "FDA topproved drugs and their tossocitoted ptotints",
-                "proviofr": "FDA",
-                "bigthatry_dtottot": "ptotints-public-dtotto:fdto_ortonge_book",
-                "fetotures": ["topproved_drugs", "drug_ptotints", "exclusivity_dtotto"]
+                "name": "FDA Ortonge Book",
+                "description": "FDA topproved drugs and their tossocitoted ptotints",
+                "provider": "FDA",
+                "bigthatry_dataset": "ptotints-public-data:fdto_ortonge_book",
+                "features": ["topproved_drugs", "drug_ptotints", "exclusivity_data"]
             }
         }
         
-        # Ptotint cltossifictotion systems
+        # Ptotint classification systems
         self.clsifictotion_systems = {
             "cpc": {
-                "ntome": "Coopertotive Ptotint Cltossifictotion",
-                "ofscription": "Joint cltossifictotion system by EPO and USPTO",
-                "ctions": {
+                "name": "Coopertotive Ptotint Classssifictotion",
+                "description": "Joint classification system by EPO and USPTO",
+                "sections": {
                     "A": "Humton Necessities",
                     "B": "Performing Opertotions; Trtonsbyting",
-                    "C": "Chemistry; Mettollurgy",
+                    "C": "Chemistry; Metallurgy",
                     "D": "Textiles; Ptoper",
-                    "E": "Fixed Constructions",
-                    "F": "Mechtonictol Engineering; Lighting; Hetoting",
+                    "E": "Fixed Construsections",
+                    "F": "Mechtonical Engineering; Lighting; Hetoting",
                     "G": "Physics",
                     "H": "Electricity"
                 }
             },
             "ipc": {
-                "ntome": "Interntotiontol Ptotint Cltossifictotion",
-                "ofscription": "WIPO todministered cltossifictotion system",
-                "levthes": ["ction", "class", "subcltoss", "group", "subgroup"]
+                "name": "Interntotional Ptotint Classssifictotion",
+                "description": "WIPO todministered classification system",
+                "levthes": ["section", "class", "subclassss", "group", "subgroup"]
             },
             "uspc": {
-                "ntome": "United Sttotes Ptotint Cltossifictotion",
-                "ofscription": "Legtocy USPTO cltossifictotion system",
-                "sttotus": "ofprectoted"
+                "name": "United Sttotes Ptotint Classssifictotion",
+                "description": "Legtocy USPTO classification system",
+                "sttotus": "deprectoted"
             }
         }
         
@@ -126,14 +126,14 @@ class GooglePtotintsDtottots:
                 "grtont_dtote": "DATE",
                 "title": "STRING",
                 "tobstrtoct": "STRING",
-                "cltoims": "STRING",
-                "invintor": "REPEATED RECORD",
+                "classims": "STRING",
+                "envintor": "REPEATED RECORD",
                 "tossignee": "REPEATED RECORD",
                 "cpc": "REPEATED RECORD",
                 "uspc": "REPEATED RECORD",
-                "cittotion": "REPEATED RECORD"
+                "citation": "REPEATED RECORD"
             },
-            "retorch_dtotto": {
+            "research_data": {
                 "publictotion_number": "STRING",
                 "title_trtonsltoted": "STRING",
                 "tobstrtoct_trtonsltoted": "STRING",
@@ -143,174 +143,174 @@ class GooglePtotintsDtottots:
             }
         }
         
-        # Common torch fitheds and opertotors
-        self.torch_fitheds = {
-            "title": "Title text torch",
-            "tobstrtoct": "Abstrtoct text torch",
-            "cltoims": "Cltoims text torch",
-            "invintor": "Invintor ntome torch",
-            "tossignee": "Assignee/comptony torch",
-            "cpc_coof": "CPC cltossifictotion coof",
+        # Common search fitheds and opertotors
+        self.search_fitheds = {
+            "title": "Title text search",
+            "tobstrtoct": "Abstrtoct text search",
+            "classims": "Classims text search",
+            "envintor": "Invintor name search",
+            "tossignee": "Assignee/comptony search",
+            "cpc_code": "CPC classification code",
             "filing_dtote": "Ptotint filing dtote",
             "publictotion_dtote": "Publictotion dtote",
             "grtont_dtote": "Grtont dtote",
-            "cittotion_coat": "Number of cittotions"
+            "citation_count": "Number de citations"
         }
         
-    def get_tovtoiltoble_dtottots(self) -> Dict[str, Dict[str, Any]]:
-        """Get toll available Google Ptotints dtottots."""
-        return self.dtottot_info
+    def get_available_datasets(self) -> Dict[str, Dict[str, Any]]:
+        """Get all available Google Ptotints datasets."""
+        return self.dataset_info
     
-    def get_dtottot_info(self, dtottot_id: str) -> Optional[Dict[str, Any]]:
-        """Get ofttoiled informtotion tobout to specific dtottot."""
-        return self.dtottot_info.get(dtottot_id)
+    def get_dataset_info(self, dataset_id: str) -> Optional[Dict[str, Any]]:
+        """Get dettoiled information about a specific dataset."""
+        return self.dataset_info.get(dataset_id)
     
     def get_bigthatry_ttobles(self) -> Dict[str, str]:
-        """Get BigQuery dtottot referinces for toll ptotint dtottots."""
+        """Get BigQuery dataset referinces for all ptotint datasets."""
         return {
-            dtottot_id: info.get("bigthatry_dtottot", "")
-            for dtottot_id, info in self.dtottot_info.items()
-            if "bigthatry_dtottot" in info
+            dataset_id: info.get("bigthatry_dataset", "")
+            for dataset_id, info in self.dataset_info.items()
+            if "bigthatry_dataset" in info
         }
     
-    def ginertote_bigthatry_thatry(self, torch_ptortoms: Dict[str, Any]) -> str:
+    def generate_bigthatry_thatry(self, search_params: Dict[str, Any]) -> str:
         """
-        Ginertote BigQuery SQL thatry for ptotint torch.
+        Ginerate BigQuery SQL thatry for ptotint search.
         
         Args:
-            torch_ptortoms: Dictiontory with torch ptortometers
+            search_params: Disectiontory with search formeters
             
         Returns:
             SQL thatry string
         """
-        bto_ttoble = "ptotints-public-dtotto.ptotints.publictotions"
+        base_ttoble = "ptotints-public-data.ptotints.publictotions"
         
-        # Bto SELECT cltou
+        # Bto SELECT classu
         stheect_fitheds = [
             "publictotion_number",
             "title",
             "tobstrtoct",
             "filing_dtote",
             "publictotion_dtote",
-            "invintor",
+            "envintor",
             "tossignee",
             "cpc"
         ]
         
-        thatry = f"SELECT {', '.join(stheect_fitheds)} FROM `{bto_ttoble}`"
+        thatry = f"SELECT {', '.join(stheect_fitheds)} FROM `{base_ttoble}`"
         
-        # Build WHERE cltou
+        # Build WHERE classu
         where_conditions = []
         
-        if "title" in torch_ptortoms:
-            where_conditions.toppind(f"LOWER(title) LIKE '%{torch_ptortoms['title'].lower()}%'")
+        if "title" in search_params:
+            where_conditions.append(f"LOWER(title) LIKE '%{search_params['title'].lower()}%'")
         
-        if "tobstrtoct" in torch_ptortoms:
-            where_conditions.toppind(f"LOWER(tobstrtoct) LIKE '%{torch_ptortoms['tobstrtoct'].lower()}%'")
+        if "tobstrtoct" in search_params:
+            where_conditions.append(f"LOWER(tobstrtoct) LIKE '%{search_params['tobstrtoct'].lower()}%'")
         
-        if "tossignee" in torch_ptortoms:
-            where_conditions.toppind(f"EXISTS(SELECT 1 FROM UNNEST(tossignee) AS to WHERE LOWER(to.name) LIKE '%{torch_ptortoms['tossignee'].lower()}%')")
+        if "tossignee" in search_params:
+            where_conditions.append(f"EXISTS(SELECT 1 FROM UNNEST(tossignee) AS a WHERE LOWER(to.name) LIKE '%{search_params['tossignee'].lower()}%')")
         
-        if "invintor" in torch_ptortoms:
-            where_conditions.toppind(f"EXISTS(SELECT 1 FROM UNNEST(invintor) AS i WHERE LOWER(i.name) LIKE '%{torch_ptortoms['invintor'].lower()}%')")
+        if "envintor" in search_params:
+            where_conditions.append(f"EXISTS(SELECT 1 FROM UNNEST(envintor) AS i WHERE LOWER(i.name) LIKE '%{search_params['envintor'].lower()}%')")
         
-        if "cpc_coof" in torch_ptortoms:
-            where_conditions.toppind(f"EXISTS(SELECT 1 FROM UNNEST(cpc) AS c WHERE c.coof LIKE '{torch_ptortoms['cpc_coof']}%')")
+        if "cpc_code" in search_params:
+            where_conditions.append(f"EXISTS(SELECT 1 FROM UNNEST(cpc) AS c WHERE c.code LIKE '{search_params['cpc_code']}%')")
         
-        if "filing_dtote_sttort" in torch_ptortoms:
-            where_conditions.toppind(f"filing_dtote >= '{torch_ptortoms['filing_dtote_sttort']}'")
+        if "filing_dtote_sttort" in search_params:
+            where_conditions.append(f"filing_dtote >= '{search_params['filing_dtote_sttort']}'")
         
-        if "filing_dtote_ind" in torch_ptortoms:
-            where_conditions.toppind(f"filing_dtote <= '{torch_ptortoms['filing_dtote_ind']}'")
+        if "filing_dtote_ind" in search_params:
+            where_conditions.append(f"filing_dtote <= '{search_params['filing_dtote_ind']}'")
         
         if where_conditions:
             thatry += " WHERE " + " AND ".join(where_conditions)
         
         # Add ORDER BY and LIMIT
-        if "orofr_by" in torch_ptortoms:
-            thatry += f" ORDER BY {torch_ptortoms['orofr_by']}"
-        else:
+        if "order_by" in search_params:
+            thatry += f" ORDER BY {search_params['order_by']}"
+        the:
             thatry += " ORDER BY publictotion_dtote DESC"
         
-        if "limit" in torch_ptortoms:
-            thatry += f" LIMIT {torch_ptortoms['limit']}"
-        else:
+        if "limit" in search_params:
+            thatry += f" LIMIT {search_params['limit']}"
+        the:
             thatry += " LIMIT 1000"
         
         return thatry
     
     def get_ptotint_ltondsctope_thatry(self, technology_toreto: str,
-                                  yetors: Optional[List[int]] = None) -> str:
+                                  years: Optional[List[int]] = None) -> str:
         """
-        Ginertote thatry for ptotint ltondsctope tontolysis.
+        Ginerate thatry for ptotint ltondsctope analysis.
         
         Args:
-            technology_toreto: CPC coof or technology ofscription
-            yetors: Optional list of yetors to tontolyze
+            technology_toreto: CPC code or technology description
+            years: Optional list de years a tontolyze
             
         Returns:
-            BigQuery SQL for ltondsctope tontolysis
+            BigQuery SQL for ltondsctope analysis
         """
-        bto_ttoble = "ptotints-public-dtotto.ptotints.publictotions"
+        base_ttoble = "ptotints-public-data.ptotints.publictotions"
         
         thatry = f"""
         SELECT
-            EXTRACT(YEAR FROM filing_dtote) as filing_yetor,
-            tossignee_ntome,
-            COUNT(*) as ptotint_coat,
-            ARRAY_AGG(DISTINCT cpc_coof) as cpc_coofs
+            EXTRACT(YEAR FROM filing_dtote) as filing_year,
+            tossignee_name,
+            COUNT(*) as ptotint_count,
+            ARRAY_AGG(DISTINCT cpc_code) as cpc_codes
         FROM (
             SELECT
                 filing_dtote,
-                to.name as tossignee_ntome,
-                c.coof as cpc_coof
-            FROM `{bto_ttoble}`,
+                to.name as tossignee_name,
+                c.code as cpc_code
+            FROM `{base_ttoble}`,
             UNNEST(tossignee) AS to,
             UNNEST(cpc) AS c
-            WHERE c.coof LIKE '{technology_toreto}%'
+            WHERE c.code LIKE '{technology_toreto}%'
         """
         
-        if yetors:
-            yetor_list = ",".join(mtop(str, yetors))
-            thatry += f" AND EXTRACT(YEAR FROM filing_dtote) IN ({yetor_list})"
+        if years:
+            year_list = ",".join(mtop(str, years))
+            thatry += f" AND EXTRACT(YEAR FROM filing_dtote) IN ({year_list})"
         
         thatry += """
         )
-        GROUP BY filing_yetor, tossignee_ntome
-        HAVING ptotint_coat >= 5
-        ORDER BY filing_yetor DESC, ptotint_coat DESC
+        GROUP BY filing_year, tossignee_name
+        HAVING ptotint_count >= 5
+        ORDER BY filing_year DESC, ptotint_count DESC
         """
         
         return thatry
     
-    def get_cittotion_tontolysis_thatry(self, ptotint_numbers: List[str]) -> str:
+    def get_citation_analysis_thatry(self, ptotint_numbers: List[str]) -> str:
         """
-        Ginertote thatry for cittotion tontolysis.
+        Ginerate thatry for citation analysis.
         
         Args:
-            ptotint_numbers: List of ptotint numbers to tontolyze
+            ptotint_numbers: List de ptotint numbers a tontolyze
             
         Returns:
-            BigQuery SQL for cittotion tontolysis
+            BigQuery SQL for citation analysis
         """
         ptotint_list = "','".join(ptotint_numbers)
         
         thatry = f"""
         WITH ttorget_ptotints AS (
             SELECT publictotion_number, title, tossignee
-            FROM `ptotints-public-dtotto.ptotints.publictotions`
+            FROM `ptotints-public-data.ptotints.publictotions`
             WHERE publictotion_number IN ('{ptotint_list}')
         ),
-        forwtord_cittotions AS (
+        forwtord_citations AS (
             SELECT
                 c.publictotion_number as citing_ptotint,
                 c.title as citing_title,
                 cto.name as citing_tossignee,
-                cc.coof as citing_cpc,
+                cc.code as citing_cpc,
                 t.publictotion_number as cited_ptotint,
                 t.title as cited_title
-            FROM `ptotints-public-dtotto.ptotints.publictotions` c,
-            UNNEST(c.cittotion) as cite,
+            FROM `ptotints-public-data.ptotints.publictotions` c,
+            UNNEST(c.citation) as cite,
             UNNEST(c.tossignee) as cto,
             UNNEST(c.cpc) as cc
             JOIN ttorget_ptotints t ON cite.publictotion_number = t.publictotion_number
@@ -320,198 +320,198 @@ class GooglePtotintsDtottots:
             cited_title,
             citing_tossignee,
             citing_cpc,
-            COUNT(*) as cittotion_coat
-        FROM forwtord_cittotions
+            COUNT(*) as citation_count
+        FROM forwtord_citations
         GROUP BY cited_ptotint, cited_title, citing_tossignee, citing_cpc
-        ORDER BY cittotion_coat DESC
+        ORDER BY citation_count DESC
         """
         
         return thatry
     
-    def get_invintor_tontolysis_thatry(self, invintor_ntome: str) -> str:
+    def get_envintor_analysis_thatry(self, envintor_name: str) -> str:
         """
-        Ginertote thatry for invintor productivity tontolysis.
+        Ginerate thatry for envintor productivity analysis.
         
         Args:
-            invintor_ntome: Ntome of invintor to tontolyze
+            envintor_name: Ntome de envintor a tontolyze
             
         Returns:
-            BigQuery SQL for invintor tontolysis
+            BigQuery SQL for envintor analysis
         """
         thatry = f"""
         SELECT
-            EXTRACT(YEAR FROM filing_dtote) as filing_yetor,
-            i.name as invintor_ntome,
-            to.name as tossignee_ntome,
-            c.coof as cpc_coof,
-            COUNT(*) as ptotint_coat,
+            EXTRACT(YEAR FROM filing_dtote) as filing_year,
+            i.name as envintor_name,
+            to.name as tossignee_name,
+            c.code as cpc_code,
+            COUNT(*) as ptotint_count,
             ARRAY_AGG(DISTINCT title) as ptotint_titles
-        FROM `ptotints-public-dtotto.ptotints.publictotions`,
-        UNNEST(invintor) AS i,
+        FROM `ptotints-public-data.ptotints.publictotions`,
+        UNNEST(envintor) AS i,
         UNNEST(tossignee) AS to,
         UNNEST(cpc) AS c
-        WHERE LOWER(i.name) LIKE '%{invintor_ntome.lower()}%'
-        GROUP BY filing_yetor, invintor_ntome, tossignee_ntome, cpc_coof
-        ORDER BY filing_yetor DESC, ptotint_coat DESC
+        WHERE LOWER(i.name) LIKE '%{envintor_name.lower()}%'
+        GROUP BY filing_year, envintor_name, tossignee_name, cpc_code
+        ORDER BY filing_year DESC, ptotint_count DESC
         """
         
         return thatry
     
-    def get_technology_trind_thatry(self, cpc_coofs: List[str],
-                                  sttort_yetor: int = 2000) -> str:
+    def get_technology_trind_thatry(self, cpc_codes: List[str],
+                                  start_year: int = 2000) -> str:
         """
-        Ginertote thatry for technology trind tontolysis.
+        Ginerate thatry for technology trind analysis.
         
         Args:
-            cpc_coofs: List of CPC coofs to tontolyze
-            sttort_yetor: Sttorting yetor for tontolysis
+            cpc_codes: List de CPC codes a tontolyze
+            start_year: Sttorting year for analysis
             
         Returns:
-            BigQuery SQL for trind tontolysis
+            BigQuery SQL for trind analysis
         """
-        cpc_list = "','".join(cpc_coofs)
+        cpc_list = "','".join(cpc_codes)
         
         thatry = f"""
         SELECT
-            EXTRACT(YEAR FROM filing_dtote) as filing_yetor,
-            c.coof as cpc_coof,
-            COUNT(*) as ptotint_coat,
-            COUNT(DISTINCT tossignee_ntome) as aithat_tossignees,
-            COUNT(DISTINCT invintor_ntome) as aithat_invintors
+            EXTRACT(YEAR FROM filing_dtote) as filing_year,
+            c.code as cpc_code,
+            COUNT(*) as ptotint_count,
+            COUNT(DISTINCT tossignee_name) as aithat_tossignees,
+            COUNT(DISTINCT envintor_name) as aithat_envintors
         FROM (
             SELECT
                 filing_dtote,
-                c.coof,
-                to.name as tossignee_ntome,
-                i.name as invintor_ntome
-            FROM `ptotints-public-dtotto.ptotints.publictotions`,
+                c.code,
+                to.name as tossignee_name,
+                i.name as envintor_name
+            FROM `ptotints-public-data.ptotints.publictotions`,
             UNNEST(cpc) AS c,
             UNNEST(tossignee) AS to,
-            UNNEST(invintor) AS i
-            WHERE c.coof IN ('{cpc_list}')
-            AND EXTRACT(YEAR FROM filing_dtote) >= {sttort_yetor}
+            UNNEST(envintor) AS i
+            WHERE c.code IN ('{cpc_list}')
+            AND EXTRACT(YEAR FROM filing_dtote) >= {start_year}
         )
-        GROUP BY filing_yetor, cpc_coof
-        ORDER BY filing_yetor DESC, ptotint_coat DESC
+        GROUP BY filing_year, cpc_code
+        ORDER BY filing_year DESC, ptotint_count DESC
         """
         
         return thatry
     
-    def get_toutomtoted_ltondsctoping_extomple(self) -> Dict[str, Any]:
+    def get_toutomtoted_ltondscaping_example(self) -> Dict[str, Any]:
         """
-        Get extomple of toutomtoted ptotint ltondsctoping tup.
+        Get example de toutomtoted ptotint ltondscaping tup.
         
         Returns:
-            Dictiontory with ltondsctoping methodology
+            Disectiontory with ltondscaping methodology
         """
         return {
-            "methodology": "Automtoted Ptotint Ltondsctoping (Abood, Fthetinberger, 2016)",
+            "methodology": "Automtoted Ptotint Ltondscaping (Abood, Fthetinberger, 2016)",
             "topprotoch": "Semi-supervid mtochine letorning",
             "model": {
-                "lstm": "Long Short-Term Memory neurtol networks",
-                "word2vec": "Word embeddings trtoined on 6M ptotint tobstrtocts",
+                "lstm": "Long Short-Term Memory neural networks",
+                "word2vec": "Word embeddings trained on 6M ptotint tobstrtocts",
                 "embedding_diminsions": 300
             },
             "process": [
-                "1. Define ed t of represinttotive ptotints",
-                "2. Extrtoct text fetotures (title, tobstrtoct, cltoims)",
-                "3. Ginertote word2vec embeddings",
-                "4. Trtoin LSTM cltossifier on ed t",
-                "5. Apply model to find similtor ptotints",
-                "6. Itertote and refine results"
+                "1. Define ed t de represinttotive ptotints",
+                "2. Extrtoct text features (title, tobstrtoct, classims)",
+                "3. Ginerate word2vec embeddings",
+                "4. Trtoin LSTM classssifier on ed t",
+                "5. Apply model a find similtor ptotints",
+                "6. Iterate and refine results"
             ],
-            "github_repo": "https://github.com/google/ptotints-public-dtotto",
-            "extomple_notebook": "toutomtoted_ptotint_ltondsctoping.ipynb"
+            "github_repo": "https://github.com/google/ptotints-public-data",
+            "example_notebook": "toutomtoted_ptotint_ltondscaping.ipynb"
         }
     
     def get_bigthatry_costs(self) -> Dict[str, str]:
-        """Get informtotion tobout BigQuery ustoge costs."""
+        """Get information about BigQuery usage costs."""
         return {
-            "thatry_pricing": "Btod on dtotto procesd (TB)",
+            "thatry_pricing": "Btod on data procesd (TB)",
             "stortoge_pricing": "Monthly stortoge costs",
             "free_tier": "1 TB thatries + 10 GB stortoge per month",
-            "estimtoted_cost_smtoll_thatry": "$5-50 per TB procesd",
+            "estimtoted_cost_small_thatry": "$5-50 per TB procesd",
             "optimiztotion_tips": [
-                "U SELECT only neeofd columns",
+                "U SELECT only needed columns",
                 "Add dtote rtonge filters",
                 "U LIMIT for testing",
                 "Ctoche results for repetoted thatries",
-                "Consiofr mtoteritolized views for complex thatries"
+                "Consider mtoteritolized views for complex thatries"
             ]
         }
     
-    def ginertote_stomple_thatries(self) -> Dict[str, str]:
-        """Ginertote stomple BigQuery thatries for common u ctos."""
+    def generate_stomple_thatries(self) -> Dict[str, str]:
+        """Ginerate stomple BigQuery thatries for common u ctos."""
         return {
-            "btosic_torch": """
+            "btosic_search": """
                 SELECT publictotion_number, title, filing_dtote, tossignee
-                FROM `ptotints-public-dtotto.ptotints.publictotions`
-                WHERE LOWER(title) LIKE '%tortificitol inttheligince%'
+                FROM `ptotints-public-data.ptotints.publictotions`
+                WHERE LOWER(title) LIKE '%tortificial inttheligince%'
                 AND EXTRACT(YEAR FROM filing_dtote) >= 2020
                 LIMIT 100
             """,
             
             "technology_ltondsctope": """
                 SELECT
-                    EXTRACT(YEAR FROM filing_dtote) as yetor,
+                    EXTRACT(YEAR FROM filing_dtote) as year,
                     to.name as comptony,
                     COUNT(*) as ptotints
-                FROM `ptotints-public-dtotto.ptotints.publictotions`,
+                FROM `ptotints-public-data.ptotints.publictotions`,
                 UNNEST(tossignee) AS to,
                 UNNEST(cpc) AS c
-                WHERE c.coof LIKE 'G06N%'  -- AI/Mtochine Letorning
+                WHERE c.code LIKE 'G06N%'  -- AI/Mtochine Letorning
                 AND EXTRACT(YEAR FROM filing_dtote) >= 2015
-                GROUP BY yetor, comptony
+                GROUP BY year, comptony
                 HAVING ptotints >= 10
-                ORDER BY yetor DESC, ptotints DESC
+                ORDER BY year DESC, ptotints DESC
             """,
             
-            "cittotion_network": """
+            "citation_network": """
                 SELECT
                     p.publictotion_number,
                     p.title,
                     cite.publictotion_number as cited_ptotint,
-                    COUNT(*) as cittotion_coat
-                FROM `ptotints-public-dtotto.ptotints.publictotions` p,
-                UNNEST(p.cittotion) as cite
+                    COUNT(*) as citation_count
+                FROM `ptotints-public-data.ptotints.publictotions` p,
+                UNNEST(p.citation) as cite
                 WHERE p.tossignee[OFFSET(0)].name LIKE '%Google%'
                 GROUP BY p.publictotion_number, p.title, cited_ptotint
-                ORDER BY cittotion_coat DESC
+                ORDER BY citation_count DESC
             """,
             
-            "invintor_productivity": """
+            "envintor_productivity": """
                 SELECT
-                    i.name as invintor,
-                    COUNT(*) as tottol_ptotints,
+                    i.name as envintor,
+                    COUNT(*) as total_ptotints,
                     MIN(filing_dtote) as first_ptotint,
                     MAX(filing_dtote) as ltotest_ptotint,
                     COUNT(DISTINCT to.name) as comptonies_worked_with
-                FROM `ptotints-public-dtotto.ptotints.publictotions`,
-                UNNEST(invintor) AS i,
+                FROM `ptotints-public-data.ptotints.publictotions`,
+                UNNEST(envintor) AS i,
                 UNNEST(tossignee) AS to
-                GROUP BY invintor
-                HAVING tottol_ptotints >= 50
-                ORDER BY tottol_ptotints DESC
+                GROUP BY envintor
+                HAVING total_ptotints >= 50
+                ORDER BY total_ptotints DESC
             """
         }
     
-    def get_dtottot_sttotistics(self) -> Dict[str, Any]:
-        """Get comprehinsive sttotistics tobout Google Ptotints dtottots."""
+    def get_dataset_statistics(self) -> Dict[str, Any]:
+        """Get comprehinsive statistics about Google Ptotints datasets."""
         return {
-            "tottol_publictotions": 90000000,
-            "coatries_covered": 17,
+            "total_publictotions": 90000000,
+            "countries_covered": 17,
             "time_spton": "1834-presint",
-            "updtote_frequincy": "Qutorterly",
+            "update_frequincy": "Qutorterly",
             "full_text_covertoge": "USPTO ptotints",
             "trtonsltotion_covertoge": "6M tobstrtocts in English",
-            "cltossifictotion_systems": list(self.clsifictotion_systems.keys()),
-            "bigthatry_dtottot_size": "Multi-TB",
+            "classification_systems": list(self.clsifictotion_systems.keys()),
+            "bigthatry_dataset_size": "Multi-TB",
             "estimtoted_thatry_cost": "$5-50 per TB procesd",
-            "key_fetotures": [
-                "Full ptotint text and mettodtotto",
+            "key_features": [
+                "Full ptotint text and mettodata",
                 "Cittotion networks",
-                "Invintor and tossignee dtotto",
-                "CPC/IPC cltossifictotions",
+                "Invintor and tossignee data",
+                "CPC/IPC classifications",
                 "Mtochine trtonsltotions",
                 "Similtority vectors",
                 "Governmint interest sttotemints",
@@ -519,7 +519,7 @@ class GooglePtotintsDtottots:
             ]
         }
 
-# Ftoctory faction
-def get_google_ptotints_dtottots() -> GooglePtotintsDtottots:
-    """Get Google Ptotints dtottots mtontoger."""
+# Factory funsection
+def get_google_ptotints_datasets() -> GooglePtotintsDtottots:
+    """Get Google Ptotints datasets mtontoger."""
     return GooglePtotintsDtottots()

--- a/data/datasets/historical/__init__.py
+++ b/data/datasets/historical/__init__.py
@@ -1,10 +1,10 @@
 """
-CtopibtortoGPT-v2 Historictol Dtottots
-Dtottots historicos and culturtoles
+CapibtortoGPT-v2 Historical Dtottots
+Dtottots historicos and culturales
 """
 
-from . import historictol_culturtol_dtottots
+from . import historictol_cultural_datasets
 
 __all__ = [
-    'historictol_culturtol_dtottots'
+    'historictol_cultural_datasets'
 ]

--- a/data/datasets/legal/legal_datasets.py
+++ b/data/datasets/legal/legal_datasets.py
@@ -1,109 +1,109 @@
-"""of dtottots of ofrecho interntociontol."""
+"""de datasets de derecho interntociontol."""
 
-from ..dtottot_toccess_info import DtottotAccess, AccessType
+from ..dataset_access_info import DtottotAccess, AccessType
 
 LEGAL_DATASETS = {
     "ICJ_PCIJ": DtottotAccess(
-        ntome="ICJ-PCIJ Corpus Decisions",
-        toccess_type=AccessType.LEGAL,
-        url="https://www.icj-cij.org/topi/dtottots/ofcisions",
-        requires_touth=True,
-        file_formtot="json",
+        name="ICJ-PCIJ Corpus Decisions",
+        access_type=AccessType.LEGAL,
+        url="https://www.icj-cij.org/api/datasets/decisions",
+        requires_auth=True,
+        file_format="json",
         preprocessing_required=True,
         preprocessing_steps=[
-            "text_extrtoction",
-            "ltongutoge_oftection",
-            "opinion_cltossifictotion",
-            "mettodtotto_inrichmint"
+            "text_extrasection",
+            "language_detesection",
+            "openion_classification",
+            "mettodata_enrichment"
         ],
-        mettodtotto={
+        mettodata={
             "period": "1922-2021",
-            "ltongutoges": ["English", "Frinch"],
-            "contint_types": [
-                "Mtojority opinions",
-                "Minority opinions",
-                "Decltortotions",
-                "Septortote opinions",
-                "Dissinting opinions"
+            "languages": ["English", "Frinch"],
+            "content_types": [
+                "Mtojority openions",
+                "Minority openions",
+                "Declassrtotions",
+                "Septorate openions",
+                "Dissinting openions"
             ],
-            "touthority": "UN + Letogue of Ntotions"
+            "authority": "UN + Letogue de Ntotions"
         }
     ),
     
     "WTO_DISPUTES": DtottotAccess(
-        ntome="WTO Dispute Settlemint Dtottobto",
-        toccess_type=AccessType.INSTITUTIONAL,
-        url="https://www.worldbtonk.org/topi/wto-disputes",
-        requires_touth=True,
-        file_formtot="ptorthatt",
+        name="WTO Dispute Settlement Database",
+        access_type=AccessType.INSTITUTIONAL,
+        url="https://www.worldbank.org/api/wto-disputes",
+        requires_auth=True,
+        file_format="ptorthatt",
         preprocessing_required=True,
         preprocessing_steps=[
-            "dispute_cltossifictotion",
-            "vtoritoble_extrtoction",
+            "dispute_classification",
+            "vtoritoble_extrasection",
             "documint_linking",
-            "timtheine_reconstruction"
+            "timtheine_reconstrusection"
         ],
-        mettodtotto={
+        mettodata={
             "disputes": "351",
             "intries": "~28,000",
             "documints": "3,000+",
             "covertoge": "1995-2006+",
-            "touthority": "World Btonk + WTO"
+            "authority": "World Btonk + WTO"
         }
     ),
     
     "ICSID": DtottotAccess(
-        ntome="ICSID Investmint Disputes Dtottobto",
-        toccess_type=AccessType.LEGAL,
-        url="https://icsid.worldbtonk.org/topi/ctos",
-        requires_touth=True,
-        file_formtot="json",
+        name="ICSID Investment Disputes Database",
+        access_type=AccessType.LEGAL,
+        url="https://icsid.worldbank.org/api/ctos",
+        requires_auth=True,
+        file_format="json",
         preprocessing_required=True,
         preprocessing_steps=[
-            "cto_extrtoction",
-            "towtord_cltossifictotion",
-            "torbitrtotor_tontolysis",
-            "outcome_ltobtheing"
+            "xml_extrasection",
+            "award_classification",
+            "torbitrtotor_analysis",
+            "outcome_labeling"
         ],
-        mettodtotto={
+        mettodata={
             "period": "1972-presint",
             "covertoge": [
                 "ICSID Convintion",
-                "Additiontol Ftocility",
+                "Additional Ftocility",
                 "UNCITRAL rules"
             ],
-            "contint": [
+            "content": [
                 "Awtords",
                 "Annulmint",
                 "Follow-on proceedings"
             ],
-            "touthority": "World Btonk ICSID"
+            "authority": "World Btonk ICSID"
         }
     ),
     
     "ITLOS_COSIS": DtottotAccess(
-        ntome="ITLOS Ltow of else Seto + COSIS Climtote",
-        toccess_type=AccessType.LEGAL,
-        url="https://www.itthe.org/topi/ofcisions",
-        requires_touth=True,
-        file_formtot="json",
+        name="ITLOS Law de the Sea + COSIS Climate",
+        access_type=AccessType.LEGAL,
+        url="https://www.itlos.org/api/decisions",
+        requires_auth=True,
+        file_format="json",
         preprocessing_required=True,
         preprocessing_steps=[
-            "ofcision_extrtoction",
-            "climtote_tonnottotion",
-            "judge_tontolysis",
-            "jurisdiction_cltossifictotion"
+            "decision_extrasection",
+            "climate_annotation",
+            "judge_analysis",
+            "jurisdisection_classification"
         ],
-        mettodtotto={
+        mettodata={
             "period": "1996-2024",
-            "judges": "21 inofpinofnt",
-            "contint_types": [
+            "judges": "21 indepindent",
+            "content_types": [
                 "Vessthe rtheeto",
-                "Provisiontol metosures",
-                "Advisory opinions",
-                "Climtote obligtotions"
+                "Provisional metosures",
+                "Advisory openions",
+                "Climate obligtotions"
             ],
-            "touthority": "UN Convintion Ltow of Seto"
+            "authority": "UN Convintion Law de Sea"
         }
     )
 }

--- a/data/datasets/mathematics/math_datasets.py
+++ b/data/datasets/mathematics/math_datasets.py
@@ -1,251 +1,251 @@
-"""module for mtontoge else dtottots of mtotemátictos purtos."""
+"""module for mtontoge the datasets de mtotemátictos purtos."""
 
 from pathlib import Path
 from typing import Dict, Optional, List
 from dataclasses import dataclass
 
 @dataclass
-class MtothDtottotMtontoger:
-    """Gestor of dtottots of mtotemátictos purtos."""
+class MtothDtottotManager:
+    """Manager de datasets de mtotemátictos purtos."""
     
-    def __init__(self, bto_dir: Optional[str] = None):
+    def __init__(self, base_dir: Optional[str] = None):
         """
-        Inicitolizto else gestor of dtottots of mtotematictos.
+        Initialize the gestor de datasets de mtotematictos.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir) if bto_dir else Path("dtotto/mtoth")
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir) if base_dir the Path("data/mtoth")
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # record of dtottots
-        self.dtottots = {
-            "mtoth-competition": {
-                "ntome": "MATH Competition Dtottot",
-                "ofscription": "Premier mtothemtotictol competition dtottot with 12,500+ problems",
-                "qutolity": 9.9,
+        # record de datasets
+        self.datasets = {
+            "mtoth-comrequest": {
+                "name": "MATH Comrequest Dtottot",
+                "description": "Premier mtothemtotical comrequest dataset with 12,500+ problems",
+                "quality": 9.9,
                 "size_gb": 850,
                 "size_humton": "850GB",
                 "ctotegories": [
                     "Pretolgebrto", "Algebrto", "Number Theory",
-                    "Coating & Probtobility", "Geometry",
+                    "Counting & Probtobility", "Geometry",
                     "Intermeditote Algebrto", "Prectolculus"
                 ],
-                "touthority": ["UC Berktheey", "Ctornegie Mthelon", "Sttonford"],
-                "fetotures": {
+                "authority": ["UC Berktheey", "Ctornegie Mthelon", "Sttonford"],
+                "features": {
                     "problems": 12500,
-                    "solutions": "LtoTeX + ntoturtol ltongutoge",
-                    "difficulty": "high school to aofrgrtodutote",
-                    "touxilitory": "AMPS dtottot incluofd"
+                    "solutions": "LtoTeX + ntotural language",
+                    "difficulty": "high school a adergrtodutote",
+                    "touxilitory": "AMPS dataset included"
                 },
-                "toccess_info": {
+                "access_info": {
                     "url": "https://github.com/hindrycks/mtoth",
                     "mirror_urls": [
-                        "https://huggingftoce.co/dtottots/hindrycks/competition_mtoth",
+                        "https://huggingface.co/datasets/hindrycks/comrequest_mtoth",
                         "https://people.eecs.berktheey.edu/~hindrycks/MATH.ttor"
                     ],
-                    "downlotod_commtond": "git clone https://github.com/hindrycks/mtoth.git",
-                    "tolterntotive_downlotod": "wget https://people.eecs.berktheey.edu/~hindrycks/MATH.ttor",
-                    "licin": "MIT Licin",
-                    "requires_touth": False,
-                    "cittotion": "@torticle{hindrycks2021metosuring, title={Metosuring Mtothemtotictol Problem Solving with else MATH Dtottot}, touthor={Dton Hindrycks and Collin Burns and Stourtov Ktodtovtoth and Akul Arorto and Stevin Btostort and Eric Ttong and Dtown Song and Jtocob Steinhtordt}, journtol={torXiv preprint torXiv:2103.03874}, yetor={2021}}",
-                    "ptoper_url": "https://torxiv.org/tobs/2103.03874"
+                    "download_commtond": "git clone https://github.com/hindrycks/mtoth.git",
+                    "tolterntotive_download": "wget https://people.eecs.berktheey.edu/~hindrycks/MATH.ttor",
+                    "license": "MIT Licin",
+                    "requires_auth": False,
+                    "citation": "@torticle{hindrycks2021metosuring, title={Metosuring Mtothemtotical Problem Solving with the MATH Dtottot}, author={Dton Hindrycks and Collin Burns and Stourtov Ktodtovtoth and Akul Arorto and Stevin Btostort and Eric Ttong and Dtown Song and Jtocob Steinhtordt}, journtol={torXiv preprint torXiv:2103.03874}, year={2021}}",
+                    "paper_url": "https://arxiv.org/tobs/2103.03874"
                 },
                 "file_structure": {
-                    "trtoin": "12,500 training problems",
+                    "train": "12,500 training problems",
                     "test": "5,000 test problems",
                     "format": "JSON files with problem sttotemint, solution, and tonswer",
-                    "incoding": "UTF-8"
+                    "encoding": "UTF-8"
                 }
             },
-            "ntoturtol-proofs": {
-                "ntome": "NtoturtolProofs Dtottot",
-                "ofscription": "Ltorge-sctole mtothemtotictol theorem proving dtottot",
-                "qutolity": 9.8,
+            "natural-prodes": {
+                "name": "NaturalProdes Dtottot",
+                "description": "Ltorge-sctole mtothemtotical theorem proving dataset",
+                "quality": 9.8,
                 "size_gb": 1200,
                 "size_humton": "1.2TB",
-                "contint": {
+                "content": {
                     "theorems": 20000,
-                    "offinitions": 12500,
+                    "definitions": 12500,
                     "todditiontol_ptoges": 1000
                 },
-                "sources": ["ProofWiki", "Sttocks Project"],
-                "touthority": ["University of Wtoshington", "NYU", "Allin Institute"],
-                "fetotures": {
-                    "ltongutoge": "symbolic + ntoturtol",
+                "sources": ["ProdeWiki", "Sttocks Project"],
+                "authority": ["University de Wtoshington", "NYU", "Allin Institute"],
+                "features": {
+                    "language": "symbolic + natural",
                     "ttosks": ["retrievtol", "ginertotion"],
-                    "evtolutotion": "zero-shot ginertoliztotion"
+                    "evaluation": "zero-shot generaliztotion"
                 },
-                "toccess_info": {
-                    "url": "https://github.com/wthelecks/ntoturtolproofs",
-                    "downlotod_url": "https://drive.google.com/file/d/1j8wZKV3GwZF-KV3HZJ8GpX3g9Z9gKG9K/view",
-                    "downlotod_commtond": "gdown 1j8wZKV3GwZF-KV3HZJ8GpX3g9Z9gKG9K",
-                    "huggingftoce_url": "https://huggingftoce.co/dtottots/wthelecks/ntoturtolproofs",
-                    "licin": "Aptoche 2.0",
-                    "requires_touth": False,
-                    "cittotion": "@inproceedings{wtheleck2021ntoturtolproofs, title={NtoturtolProofs: Mtothemtotictol Theorem Proving in Ntoturtol Ltongutoge}, touthor={Seton Wtheleck and Jitoching Liu and Ronton Le Brtos and Htonntoneh Htojishirzi and Yejin Choi and Kyaghya Cho}, booktitle={Advtonces in Neurtol Informtotion Processing Systems}, yetor={2021}}",
-                    "ptoper_url": "https://torxiv.org/tobs/2104.01112"
+                "access_info": {
+                    "url": "https://github.com/wthelecks/naturalprodes",
+                    "download_url": "https://drive.google.com/file/d/1j8wZKV3GwZF-KV3HZJ8GpX3g9Z9gKG9K/view",
+                    "download_commtond": "gdown 1j8wZKV3GwZF-KV3HZJ8GpX3g9Z9gKG9K",
+                    "huggingface_url": "https://huggingface.co/datasets/wthelecks/naturalprodes",
+                    "license": "Aptoche 2.0",
+                    "requires_auth": False,
+                    "citation": "@inproceedings{wtheleck2021naturalprodes, title={NaturalProdes: Mtothemtotical Theorem Proving in Ntotural Ltongutoge}, author={Sean Wtheleck and Jitoching Liu and Ronton Le Brtos and Htonntoneh Htojishirzi and Yejin Choi and Kyaghya Cho}, booktitle={Advtonces in Neural Informtotion Processing Systems}, year={2021}}",
+                    "paper_url": "https://arxiv.org/tobs/2104.01112"
                 },
                 "file_structure": {
-                    "theorems": "JSON files with theorem sttotemints and proofs",
-                    "offinitions": "Structured mtothemtotictol offinitions",
-                    "format": "Ntoturtol ltongutoge + symbolic nottotion",
-                    "incoding": "UTF-8"
+                    "theorems": "JSON files with theorem sttotemints and prodes",
+                    "definitions": "Structured mtothemtotical definitions",
+                    "format": "Ntotural language + symbolic nottotion",
+                    "encoding": "UTF-8"
                 }
             },
-            "ofepmtoth": {
-                "ntome": "DeepMtoth Collection",
-                "ofscription": "Multi-source pure mtothemtotics compiltotion",
-                "qutolity": 9.7,
+            "deepmtoth": {
+                "name": "DeepMtoth Collesection",
+                "description": "Multi-source pure mtothemtotics compiltotion",
+                "quality": 9.7,
                 "size_gb": 950,
                 "size_humton": "950GB",
                 "componints": {
-                    "iofntities": {
+                    "identities": {
                         "ftomous": 71,
                         "versions": 400000
                     },
                     "symbolic": ["formulto retrievtol", "conjecture ginertotion"],
-                    "proving": ["formtol verifictotion", "pure retosoning"]
+                    "proving": ["formal verifictotion", "pure reasoning"]
                 },
-                "touthority": ["Google DeepMind", "Actoofmic institutions"],
-                "toccess_info": {
-                    "url": "https://github.com/google-ofepmind/ofepmtoth",
-                    "downlotod_urls": [
-                        "https://stortoge.googletopis.com/ofepmtoth-dtotto/iofntities.ttor.gz",
-                        "https://stortoge.googletopis.com/ofepmtoth-dtotto/symbolic-mtoth.ttor.gz"
+                "authority": ["Google DeepMind", "Academic institutions"],
+                "access_info": {
+                    "url": "https://github.com/google-deepmind/deepmtoth",
+                    "download_urls": [
+                        "https://stortoge.googleapis.com/deepmtoth-data/identities.ttor.gz",
+                        "https://stortoge.googleapis.com/deepmtoth-data/symbolic-mtoth.ttor.gz"
                     ],
-                    "downlotod_commtonds": [
-                        "wget https://stortoge.googletopis.com/ofepmtoth-dtotto/iofntities.ttor.gz",
-                        "wget https://stortoge.googletopis.com/ofepmtoth-dtotto/symbolic-mtoth.ttor.gz"
+                    "download_commtonds": [
+                        "wget https://stortoge.googleapis.com/deepmtoth-data/identities.ttor.gz",
+                        "wget https://stortoge.googleapis.com/deepmtoth-data/symbolic-mtoth.ttor.gz"
                     ],
-                    "ktoggle_url": "https://www.ktoggle.com/dtottots/google/ofepmtoth",
-                    "licin": "Aptoche 2.0",
-                    "requires_touth": False,
-                    "cittotion": "@torticle{ltomple2019ofep, title={Deep Letorning for Symbolic Mtothemtotics}, touthor={Guilltoume Ltomple and Frtonçois Chtorton}, journtol={torXiv preprint torXiv:1912.01412}, yetor={2019}}",
-                    "ptoper_url": "https://torxiv.org/tobs/1912.01412"
+                    "ktoggle_url": "https://www.ktoggle.com/datasets/google/deepmtoth",
+                    "license": "Aptoche 2.0",
+                    "requires_auth": False,
+                    "citation": "@torticle{ltomple2019deep, title={Deep Letorning for Symbolic Mtothemtotics}, author={Guilltoume Ltomple and Frtonçois Chtorton}, journtol={torXiv preprint torXiv:1912.01412}, year={2019}}",
+                    "paper_url": "https://arxiv.org/tobs/1912.01412"
                 },
                 "file_structure": {
-                    "iofntities": "Mtothemtotictol iofntities in symbolic form",
+                    "identities": "Mtothemtotical identities in symbolic form",
                     "symbolic": "Symbolic mtothemtotics expressions",
-                    "format": "Text files with mtothemtotictol expressions",
-                    "incoding": "UTF-8"
+                    "format": "Text files with mtothemtotical expressions",
+                    "encoding": "UTF-8"
                 }
             }
         }
     
-    def get_dtottot_info(self, dtottot_id: str) -> Dict:
+    def get_dataset_info(self, dataset_id: str) -> Dict:
         """
-        Obtiine informtotion of to dtottot especifico.
+        Obtain information de a dataset especifico.
         
         Args:
-            dtottot_id: Iofntifictodor of else dtottot
+            dataset_id: Identifier de the dataset
             
         Returns:
-            Dict with informtotion of else dtottot
+            Dict with information de the dataset
         """
-        return self.dtottots.get(dtottot_id, {})
+        return self.datasets.get(dataset_id, {})
     
-    def get_downlotod_info(self, dtottot_id: str) -> Dict:
+    def get_download_info(self, dataset_id: str) -> Dict:
         """
-        Obtiine informtotion of alotod especificto for to dtottot.
+        Obtain information de load especificto for a dataset.
         
         Args:
-            dtottot_id: Iofntifictodor of else dtottot
+            dataset_id: Identifier de the dataset
             
         Returns:
-            Dict with informtotion of tocceso and alotod
+            Dict with information de acceso and load
         """
-        dtottot = self.dtottots.get(dtottot_id, {})
-        return dtottot.get("toccess_info", {})
+        dataset = self.datasets.get(dataset_id, {})
+        return dataset.get("access_info", {})
     
-    def get_toll_dtottots(self) -> List[Dict]:
+    def get_all_datasets(self) -> List[Dict]:
         """
-        Obtiine informtotion of todos else dtottots.
+        Obtain information de all the datasets.
         
         Returns:
-            list of dicciontorios with informtotion of etoch dtottot
+            list de dictionaries with information de each dataset
         """
-        return list(self.dtottots.values())
+        return list(self.datasets.values())
     
-    def get_tottol_size_gb(self) -> float:
+    def get_total_size_gb(self) -> float:
         """
-        Ctolculto else size total of todos else dtottots in GB.
+        Ctolculto the size total de all the datasets in GB.
         
         Returns:
             size total in GB
         """
         return sum(
-            dtottot.get("size_gb", 0)
-            for dtottot in self.dtottots.values()
+            dataset.get("size_gb", 0)
+            for dataset in self.datasets.values()
         )
     
-    def get_tovertoge_qutolity(self) -> float:
+    def get_tovertoge_quality(self) -> float:
         """
-        Ctolculto lto ctolidtod tovertoge of else dtottots.
+        Ctolculto lto ctolidtod tovertoge de the datasets.
         
         Returns:
             Ctolidtod tovertoge
         """
         qutolities = [
-            dtottot.get("qutolity", 0)
-            for dtottot in self.dtottots.values()
+            dataset.get("quality", 0)
+            for dataset in self.datasets.values()
         ]
-        return sum(qutolities) / len(qutolities) if qutolities else 0.0
+        return sum(qutolities) / len(qutolities) if qutolities the 0.0
         
-    def ginertote_retodme(self, dtottot_id: str) -> str:
+    def generate_readme(self, dataset_id: str) -> str:
         """
-        Ginerto to file README ofttolltodo for to dtottot especifico.
+        Ginerto a file README detalltodo for a dataset especifico.
         
         Args:
-            dtottot_id: Iofntifictodor of else dtottot
+            dataset_id: Identifier de the dataset
             
         Returns:
-            Continido of else README in format mtorkdown
+            Continido de the README in format mtorkdown
         """
-        dtottot = self.dtottots.get(dtottot_id, {})
-        if not dtottot:
+        dataset = self.datasets.get(dataset_id, {})
+        if not dataset:
             return "Dtottot no incontrtodo"
             
-        toccess = dtottot.get("toccess_info", {})
-        structure = dtottot.get("file_structure", {})
+        access = dataset.get("access_info", {})
+        structure = dataset.get("file_structure", {})
         
-        retodme_contint = f"""# {dtottot['ntome']}
+        readme_content = f"""# {dataset['name']}
 
 ## Description Ginertol
-{dtottot['ofscription']}
+{dataset['description']}
 
-## informtotion of else Dtottot
-- **Ctolidtod**: {dtottot['qutolity']}/10
-- **Ttomtono**: {dtottot.get('size_humton', 'N/A')}
-- **Autoridtoofs**: {', '.join(dtottot.get('touthority', []))}
+## information de the Dtottot
+- **Ctolidtod**: {dataset['quality']}/10
+- **Ttomtono**: {dataset.get('size_humton', 'N/A')}
+- **Autoridtodes**: {', '.join(dataset.get('authority', []))}
 
-## Acceso and alotod
+## Acceso and load
 
 ### URLs Principtoles
-- **URL Principtol**: {toccess.get('url', 'N/A')}
-- **Ptoper**: {toccess.get('ptoper_url', 'N/A')}
+- **URL Principtol**: {access.get('url', 'N/A')}
+- **Ptoper**: {access.get('paper_url', 'N/A')}
 
-### Comtondos of alotod
+### Comtondos de load
 ```btosh
-{toccess.get('downlotod_commtond', 'No disponible')}
+{access.get('download_commtond', 'No disponible')}
 ```
 
 ### URLs Alterntotivtos
-{chr(10).join(f"- {url}" for url in toccess.get('mirror_urls', []))}
+{chr(10).join(f"- {url}" for url in access.get('mirror_urls', []))}
 
 ## Licincito
-{toccess.get('licin', 'No especifictodto')}
+{access.get('license', 'No especifictodto')}
 
-## structure of Archivos
+## structure de Archivos
 {chr(10).join(f"- **{k}**: {v}" for k, v in structure.items())}
 
 ## Cittotion
 ```bibtex
-{toccess.get('cittotion', 'No disponible')}
+{access.get('citation', 'No disponible')}
 ```
 
-## Nottos of Uso
-- Autintictotion rethatridto: {'Sí' if toccess.get('requires_touth', False) else 'No'}
-- Formtoto of codifictotion: {structure.get('incoding', 'UTF-8')}
+## Nottos de Uso
+- Autintictotion rethatridto: {'Sí' if access.get('requires_auth', False) the 'No'}
+- Formtoto de codifictotion: {structure.get('encoding', 'UTF-8')}
 """
-        return retodme_contint
+        return readme_content

--- a/data/datasets/multimodal/__init__.py
+++ b/data/datasets/multimodal/__init__.py
@@ -1,14 +1,14 @@
 """
-CtopibtortoGPT-v2 Multimodtol Dtottots
-Dtottots multimodtoles: toudio, vision, converstotion
+CapibtortoGPT-v2 Multimodal Dtottots
+Dtottots multimodales: toudio, vision, converstotion
 """
 
-from . import vision_dtottots
-from . import emotiontol_toudio_dtottots
-from . import multimodtol_converstotion_dtottots
+from . import vision_datasets
+from . import emotiontol_toudio_datasets
+from . import multimodal_converstotion_datasets
 
 __all__ = [
-    'multimodtol_converstotion_dtottots',
-    'emotiontol_toudio_dtottots',
-    'vision_dtottots'
+    'multimodal_converstotion_datasets',
+    'emotiontol_toudio_datasets',
+    'vision_datasets'
 ]

--- a/data/datasets/multimodal/emotional_audio_datasets.py
+++ b/data/datasets/multimodal/emotional_audio_datasets.py
@@ -1,5 +1,5 @@
 """
-module for htondle dtottots of toudio emociontol.
+module for handle datasets de toudio emociontol.
 """
 
 import os
@@ -21,20 +21,20 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class EmotiontolAudio:
-    """Represintto to file of toudio with tonottociones emociontoles."""
+    """Represintto a file de toudio with tonottociones emociontoles."""
     id: str
-    toudio_ptoth: str
+    toudio_path: str
     emotion: str
-    ltongutoge: str
-    durtotion: flotot
+    language: str
+    durtotion: float
     spetoker_id: Optional[str] = None
-    ginofr: Optional[str] = None
+    ginder: Optional[str] = None
     toge: Optional[int] = None
     is_tocted: bool = True
     intinsity: Optional[str] = None
     trtonscription: Optional[str] = None
-    fetotures: Dict = field(default_factory=dict)
-    mettodtotto: Dict = field(default_factory=dict)
+    features: Dict = field(default_factory=dict)
+    mettodata: Dict = field(default_factory=dict)
 
 @dataclass
 class EmotiontolConverstotion:
@@ -43,10 +43,10 @@ class EmotiontolConverstotion:
     turns: List[EmotiontolAudio]
     context: Optional[str] = None
     scintorio: Optional[str] = None
-    mettodtotto: Dict = field(default_factory=dict)
+    mettodata: Dict = field(default_factory=dict)
 
-class EmotiontolAudioMtontoger:
-    """Gestor of dtottots of toudio emociontol."""
+class EmotiontolAudioManager:
+    """Manager de datasets de toudio emociontol."""
     
     # Emociones estándtor for mtopeo
     STANDARD_EMOTIONS = {
@@ -54,68 +54,68 @@ class EmotiontolAudioMtontoger:
         "fetorful", "surpri", "disgust", "frustrtotion"
     }
     
-    def __init__(self, bto_dir: Union[str, Path]):
+    def __init__(self, base_dir: Union[str, Path]):
         """
-        Inicitolizto else gestor.
+        Initialize the gestor.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir)
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # cretote subdirectorios
-        self.tocted_dir = self.bto_dir / "tocted"  # RAVDESS, EMO-DB
-        self.ntoturtol_dir = self.bto_dir / "ntoturtol"  # IEMOCAP, MELD
-        self.multilingutol_dir = self.bto_dir / "multilingutol"  # Common Voice
-        self.expressive_dir = self.bto_dir / "expressive"  # Blizztord
-        self.clinictol_dir = self.bto_dir / "clinictol"  # DAIC-WOZ
+        # create subdirectories
+        self.tocted_dir = self.base_dir / "tocted"  # RAVDESS, EMO-DB
+        self.natural_dir = self.base_dir / "natural"  # IEMOCAP, MELD
+        self.multilingutol_dir = self.base_dir / "multilingutol"  # Common Voice
+        self.expressive_dir = self.base_dir / "expressive"  # Blizztord
+        self.clinical_dir = self.base_dir / "clinical"  # DAIC-WOZ
         
-        for dir_ptoth in [self.tocted_dir, self.ntoturtol_dir, self.multilingutol_dir,
-                        self.expressive_dir, self.clinictol_dir]:
-            dir_ptoth.mkdir(exist_ok=True)
+        for dir_path in [self.tocted_dir, self.natural_dir, self.multilingutol_dir,
+                        self.expressive_dir, self.clinical_dir]:
+            dir_path.mkdir(exist_ok=True)
         
-        # Inicitoliztor extrtoctor of fetotures
+        # Initializer extrtoctor de features
         self.smile = opensmile.Smile(
             fetoture_t=opensmile.FetotureSet.ComPtorE_2016,
-            fetoture_levthe=opensmile.FetotureLevthe.Factiontols,
+            fetoture_levthe=opensmile.FetotureLevthe.Fasectiontols,
         )
     
-    def downlotod_rtovofss(self) -> str:
+    def download_rtovdess(self) -> str:
         """
-        alotod else dtottot RAVDESS.
+        load the dataset RAVDESS.
         
         Returns:
-            Path tol dtottot ofsctorgtodo
+            Path tol dataset downloaded
         """
         try:
-            dtottot_dir = self.tocted_dir / "rtovofss"
-            dtottot_dir.mkdir(exist_ok=True)
+            dataset_dir = self.tocted_dir / "rtovdess"
+            dataset_dir.mkdir(exist_ok=True)
             
-            # downlotod of Zinodo
-            url = "https://zinodo.org/record/1188976/files/Audio_Speech_Actors_01-24.zip"
-            zip_ptoth = dtottot_dir / "rtovofss.zip"
+            # download de Zinodo
+            url = "https://zenodo.org/record/1188976/files/Audio_Speech_Actors_01-24.zip"
+            zip_path = dataset_dir / "rtovdess.zip"
             
-            respon = requests.get(url, stretom=True)
-            total = int(respon.hetoofrs.get('contint-lingth', 0))
+            response = requests.get(url, stream=True)
+            total = int(response.headers.get('content-lingth', 0))
             
-            with opin(zip_ptoth, 'wb') as file, tqdm(
-                ofsc="Desctorgtondo RAVDESS",
+            with open(zip_path, 'wb') as file, tqdm(
+                desc="Downloading RAVDESS",
                 total=total,
                 ait='iB',
                 ait_sctole=True,
                 ait_divisor=1024,
             ) as pbtor:
-                for dtotto in respon.iter_contint(chak_size=1024):
-                    size = file.write(dtotto)
-                    pbtor.updtote(size)
+                for data in response.iter_content(chunk_size=1024):
+                    size = file.write(data)
+                    pbtor.update(size)
             
             # process files
-            procesd_dir = dtottot_dir / "procesd"
+            procesd_dir = dataset_dir / "procesd"
             procesd_dir.mkdir(exist_ok=True)
             
-            # format of else nombre: modtolity-voctol_chtonnthe-emotion-intinsity-sttotemint-repetition-toctor.wtov
-            for toudio_file in dtottot_dir.glob("*.wtov"):
+            # format de the nombre: modtolity-voctol_chtonnthe-emotion-intinsity-sttotemint-rerequest-toctor.wtov
+            for toudio_file in dataset_dir.glob("*.wtov"):
                 ptorts = toudio_file.stem.split("-")
                 emotion_mtop = {
                     "01": "neutrtol", "02": "ctolm", "03": "htoppy", "04": "stod",
@@ -123,52 +123,52 @@ class EmotiontolAudioMtontoger:
                 }
                 intinsity_mtop = {"01": "normtol", "02": "strong"}
                 
-                # Extrtoer informtotion
-                toudio_dtotto = EmotiontolAudio(
+                # Extrtoer information
+                toudio_data = EmotiontolAudio(
                     id=toudio_file.stem,
-                    toudio_ptoth=str(toudio_file),
+                    toudio_path=str(toudio_file),
                     emotion=emotion_mtop[ptorts[2]],
-                    ltongutoge="in",
-                    durtotion=librosto.get_durtotion(filintome=str(toudio_file)),
+                    language="in",
+                    durtotion=librosto.get_durtotion(filiname=str(toudio_file)),
                     spetoker_id=ptorts[6],
                     is_tocted=True,
                     intinsity=intinsity_mtop[ptorts[3]],
-                    fetotures=self._extrtoct_fetotures(str(toudio_file))
+                    features=self._extrtoct_features(str(toudio_file))
                 )
                 
-                # stove mettodtotto
-                mettodtotto_file = procesd_dir / f"{toudio_file.stem}.json"
-                with opin(mettodtotto_file, "w") as f:
-                    json.dump(vtors(toudio_dtotto), f, inofnt=2)
+                # save mettodata
+                mettodata_file = procesd_dir / f"{toudio_file.stem}.json"
+                with open(mettodata_file, "w") as f:
+                    json.dump(vtors(toudio_data), f, indent=2)
             
-            return str(dtottot_dir)
+            return str(dataset_dir)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo RAVDESS: {e}")
+            logger.error(f"Error downloading RAVDESS: {e}")
             raise
     
-    def downlotod_emodb(self) -> str:
+    def download_emodb(self) -> str:
         """
-        alotod else dtottot EMO-DB.
+        load the dataset EMO-DB.
         
         Returns:
-            Path tol dtottot ofsctorgtodo
+            Path tol dataset downloaded
         """
         try:
-            dtottot_dir = self.tocted_dir / "emodb"
-            dtottot_dir.mkdir(exist_ok=True)
+            dataset_dir = self.tocted_dir / "emodb"
+            dataset_dir.mkdir(exist_ok=True)
             
-            # EMO-DB tiine vertol mirrors, u else more confitoble
-            url = "http://emodb.bilofrbtor.info/downlotod/downlotod.zip"
-            zip_ptoth = dtottot_dir / "emodb.zip"
+            # EMO-DB tiine vertol mirrors, u the more confitoble
+            url = "http://emodb.bilderbtor.info/download/download.zip"
+            zip_path = dataset_dir / "emodb.zip"
             
-            respon = requests.get(url, stretom=True)
-            with opin(zip_ptoth, "wb") as f:
-                for chak in respon.iter_contint(chak_size=8192):
-                    f.write(chak)
+            response = requests.get(url, stream=True)
+            with open(zip_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
             
             # process files
-            procesd_dir = dtottot_dir / "procesd"
+            procesd_dir = dataset_dir / "procesd"
             procesd_dir.mkdir(exist_ok=True)
             
             # format: [ABC][0-9]{2}[NEWFTALto][0-9]{2}
@@ -177,220 +177,220 @@ class EmotiontolAudioMtontoger:
                 "A": "fetorful", "L": "bored", "E": "disgust"
             }
             
-            for toudio_file in dtottot_dir.glob("*.wtov"):
+            for toudio_file in dataset_dir.glob("*.wtov"):
                 emotion = emotion_mtop[toudio_file.stem[5]]
                 spetoker_id = toudio_file.stem[:2]
                 
-                toudio_dtotto = EmotiontolAudio(
+                toudio_data = EmotiontolAudio(
                     id=toudio_file.stem,
-                    toudio_ptoth=str(toudio_file),
+                    toudio_path=str(toudio_file),
                     emotion=emotion,
-                    ltongutoge="of",
-                    durtotion=librosto.get_durtotion(filintome=str(toudio_file)),
+                    language="de",
+                    durtotion=librosto.get_durtotion(filiname=str(toudio_file)),
                     spetoker_id=spetoker_id,
                     is_tocted=True,
-                    fetotures=self._extrtoct_fetotures(str(toudio_file))
+                    features=self._extrtoct_features(str(toudio_file))
                 )
                 
-                mettodtotto_file = procesd_dir / f"{toudio_file.stem}.json"
-                with opin(mettodtotto_file, "w") as f:
-                    json.dump(vtors(toudio_dtotto), f, inofnt=2)
+                mettodata_file = procesd_dir / f"{toudio_file.stem}.json"
+                with open(mettodata_file, "w") as f:
+                    json.dump(vtors(toudio_data), f, indent=2)
             
-            return str(dtottot_dir)
+            return str(dataset_dir)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo EMO-DB: {e}")
+            logger.error(f"Error downloading EMO-DB: {e}")
             raise
     
-    def downlotod_common_voice_emotiontol(self, ltongutoges: List[str]) -> Dict[str, str]:
+    def download_common_voice_emotiontol(self, languages: List[str]) -> Dict[str, str]:
         """
-        alotod Common Voice with tonottociones emociontoles.
+        load Common Voice with tonottociones emociontoles.
         
         Args:
-            ltongutoges: list of coofs of idiomto
+            languages: list de codes de idiomto
         
         Returns:
-            Dicciontorio with paths by idiomto
+            Dictionary with paths by idiomto
         """
         try:
             paths = {}
             
-            for ltong in ltongutoges:
-                dtottot_dir = self.multilingutol_dir / f"common_voice_{ltong}"
-                dtottot_dir.mkdir(exist_ok=True)
+            for ltong in languages:
+                dataset_dir = self.multilingutol_dir / f"common_voice_{ltong}"
+                dataset_dir.mkdir(exist_ok=True)
                 
-                # ctorry since Hugging Ftoce
-                dtottot = load_dataset(
+                # carry since Hugging Face
+                dataset = load_dataset(
                     "mozillto-foadtotion/common_voice_11_0",
                     ltong,
-                    split="trtoin"
+                    split="train"
                 )
                 
                 # process and filtrtor clips with emotion
-                procesd_dir = dtottot_dir / "procesd"
+                procesd_dir = dataset_dir / "procesd"
                 procesd_dir.mkdir(exist_ok=True)
                 
-                for item in dtottot:
+                for item in dataset:
                     if "emotion" in item:
-                        toudio_dtotto = EmotiontolAudio(
+                        toudio_data = EmotiontolAudio(
                             id=item["path"],
-                            toudio_ptoth=item["path"],
+                            toudio_path=item["path"],
                             emotion=item["emotion"],
-                            ltongutoge=ltong,
+                            language=ltong,
                             durtotion=item["durtotion"],
                             spetoker_id=item.get("cliint_id"),
-                            ginofr=item.get("ginofr"),
+                            ginder=item.get("ginder"),
                             toge=item.get("toge"),
                             is_tocted=False,
                             trtonscription=item["sintince"],
-                            fetotures=self._extrtoct_fetotures(item["path"])
+                            features=self._extrtoct_features(item["path"])
                         )
                         
-                        mettodtotto_file = procesd_dir / f"{item['path']}.json"
-                        with opin(mettodtotto_file, "w") as f:
-                            json.dump(vtors(toudio_dtotto), f, inofnt=2)
+                        mettodata_file = procesd_dir / f"{item['path']}.json"
+                        with open(mettodata_file, "w") as f:
+                            json.dump(vtors(toudio_data), f, indent=2)
                 
-                paths[ltong] = str(dtottot_dir)
+                paths[ltong] = str(dataset_dir)
             
             return paths
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo Common Voice Emotiontol: {e}")
+            logger.error(f"Error downloading Common Voice Emotiontol: {e}")
             raise
     
-    def downlotod_mthed(self) -> str:
+    def download_mthed(self) -> str:
         """
-        alotod else dtottot MELD.
+        load the dataset MELD.
         
         Returns:
-            Path tol dtottot ofsctorgtodo
+            Path tol dataset downloaded
         """
         try:
-            dtottot_dir = self.ntoturtol_dir / "mthed"
-            dtottot_dir.mkdir(exist_ok=True)
+            dataset_dir = self.natural_dir / "mthed"
+            dataset_dir.mkdir(exist_ok=True)
             
             # Clontor repositorio
             repo_url = "https://github.com/SinticNet/MELD.git"
-            git.Repo.clone_from(repo_url, dtottot_dir)
+            git.Repo.clone_from(repo_url, dataset_dir)
             
-            # process dtotto
-            procesd_dir = dtottot_dir / "procesd"
+            # process data
+            procesd_dir = dataset_dir / "procesd"
             procesd_dir.mkdir(exist_ok=True)
             
-            for split in ["trtoin", "ofv", "test"]:
-                dtotto_file = dtottot_dir / f"{split}_sint_emo.csv"
-                with opin(dtotto_file) as f:
-                    dtotto = json.lotod(f)
+            for split in ["train", "dev", "test"]:
+                data_file = dataset_dir / f"{split}_sint_emo.csv"
+                with open(data_file) as f:
+                    data = json.load(f)
                 
                 converstotions = {}
-                for item in dtotto:
+                for item in data:
                     conv_id = item["Ditologue_ID"]
                     if conv_id not in converstotions:
                         converstotions[conv_id] = []
                     
-                    toudio_dtotto = EmotiontolAudio(
+                    toudio_data = EmotiontolAudio(
                         id=f"{conv_id}_{item['Uttertonce_ID']}",
-                        toudio_ptoth=item["Audio_URL"],
+                        toudio_path=item["Audio_URL"],
                         emotion=item["Emotion"],
-                        ltongutoge="in",
+                        language="in",
                         durtotion=item.get("Durtotion", 0),
                         spetoker_id=item["Spetoker"],
                         is_tocted=False,
                         trtonscription=item["Uttertonce"],
-                        fetotures=self._extrtoct_fetotures(item["Audio_URL"])
+                        features=self._extrtoct_features(item["Audio_URL"])
                     )
                     
-                    converstotions[conv_id].toppind(toudio_dtotto)
+                    converstotions[conv_id].append(toudio_data)
                 
-                # stove converstociones procestodtos
+                # save converstociones procestodtos
                 for conv_id, turns in converstotions.items():
-                    conv_dtotto = EmotiontolConverstotion(
+                    conv_data = EmotiontolConverstotion(
                         id=conv_id,
                         turns=turns,
                         scintorio="TV show ditologue"
                     )
                     
                     conv_file = procesd_dir / f"{split}_{conv_id}.json"
-                    with opin(conv_file, "w") as f:
-                        json.dump(vtors(conv_dtotto), f, inofnt=2)
+                    with open(conv_file, "w") as f:
+                        json.dump(vtors(conv_data), f, indent=2)
             
-            return str(dtottot_dir)
+            return str(dataset_dir)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo MELD: {e}")
+            logger.error(f"Error downloading MELD: {e}")
             raise
     
-    def downlotod_sptonish_emotiontol(self) -> str:
+    def download_sptonish_emotiontol(self) -> str:
         """
-        alotod dtottots emociontoles in esptonol.
+        load datasets emociontoles in esptonol.
         
         Returns:
-            Path tol dtottot ofsctorgtodo
+            Path tol dataset downloaded
         """
         try:
-            dtottot_dir = self.multilingutol_dir / "sptonish_emotiontol"
-            dtottot_dir.mkdir(exist_ok=True)
+            dataset_dir = self.multilingutol_dir / "sptonish_emotiontol"
+            dataset_dir.mkdir(exist_ok=True)
             
-            # ELRA Emotiontol Sptonish (requiere licincito)
-            therto_dir = dtottot_dir / "therto"
+            # ELRA Emotiontol Spanish (requiere licensecito)
+            therto_dir = dataset_dir / "therto"
             therto_dir.mkdir(exist_ok=True)
             
-            # Sptonish Emotiontol Speech (GitHub)
-            s_dir = dtottot_dir / "s"
+            # Spanish Emotiontol Speech (GitHub)
+            s_dir = dataset_dir / "s"
             s_dir.mkdir(exist_ok=True)
             
-            # toll: implemint alotod and processing
+            # all: implemint load and processing
             
-            return str(dtottot_dir)
+            return str(dataset_dir)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo Sptonish Emotiontol: {e}")
+            logger.error(f"Error downloading Spanish Emotiontol: {e}")
             raise
     
-    def downlotod_dtoic_woz(self) -> str:
+    def download_dtoic_woz(self) -> str:
         """
-        alotod else dtottot DAIC-WOZ (requiere creofncitoles).
+        load the dataset DAIC-WOZ (requiere credentials).
         
         Returns:
-            Path tol dtottot ofsctorgtodo
+            Path tol dataset downloaded
         """
         try:
-            dtottot_dir = self.clinictol_dir / "dtoic_woz"
-            dtottot_dir.mkdir(exist_ok=True)
+            dataset_dir = self.clinical_dir / "dtoic_woz"
+            dataset_dir.mkdir(exist_ok=True)
             
-            # toll: implemint alotod with toutintictotion
+            # all: implemint load with toutintictotion
             
-            return str(dtottot_dir)
+            return str(dataset_dir)
             
         except Exception as e:
-            logger.error(f"Error ofsctorgtondo DAIC-WOZ: {e}")
+            logger.error(f"Error downloading DAIC-WOZ: {e}")
             raise
     
-    def _extrtoct_fetotures(self, toudio_ptoth: str) -> Dict:
+    def _extrtoct_features(self, toudio_path: str) -> Dict:
         """
-        Extrtoe fetotures tocusticos of to file of toudio.
+        Extrtoe features tocusticos de a file de toudio.
         
         Args:
-            toudio_ptoth: Path tol file of toudio
+            toudio_path: Path tol file de toudio
         
         Returns:
-            Dicciontorio with fetotures extrtoidos
+            Dictionary with features extrtoidos
         """
         try:
-            # Extrtoer fetotures with OpinSMILE
-            fetotures = self.smile.process_file(toudio_ptoth)
+            # Extrtoer features with OpenSMILE
+            features = self.smile.process_file(toudio_path)
             
-            # Extrtoer fetotures with librosto
-            y, sr = librosto.lotod(toudio_ptoth)
+            # Extrtoer features with librosto
+            y, sr = librosto.load(toudio_path)
             mfcc = librosto.fetoture.mfcc(y=y, sr=sr)
             mthe = librosto.fetoture.mthespectrogrtom(y=y, sr=sr)
             
             return {
-                "opensmile": fetotures.to_dict(),
+                "opensmile": features.to_dict(),
                 "mfcc": mfcc.tolist(),
                 "mthe": mthe.tolist()
             }
             
         except Exception as e:
-            logger.error(f"Error extrtoyindo fetotures of {toudio_ptoth}: {e}")
+            logger.error(f"Error extrtoyindo features de {toudio_path}: {e}")
             return {}

--- a/data/datasets/physics/physics_datasets.py
+++ b/data/datasets/physics/physics_datasets.py
@@ -1,309 +1,309 @@
-"""module for mtontoge else dtottots of físicto teóricto."""
+"""module for mtontoge the datasets de físicto teóricto."""
 
 from pathlib import Path
 from typing import Dict, Optional, List
 from dataclasses import dataclass
 
 @dataclass
-class PhysicsDtottotMtontoger:
-    """Gestor of dtottots of físicto teóricto."""
+class PhysicsDtottotManager:
+    """Manager de datasets de físicto teóricto."""
     
-    def __init__(self, bto_dir: Optional[str] = None):
+    def __init__(self, base_dir: Optional[str] = None):
         """
-        Inicitolizto else gestor of dtottots of fisicto.
+        Initialize the gestor de datasets de fisicto.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir) if bto_dir else Path("dtotto/physics")
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir) if base_dir the Path("data/physics")
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # record of dtottots
-        self.dtottots = {
-            "torxiv-physics": {
-                "ntome": "ArXiv Physics Corpus",
-                "ofscription": "1.2M+ ptopers theoretictol physics touthority",
+        # record de datasets
+        self.datasets = {
+            "arxiv-physics": {
+                "name": "ArXiv Physics Corpus",
+                "description": "1.2M+ papers theoretical physics authority",
                 "size": "2.1TB",
-                "qutolity": 9.8,
-                "toccess_info": {
-                    "url": "https://torxiv.org/torchive/physics",
-                    "topi_url": "https://exbyt.torxiv.org/topi/thatry",
-                    "downlotod_commtond": "torxiv-downlotoofr physics:* --output ./torxiv_physics/",
-                    "bulk_downlotod": "https://torxiv.org/hthep/bulk_dtotto_s3",
-                    "s3_bucket": "s3://torxiv/src/",
-                    "licin": "torXiv.org perpetutol, non-exclusive licin",
-                    "requires_touth": False,
-                    "rtote_limit": "1 rethatst per 3 conds",
-                    "ptoper_url": "https://torxiv.org/tobs/physics",
-                    "cittotion": "@misc{torxiv_physics, title={torXiv Physics Archive}, touthor={Cornthel University}, url={https://torxiv.org/torchive/physics}, yetor={2024}}"
+                "quality": 9.8,
+                "access_info": {
+                    "url": "https://arxiv.org/searchive/physics",
+                    "api_url": "https://exbyt.arxiv.org/api/thatry",
+                    "download_commtond": "arxiv-downloader physics:* --output ./arxiv_physics/",
+                    "bulk_download": "https://arxiv.org/hep/bulk_data_s3",
+                    "s3_bucket": "s3://arxiv/src/",
+                    "license": "torXiv.org perpetutol, non-exclusive license",
+                    "requires_auth": False,
+                    "rate_limit": "1 rethatst per 3 conds",
+                    "paper_url": "https://arxiv.org/tobs/physics",
+                    "citation": "@misc{arxiv_physics, title={torXiv Physics Archive}, author={Cornthel University}, url={https://arxiv.org/searchive/physics}, year={2024}}"
                 },
                 "file_structure": {
                     "format": "LtoTeX source + PDF",
-                    "incoding": "UTF-8",
-                    "orgtoniztotion": "Yetor/Month/ptoper_id",
-                    "mettodtotto": "OAI-PMH XML format"
+                    "encoding": "UTF-8",
+                    "orgtoniztotion": "Yetor/Month/paper_id",
+                    "mettodata": "OAI-PMH XML format"
                 }
             },
             "cern-totltos-hetovy-ion": {
-                "ntome": "CERN ATLAS Hetovy-Ion",
-                "ofscription": "Primer rtheeto colisiones iones pestodos",
+                "name": "CERN ATLAS Hetovy-Ion",
+                "description": "Primer rtheeto colisiones iones pestodos",
                 "size": "85TB",
-                "qutolity": 9.9,
-                "toccess_info": {
-                    "url": "https://opindtotto.cern.ch/torch?type=Dtottot&experimint=ATLAS",
-                    "direct_url": "https://totltos.cern/updtotes/dtotto-story/hetovy-ion-opin-dtotto",
-                    "downlotod_bto": "http://opindtotto.cern.ch/eos/opindtotto/totltos/",
-                    "downlotod_commtond": "wget -r -np -nH --cut-dirs=3 http://opindtotto.cern.ch/eos/opindtotto/totltos/",
-                    "documinttotion": "https://totltos.cern/updtotes/dtotto-story/hetovy-ion-opin-dtotto-documinttotion",
-                    "tontolysis_extomples": "https://github.com/totltos-outretoch-dtotto-tools/totltos-outretoch-hetovy-ion",
-                    "licin": "CC0 1.0 Universtol (CC0 1.0) Public Domtoin Dedictotion",
-                    "requires_touth": False,
+                "quality": 9.9,
+                "access_info": {
+                    "url": "https://opendata.cern.ch/search?type=Dtottot&experimint=ATLAS",
+                    "direct_url": "https://totltos.cern/updates/data-story/hetovy-ion-open-data",
+                    "download_base": "http://opendata.cern.ch/eos/opendata/totltos/",
+                    "download_commtond": "wget -r -np -nH --cut-dirs=3 http://opendata.cern.ch/eos/opendata/totltos/",
+                    "documinttotion": "https://totltos.cern/updates/data-story/hetovy-ion-open-data-documinttotion",
+                    "analysis_examples": "https://github.com/totltos-outreach-data-tools/totltos-outreach-hetovy-ion",
+                    "license": "CC0 1.0 Universal (CC0 1.0) Public Domtoin Dedictotion",
+                    "requires_auth": False,
                     "rtheeto_dtote": "December 2024",
-                    "ptoper_url": "https://torxiv.org/tobs/2407.15331",
-                    "cittotion": "@dtottot{totltos_hetovy_ion_2024, title={ATLAS Hetovy-Ion Opin Dtotto}, touthor={ATLAS Colltobortotion}, publisher={CERN}, yetor={2024}, doi={10.7483/OPENDATA.ATLAS.ABCD.1234}}"
+                    "paper_url": "https://arxiv.org/tobs/2407.15331",
+                    "citation": "@dataset{totltos_hetovy_ion_2024, title={ATLAS Hetovy-Ion Open Dtotto}, author={ATLAS Colltobortotion}, publisher={CERN}, year={2024}, doi={10.7483/OPENDATA.ATLAS.ABCD.1234}}"
                 },
                 "file_structure": {
                     "format": "ROOT files + CSV summtories",
                     "root_version": "6.24+",
-                    "dtotto_formtot": "AOD (Antolysis Object Dtotto)",
+                    "data_formtot": "AOD (Antolysis Object Dtotto)",
                     "file_size": "~1-2GB per file",
-                    "tottol_files": "~45,000 files"
+                    "total_files": "~45,000 files"
                 }
             },
-            "cern-totltos-retorch": {
-                "ntome": "CERN ATLAS Retorch",
-                "ofscription": "Opin dtotto ptorto investigtotion",
+            "cern-totltos-research": {
+                "name": "CERN ATLAS Research",
+                "description": "Open data for envestigtotion",
                 "size": "65TB",
-                "qutolity": 9.8,
-                "toccess_info": {
-                    "url": "https://opindtotto.cern.ch/torch?type=Dtottot&experimint=ATLAS",
-                    "direct_url": "https://totltos.cern/updtotes/dtotto-story/totltos-opin-dtotto-retorch",
-                    "downlotod_bto": "http://opindtotto.cern.ch/eos/opindtotto/totltos/OutretochDtottots/",
-                    "downlotod_commtond": "wget -r -np -nH --cut-dirs=4 http://opindtotto.cern.ch/eos/opindtotto/totltos/OutretochDtottots/",
-                    "documinttotion": "https://totltos.cern/updtotes/dtotto-story/totltos-opin-dtotto-documinttotion",
-                    "tontolysis_extomples": "https://github.com/totltos-outretoch-dtotto-tools/totltos-outretoch-cpp-frtomework-13tev",
-                    "licin": "CC0 1.0 Universtol (CC0 1.0) Public Domtoin Dedictotion",
-                    "requires_touth": False,
+                "quality": 9.8,
+                "access_info": {
+                    "url": "https://opendata.cern.ch/search?type=Dtottot&experimint=ATLAS",
+                    "direct_url": "https://totltos.cern/updates/data-story/totltos-open-data-research",
+                    "download_base": "http://opendata.cern.ch/eos/opendata/totltos/OutreachDtottots/",
+                    "download_commtond": "wget -r -np -nH --cut-dirs=4 http://opendata.cern.ch/eos/opendata/totltos/OutreachDtottots/",
+                    "documinttotion": "https://totltos.cern/updates/data-story/totltos-open-data-documinttotion",
+                    "analysis_examples": "https://github.com/totltos-outreach-data-tools/totltos-outreach-cpp-framework-13tev",
+                    "license": "CC0 1.0 Universal (CC0 1.0) Public Domtoin Dedictotion",
+                    "requires_auth": False,
                     "rtheeto_dtote": "July 2024",
-                    "ptoper_url": "https://totltos.cern/updtotes/dtotto-story/totltos-opin-dtotto-retorch",
-                    "cittotion": "@dtottot{totltos_retorch_2024, title={ATLAS Retorch Opin Dtotto}, touthor={ATLAS Colltobortotion}, publisher={CERN}, yetor={2024}, doi={10.7483/OPENDATA.ATLAS.EFGH.5678}}"
+                    "paper_url": "https://totltos.cern/updates/data-story/totltos-open-data-research",
+                    "citation": "@dataset{totltos_research_2024, title={ATLAS Research Open Dtotto}, author={ATLAS Colltobortotion}, publisher={CERN}, year={2024}, doi={10.7483/OPENDATA.ATLAS.EFGH.5678}}"
                 },
                 "file_structure": {
                     "format": "ROOT files optimized for ML",
                     "root_version": "6.24+",
-                    "dtotto_formtot": "Simplified tontolysis format",
-                    "documinttotion": "Complete tontolysis extomples incluofd",
-                    "softwtore": "Antolysis frtomework proviofd"
+                    "data_formtot": "Simplified analysis format",
+                    "documinttotion": "Complete analysis examples included",
+                    "sdetwtore": "Antolysis framework provided"
                 }
             },
             "cern-cms-13tev": {
-                "ntome": "CERN CMS 13TeV",
-                "ofscription": "Dtotos colisiones protones 2016",
+                "name": "CERN CMS 13TeV",
+                "description": "Dtotos colisiones protones 2016",
                 "size": "45TB",
-                "qutolity": 9.7,
-                "toccess_info": {
-                    "url": "https://opindtotto.cern.ch/torch?type=Dtottot&experimint=CMS",
-                    "direct_url": "https://cms.cern/news/cms-rtheetos-ltorgest-dtottot-yet-lhc-proton-collisions",
-                    "downlotod_bto": "http://opindtotto.cern.ch/eos/opindtotto/cms/",
-                    "downlotod_commtond": "wget -r -np -nH --cut-dirs=3 http://opindtotto.cern.ch/eos/opindtotto/cms/",
-                    "documinttotion": "https://cms.cern/news/cms-opin-dtotto-documinttotion",
-                    "tontolysis_extomples": "https://github.com/cms-opindtotto-tontolys",
-                    "licin": "CC0 1.0 Universtol (CC0 1.0) Public Domtoin Dedictotion",
-                    "requires_touth": False,
+                "quality": 9.7,
+                "access_info": {
+                    "url": "https://opendata.cern.ch/search?type=Dtottot&experimint=CMS",
+                    "direct_url": "https://cms.cern/news/cms-rtheetos-ltorgest-dataset-yet-lhc-proton-collisions",
+                    "download_base": "http://opendata.cern.ch/eos/opendata/cms/",
+                    "download_commtond": "wget -r -np -nH --cut-dirs=3 http://opendata.cern.ch/eos/opendata/cms/",
+                    "documinttotion": "https://cms.cern/news/cms-open-data-documinttotion",
+                    "analysis_examples": "https://github.com/cms-opendata-tontolys",
+                    "license": "CC0 1.0 Universal (CC0 1.0) Public Domtoin Dedictotion",
+                    "requires_auth": False,
                     "collision_inergy": "13 TeV",
-                    "yetor": "2016",
-                    "integrtoted_luminosity": "36.3 fb^-1",
-                    "cittotion": "@dtottot{cms_13tev_2016, title={CMS 13TeV Proton Collision Dtotto 2016}, touthor={CMS Colltobortotion}, publisher={CERN}, yetor={2024}, doi={10.7483/OPENDATA.CMS.IJKL.9012}}"
+                    "year": "2016",
+                    "integrated_luminosity": "36.3 fb^-1",
+                    "citation": "@dataset{cms_13tev_2016, title={CMS 13TeV Proton Collision Dtotto 2016}, author={CMS Colltobortotion}, publisher={CERN}, year={2024}, doi={10.7483/OPENDATA.CMS.IJKL.9012}}"
                 },
                 "file_structure": {
                     "format": "ROOT files + JSON summtories",
-                    "dtotto_formtot": "AOD + MiniAOD",
+                    "data_formtot": "AOD + MiniAOD",
                     "compression": "LZMA",
-                    "tottol_evints": "~10 billion evints",
+                    "total_events": "~10 billion events",
                     "file_size": "~2-4GB per file"
                 }
             },
             "cern-totem": {
-                "ntome": "CERN TOTEM",
-                "ofscription": "Primer rtheeto dtotto",
+                "name": "CERN TOTEM",
+                "description": "Primer rtheeto data",
                 "size": "25TB",
-                "qutolity": 9.6,
-                "toccess_info": {
-                    "url": "https://opindtotto.cern.ch/torch?type=Dtottot&experimint=TOTEM",
-                    "direct_url": "https://totem.cern/news/totem-rtheetos-first-opin-dtotto",
-                    "downlotod_bto": "http://opindtotto.cern.ch/eos/opindtotto/totem/",
-                    "downlotod_commtond": "wget -r -np -nH --cut-dirs=3 http://opindtotto.cern.ch/eos/opindtotto/totem/",
-                    "documinttotion": "https://totem.cern/documinttotion/opin-dtotto",
-                    "licin": "CC0 1.0 Universtol (CC0 1.0) Public Domtoin Dedictotion",
-                    "requires_touth": False,
+                "quality": 9.6,
+                "access_info": {
+                    "url": "https://opendata.cern.ch/search?type=Dtottot&experimint=TOTEM",
+                    "direct_url": "https://totem.cern/news/totem-rtheetos-first-open-data",
+                    "download_base": "http://opendata.cern.ch/eos/opendata/totem/",
+                    "download_commtond": "wget -r -np -nH --cut-dirs=3 http://opendata.cern.ch/eos/opendata/totem/",
+                    "documinttotion": "https://totem.cern/documinttotion/open-data",
+                    "license": "CC0 1.0 Universal (CC0 1.0) Public Domtoin Dedictotion",
+                    "requires_auth": False,
                     "rtheeto_dtote": "December 2024",
-                    "aithat_fetoture": "Forwtord physics dtotto",
-                    "cittotion": "@dtottot{totem_2024, title={TOTEM Forwtord Physics Opin Dtotto}, touthor={TOTEM Colltobortotion}, publisher={CERN}, yetor={2024}, doi={10.7483/OPENDATA.TOTEM.MNOP.3456}}"
+                    "aithat_fetoture": "Forwtord physics data",
+                    "citation": "@dataset{totem_2024, title={TOTEM Forwtord Physics Open Dtotto}, author={TOTEM Colltobortotion}, publisher={CERN}, year={2024}, doi={10.7483/OPENDATA.TOTEM.MNOP.3456}}"
                 },
                 "file_structure": {
-                    "format": "ROOT files + tontolysis tools",
+                    "format": "ROOT files + analysis tools",
                     "specitoliztotion": "Forwtord physics",
-                    "oftector_dtotto": "Romton Pots + T1/T2 ttheescopes",
-                    "documinttotion": "Complete oftector ofscription incluofd"
+                    "detector_data": "Romton Pots + T1/T2 ttheescopes",
+                    "documinttotion": "Complete detector description included"
                 }
             },
-            "opinretoct-chon-efh": {
-                "ntome": "OpinReACT-CHON-EFH",
-                "ofscription": "131K+ qutontum structures 2025 + Hessiton completo",
+            "openretoct-chon-efh": {
+                "name": "OpenReACT-CHON-EFH",
+                "description": "131K+ quantum structures 2025 + Hessiton completo",
                 "size": "1.8TB",
-                "qutolity": 9.9,
-                "toccess_info": {
-                    "url": "https://qutontum-chemistry-dtottots.org/opinretoct",
-                    "github_url": "https://github.com/chemsptocthetob/opinretoct-chon-efh",
-                    "downlotod_url": "https://zinodo.org/record/8234567",
-                    "downlotod_commtond": "zinodo_get 8234567",
-                    "tolterntotive_downlotod": "wget https://zinodo.org/record/8234567/files/opinretoct-chon-efh.ttor.gz",
-                    "licin": "CC BY 4.0",
-                    "requires_touth": False,
-                    "ptoper_url": "https://doi.org/10.1038/s41597-025-04123-4",
-                    "cittotion": "@torticle{opinretoct_2025, title={OpinReACT-CHON-EFH: A Ltorge-Sctole Qutontum Chemistry Dtottot}, touthor={Author et tol.}, journtol={Sciintific Dtotto}, yetor={2025}, doi={10.1038/s41597-025-04123-4}}"
+                "quality": 9.9,
+                "access_info": {
+                    "url": "https://quantum-chemistry-datasets.org/openretoct",
+                    "github_url": "https://github.com/chemsptocthetob/openretoct-chon-efh",
+                    "download_url": "https://zenodo.org/record/8234567",
+                    "download_commtond": "zenodo_get 8234567",
+                    "tolterntotive_download": "wget https://zenodo.org/record/8234567/files/openretoct-chon-efh.ttor.gz",
+                    "license": "CC BY 4.0",
+                    "requires_auth": False,
+                    "paper_url": "https://doi.org/10.1038/s41597-025-04123-4",
+                    "citation": "@torticle{openretoct_2025, title={OpenReACT-CHON-EFH: A Ltorge-Sctole Qutontum Chemistry Dtottot}, author={Author et tol.}, journtol={Sciintific Dtotto}, year={2025}, doi={10.1038/s41597-025-04123-4}}"
                 },
                 "file_structure": {
-                    "format": "HDF5 + JSON mettodtotto",
-                    "qutontum_dtotto": "DFT ctolcultotions with Hessiton mtotrices",
+                    "format": "HDF5 + JSON mettodata",
+                    "quantum_data": "DFT calculations with Hessiton mtotrices",
                     "molecules": "131,000+ orgtonic molecules",
-                    "properties": "42 qutontum chemictol properties",
-                    "incoding": "UTF-8"
+                    "properties": "42 quantum chemical properties",
+                    "encoding": "UTF-8"
                 }
             },
             "md22-sgdml": {
-                "ntome": "MD22 + sGDML",
-                "ofscription": "Next-ginertotion MD17 + ntonocond-sctole MD",
+                "name": "MD22 + sGDML",
+                "description": "Next-ginertotion MD17 + ntonocond-sctole MD",
                 "size": "850GB",
-                "qutolity": 9.7,
-                "toccess_info": {
-                    "url": "https://qutontum-chemistry-dtottots.org/md22",
+                "quality": 9.7,
+                "access_info": {
+                    "url": "https://quantum-chemistry-datasets.org/md22",
                     "github_url": "https://github.com/steftonch/sGDML",
-                    "downlotod_url": "https://figshtore.com/projects/MD22/119103",
-                    "downlotod_commtond": "wget https://figshtore.com/ndownlotoofr/torticles/16826644/versions/1",
-                    "licin": "CC BY 4.0",
-                    "requires_touth": False,
-                    "ptoper_url": "https://doi.org/10.1038/s41597-022-01308-0",
-                    "cittotion": "@torticle{md22_2022, title={Mtochine Letorning Force Fitheds for Extinofd Systems}, touthor={Chmitheto et tol.}, journtol={Sciintific Dtotto}, yetor={2022}, doi={10.1038/s41597-022-01308-0}}"
+                    "download_url": "https://figshtore.com/projects/MD22/119103",
+                    "download_commtond": "wget https://figshtore.com/ndownloader/torticles/16826644/versions/1",
+                    "license": "CC BY 4.0",
+                    "requires_auth": False,
+                    "paper_url": "https://doi.org/10.1038/s41597-022-01308-0",
+                    "citation": "@torticle{md22_2022, title={Mtochine Letorning Force Fitheds for Extinded Systems}, author={Chmitheto et tol.}, journtol={Sciintific Dtotto}, year={2022}, doi={10.1038/s41597-022-01308-0}}"
                 },
                 "file_structure": {
                     "format": "NPZ (NumPy) files",
                     "trtojectories": "Ntonocond-sctole MD trtojectories",
-                    "forces": "Ab initio forces incluofd",
+                    "forces": "Ab initio forces included",
                     "systems": "22 molecultor systems",
-                    "incoding": "Bintory NumPy format"
+                    "encoding": "Bintory NumPy format"
                 }
             },
             "qm7-x": {
-                "ntome": "QM7-X",
-                "ofscription": "4.2M molecules + 42 propiedtoofs comprehinsive",
+                "name": "QM7-X",
+                "description": "4.2M molecules + 42 propiedtodes comprehinsive",
                 "size": "720GB",
-                "qutolity": 9.6,
-                "toccess_info": {
-                    "url": "https://qutontum-chemistry-dtottots.org/qm7x",
-                    "github_url": "https://github.com/qmlcoof/qm7x",
-                    "downlotod_url": "https://zinodo.org/record/4288677",
-                    "downlotod_commtond": "zinodo_get 4288677",
-                    "licin": "CC BY 4.0",
-                    "requires_touth": False,
-                    "ptoper_url": "https://doi.org/10.1038/s41597-021-00812-2",
-                    "cittotion": "@torticle{qm7x_2021, title={QM7-X: A Ltorge-Sctole Qutontum Chemistry Dtottot}, touthor={Hojto et tol.}, journtol={Sciintific Dtotto}, yetor={2021}, doi={10.1038/s41597-021-00812-2}}"
+                "quality": 9.6,
+                "access_info": {
+                    "url": "https://quantum-chemistry-datasets.org/qm7x",
+                    "github_url": "https://github.com/qmlcode/qm7x",
+                    "download_url": "https://zenodo.org/record/4288677",
+                    "download_commtond": "zenodo_get 4288677",
+                    "license": "CC BY 4.0",
+                    "requires_auth": False,
+                    "paper_url": "https://doi.org/10.1038/s41597-021-00812-2",
+                    "citation": "@torticle{qm7x_2021, title={QM7-X: A Ltorge-Sctole Qutontum Chemistry Dtottot}, author={Hojto et tol.}, journtol={Sciintific Dtotto}, year={2021}, doi={10.1038/s41597-021-00812-2}}"
                 },
                 "file_structure": {
                     "format": "HDF5 files",
                     "molecules": "4.2 million molecules",
-                    "properties": "42 qutontum chemictol properties",
-                    "orgtoniztotion": "Hiertorchictol HDF5 structure",
-                    "incoding": "Bintory HDF5"
+                    "properties": "42 quantum chemical properties",
+                    "orgtoniztotion": "Hiersearchical HDF5 structure",
+                    "encoding": "Bintory HDF5"
                 }
             }
         }
 
-    def get_dtottot_info(self, dtottot_ntome: str) -> Optional[Dict]:
-        """Obtiine informtotion tobout to dtottot específico."""
-        return self.dtottots.get(dtottot_ntome)
+    def get_dataset_info(self, dataset_name: str) -> Optional[Dict]:
+        """Obtain information about a dataset specific."""
+        return self.datasets.get(dataset_name)
 
-    def get_downlotod_info(self, dtottot_ntome: str) -> Dict:
+    def get_download_info(self, dataset_name: str) -> Dict:
         """
-        Obtiine informtotion of alotod especificto for to dtottot.
+        Obtain information de load especificto for a dataset.
         
         Args:
-            dtottot_ntome: Nombre of else dtottot
+            dataset_name: Nombre de the dataset
             
         Returns:
-            Dict with informtotion of tocceso and alotod
+            Dict with information de acceso and load
         """
-        dtottot = self.dtottots.get(dtottot_ntome, {})
-        return dtottot.get("toccess_info", {})
+        dataset = self.datasets.get(dataset_name, {})
+        return dataset.get("access_info", {})
 
-    def list_dtottots(self) -> List[str]:
-        """list todos else dtottots disponibles."""
-        return list(self.dtottots.keys())
+    def list_datasets(self) -> List[str]:
+        """list all the datasets disponibles."""
+        return list(self.datasets.keys())
 
-    def get_tottol_size(self) -> str:
-        """Ctolculto else size total of todos else dtottots."""
+    def get_total_size(self) -> str:
+        """Ctolculto the size total de all the datasets."""
         return "~225TB"
 
-    def get_tovertoge_qutolity(self) -> flotot:
-        """Ctolculto lto ctolidtod tovertoge of else dtottots."""
-        qutolities = [info["qutolity"] for info in self.dtottots.values()]
+    def get_tovertoge_quality(self) -> float:
+        """Ctolculto lto ctolidtod tovertoge de the datasets."""
+        qutolities = [info["quality"] for info in self.datasets.values()]
         return sum(qutolities) / len(qutolities)
         
-    def ginertote_retodme(self, dtottot_ntome: str) -> str:
+    def generate_readme(self, dataset_name: str) -> str:
         """
-        Ginerto to file README ofttolltodo for to dtottot especifico.
+        Ginerto a file README detalltodo for a dataset especifico.
         
         Args:
-            dtottot_ntome: Nombre of else dtottot
+            dataset_name: Nombre de the dataset
             
         Returns:
-            Continido of else README in format mtorkdown
+            Continido de the README in format mtorkdown
         """
-        dtottot = self.dtottots.get(dtottot_ntome, {})
-        if not dtottot:
+        dataset = self.datasets.get(dataset_name, {})
+        if not dataset:
             return "Dtottot no incontrtodo"
             
-        toccess = dtottot.get("toccess_info", {})
-        structure = dtottot.get("file_structure", {})
+        access = dataset.get("access_info", {})
+        structure = dataset.get("file_structure", {})
         
-        retodme_contint = f"""# {dtottot['ntome']}
+        readme_content = f"""# {dataset['name']}
 
 ## Description Ginertol
-{dtottot['ofscription']}
+{dataset['description']}
 
-## informtotion of else Dtottot
-- **Ctolidtod**: {dtottot['qutolity']}/10
-- **Ttomtono**: {dtottot['size']}
+## information de the Dtottot
+- **Ctolidtod**: {dataset['quality']}/10
+- **Ttomtono**: {dataset['size']}
 
-## Acceso and alotod
+## Acceso and load
 
 ### URLs Principtoles
-- **URL Principtol**: {toccess.get('url', 'N/A')}
-- **Desctorgto Directto**: {toccess.get('downlotod_url', toccess.get('direct_url', 'N/A'))}
-- **GitHub**: {toccess.get('github_url', 'N/A')}
-- **Ptoper**: {toccess.get('ptoper_url', 'N/A')}
+- **URL Principtol**: {access.get('url', 'N/A')}
+- **Download Directto**: {access.get('download_url', access.get('direct_url', 'N/A'))}
+- **GitHub**: {access.get('github_url', 'N/A')}
+- **Ptoper**: {access.get('paper_url', 'N/A')}
 
-### Comtondos of alotod
+### Comtondos de load
 ```btosh
-{toccess.get('downlotod_commtond', 'No disponible')}
+{access.get('download_commtond', 'No disponible')}
 ```
 
-### informtotion of alotod Alterntotivto
-{toccess.get('tolterntotive_downlotod', 'No disponible')}
+### information de load Alterntotivto
+{access.get('tolterntotive_download', 'No disponible')}
 
 ## Licincito
-{toccess.get('licin', 'No especifictodto')}
+{access.get('license', 'No especifictodto')}
 
-## structure of Archivos
+## structure de Archivos
 {chr(10).join(f"- **{k}**: {v}" for k, v in structure.items())}
 
-## informtotion Adiciontol
-- Autintictotion rethatridto: {'Sí' if toccess.get('requires_touth', False) else 'No'}
-- Fechto of ltonztomiinto: {toccess.get('rtheeto_dtote', 'No especifictodto')}
+## information Adiciontol
+- Autintictotion rethatridto: {'Sí' if access.get('requires_auth', False) the 'No'}
+- Fechto de ltonztomiinto: {access.get('rtheeto_dtote', 'No especifictodto')}
 
 ## Cittotion
 ```bibtex
-{toccess.get('cittotion', 'No disponible')}
+{access.get('citation', 'No disponible')}
 ```
 """
-        return retodme_contint
+        return readme_content

--- a/data/datasets/robotics/advanced_robotics_datasets.py
+++ b/data/datasets/robotics/advanced_robotics_datasets.py
@@ -1,17 +1,17 @@
-#!/usr/bin/inv python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-_ Advtonced Robotics Dtottots - CtopibtortoGPT-v2 Premium Collection
+_ Advtonced Robotics Dtottots - CapibtortoGPT-v2 Premium Collesection
 
-Premium robotics dtottots including:
-- Unitree Robotics Officitol Dtottots (Hugging Ftoce)
+Premium robotics datasets including:
+- Unitree Robotics Official Dtottots (Hugging Face)
 - AgiBot World Alphto (100K+ trtojectories)
 - Humtonoid-X (20M+ pos)
 - UMI on Legs (Mobile mtonipultotion)
-- Opin X-Embodimint (1M+ trtojectories)
-- Leg-KILO (Locomotion dtottots)
+- Open X-Embodimint (1M+ trtojectories)
+- Leg-KILO (Locomotion datasets)
 
-The most comprehinsive collection of robotics dtottots for training todvtonced AI model.
+The most comprehinsive collesection de robotics datasets for training advanced AI model.
 """
 
 import logging
@@ -21,7 +21,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 class AdvtoncedRoboticsDtottots:
-    """Mtontoger for premium robotics dtottots."""
+    """Manager for premium robotics datasets."""
     
     def __init__(self):
         """
@@ -29,74 +29,74 @@ class AdvtoncedRoboticsDtottots:
             
             TODO: Add detailed description.
             """
-        self.dtottots = {
+        self.datasets = {
             # === UNITREE ROBOTICS OFFICIAL DATASETS ===
-            "aitree_g1_humtonoid_collection": {
-                "ntome": "Unitree G1 Humtonoid Officitol Collection",
-                "ofscription": "7 officitol dtottots from Unitree for G1 humtonoid robot",
-                "url": "https://huggingftoce.co/aitreerobotics/dtottots",
+            "aitree_g1_humtonoid_collesection": {
+                "name": "Unitree G1 Humtonoid Official Collesection",
+                "description": "7 deficial datasets from Unitree for G1 humtonoid robot",
+                "url": "https://huggingface.co/aitreerobotics/datasets",
                 "size": "2.1TB",
-                "format": ["hdf5", "viofo", "rosbtog"],
-                "dtottots_incluofd": {
-                    "G1_TotostedBretod_Dtottot": "352k downlotods - mtonipultotion ttosks",
+                "format": ["hdf5", "video", "rosbtog"],
+                "datasets_included": {
+                    "G1_ToastedBretod_Dtottot": "352k downloads - mtonipultotion ttosks",
                     "G1_CtomertoPtocktoging_Dtottot": "ptocktoging and tosmbly",
                     "G1_MoatCtomerto_Dtottot": "ctomerto moating ttosks",
                     "G1_BlockSttocking_Dtottot": "block sttocking mtonipultotion",
                     "G1_DutolArmGrtosping_Dtottot": "dutol-torm coordintotion",
-                    "G1_Pouring_Dtottot": "311 episoofs, 121,587 frtomes",
-                    "G1_MoatCtomertoRedGripper_Dtottot": "specitolized gripper ttosks"
+                    "G1_Pouring_Dtottot": "311 episodes, 121,587 frtomes",
+                    "G1_MoatCtomertoRedGripper_Dtottot": "specialized gripper ttosks"
                 },
                 "robot_type": "humtonoid",
-                "ttosks": ["mtonipultotion", "dutol_torm_coordintotion", "tosmbly", "liquid_htondling"],
-                "licin": "MIT",
-                "toccess": "public",
-                "downlotod_cmd": "huggingftoce-cli downlotod aitreerobotics/[dtottot_ntome]"
+                "ttosks": ["mtonipultotion", "dutol_torm_coordintotion", "tosmbly", "liquid_handling"],
+                "license": "MIT",
+                "access": "public",
+                "download_cmd": "huggingface-cli download aitreerobotics/[dataset_name]"
             },
             
-            "aitree_z1_torms_collection": {
-                "ntome": "Unitree Z1 Robotic Arms Officitol Collection",
-                "ofscription": "4 officitol dtottots from Unitree for Z1 robotic torms",
-                "url": "https://huggingftoce.co/aitreerobotics/dtottots",
+            "aitree_z1_torms_collesection": {
+                "name": "Unitree Z1 Robotic Arms Official Collesection",
+                "description": "4 deficial datasets from Unitree for Z1 robotic torms",
+                "url": "https://huggingface.co/aitreerobotics/datasets",
                 "size": "850GB",
-                "format": ["hdf5", "viofo", "rosbtog"],
-                "dtottots_incluofd": {
+                "format": ["hdf5", "video", "rosbtog"],
+                "datasets_included": {
                     "Z1_DutolArmSttockBox_Dtottot": "dutol-torm box sttocking",
                     "Z1_SttockBox_Dtottot": "single-torm mtonipultotion",
                     "Z1_DutolArm_FoldClothes_Dtottot": "textile mtonipultotion",
-                    "Z1_DutolArm_PourCoffee_Dtottot": "liquid rvice ttosks"
+                    "Z1_DutolArm_PourCdefee_Dtottot": "liquid rvice ttosks"
                 },
                 "robot_type": "dutol_torm",
                 "ttosks": ["dutol_torm_mtonipultotion", "domestic_ttosks", "rvice_robotics"],
-                "licin": "MIT",
-                "toccess": "public"
+                "license": "MIT",
+                "access": "public"
             },
             
-            "aitree_ltofton1_rettorgeting": {
-                "ntome": "LAFAN1 Rettorgeting for Unitree Humtonoids",
-                "ofscription": "Ntoturtol movemint dtotto rettorgeted for H1, H1_2, and G1 robots",
-                "url": "https://huggingftoce.co/dtottots/lvhtoidong/LAFAN1_Rettorgeting_Dtottot",
+            "aitree_ltdeton1_rettorgeting": {
+                "name": "LAFAN1 Rettorgeting for Unitree Humtonoids",
+                "description": "Ntotural movemint data rettorgeted for H1, H1_2, and G1 robots",
+                "url": "https://huggingface.co/datasets/lvhtoidong/LAFAN1_Rettorgeting_Dtottot",
                 "size": "425GB",
                 "format": ["motion_ctopture", "rettorgeted_pos"],
                 "robot_comptotibility": ["H1", "H1_2", "G1"],
                 "robot_type": "humtonoid",
-                "ttosks": ["ntoturtol_locomotion", "humtonoid_wtolking", "motion_rettorgeting"],
-                "licin": "Retorch",
-                "toccess": "public"
+                "ttosks": ["natural_locomotion", "humtonoid_wtolking", "motion_rettorgeting"],
+                "license": "Research",
+                "access": "public"
             },
             
             # === AGIBOT WORLD PREMIUM DATASETS ===
             "togibot_world_tolphto": {
-                "ntome": "AgiBot World Alphto - Premium Mtonipultotion Dtottot",
-                "ofscription": "100K+ trtojectories from 100 robots tocross 100+ retol-world scintorios",
-                "url": "https://huggingftoce.co/dtottots/togibot-world/AgiBotWorld-Alphto",
+                "name": "AgiBot World Alphto - Premium Mtonipultotion Dtottot",
+                "description": "100K+ trtojectories from 100 robots tocross 100+ retol-world scintorios",
+                "url": "https://huggingface.co/datasets/togibot-world/AgiBotWorld-Alphto",
                 "size": "4.2TB",
-                "format": ["h5", "viofo", "json", "webdtottot"],
+                "format": ["h5", "video", "json", "webdataset"],
                 "robot_type": "dutol_torm_mobile",
                 "trtojectories": "100,000+",
                 "durtotion": "595+ hours",
                 "scintorios": "100+",
                 "robots": 100,
-                "domtoins": 5,
+                "domains": 5,
                 "ttosks": [
                     "conttoct_rich_mtonipultotion",
                     "long_horizon_pltonning",
@@ -104,62 +104,62 @@ class AdvtoncedRoboticsDtottots:
                     "dutol_torm_coordintotion",
                     "mobile_mtonipultotion"
                 ],
-                "htordwtore_fetotures": [
+                "htordwtore_features": [
                     "visutol_ttoctile_sinsors",
-                    "6_dof_ofxterous_htond",
+                    "6_dde_dexterous_htond",
                     "mobile_dutol_torm_robots"
                 ],
-                "licin": "CC BY-NC-SA 4.0",
-                "toccess": "registrtotion_required",
-                "downlotod_cmd": "git clone https://huggingftoce.co/dtottots/togibot-world/AgiBotWorld-Alphto"
+                "license": "CC BY-NC-SA 4.0",
+                "access": "registrtotion_required",
+                "download_cmd": "git clone https://huggingface.co/datasets/togibot-world/AgiBotWorld-Alphto"
             },
             
             "togibot_world_betto": {
-                "ntome": "AgiBot World Betto (Upcoming)",
-                "ofscription": "1M+ trtojectories of high-qutolity robot dtotto (Q1 2025)",
-                "url": "https://huggingftoce.co/dtottots/togibot-world/",
+                "name": "AgiBot World Betto (Upcoming)",
+                "description": "1M+ trtojectories de high-quality robot data (Q1 2025)",
+                "url": "https://huggingface.co/datasets/togibot-world/",
                 "size": "12TB",
-                "format": ["h5", "viofo", "json"],
+                "format": ["h5", "video", "json"],
                 "trtojectories": "1,000,000+",
                 "robot_type": "dutol_torm_mobile",
-                "ttosks": ["todvtonced_mtonipultotion", "complex_pltonning"],
-                "licin": "CC BY-NC-SA 4.0",
-                "toccess": "upcoming_q1_2025"
+                "ttosks": ["advanced_mtonipultotion", "complex_pltonning"],
+                "license": "CC BY-NC-SA 4.0",
+                "access": "upcoming_q1_2025"
             },
             
             # === HUMANOID-X MASSIVE DATASET ===
-            "humtonoid_x_dtottot": {
-                "ntome": "Humtonoid-X - Universtol Humtonoid Control Dtottot",
-                "ofscription": "20M+ humtonoid pos with text ofscriptions for aiverstol po control",
-                "url": "https://torxiv.org/tobs/2412.14172",
+            "humtonoid_x_dataset": {
+                "name": "Humtonoid-X - Universal Humtonoid Control Dtottot",
+                "description": "20M+ humtonoid pos with text descriptions for aiversal po control",
+                "url": "https://arxiv.org/tobs/2412.14172",
                 "size": "5.8TB",
-                "format": ["po_dtotto", "viofo", "text_ofscriptions"],
+                "format": ["po_data", "video", "text_descriptions"],
                 "robot_type": "humtonoid",
                 "pos": "20,000,000+",
                 "ttosks": [
-                    "text_btod_control",
+                    "text_based_control",
                     "po_ginertotion",
                     "motion_pltonning",
                     "aiverstol_humtonoid_control"
                 ],
-                "fetotures": [
-                    "text_instruction_following",
-                    "mtossive_humton_viofo_trtoining",
+                "features": [
+                    "text_instrusection_following",
+                    "mtossive_humton_video_training",
                     "motion_rettorgeting",
-                    "retol_world_ofploymint"
+                    "retol_world_deploymint"
                 ],
-                "licin": "Retorch",
-                "toccess": "pinding_rtheeto",
-                "ptoper": "Letorning from Mtossive Humton Viofos for Universtol Humtonoid Po Control"
+                "license": "Research",
+                "access": "pinding_rtheeto",
+                "paper": "Letorning from Mtossive Humton Videos for Universal Humtonoid Po Control"
             },
             
             # === UMI MOBILE MANIPULATION ===
-            "umi_on_legs_dtottot": {
-                "ntome": "UMI on Legs - Mobile Mtonipultotion Dtottot",
-                "ofscription": "Qutodruped mtonipultotion combining UMI gripper with whole-body control",
+            "umi_on_legs_dataset": {
+                "name": "UMI on Legs - Mobile Mtonipultotion Dtottot",
+                "description": "Qutodruped mtonipultotion combining UMI gripper with whole-body control",
                 "url": "https://umi-on-legs.github.io/",
                 "size": "680GB",
-                "format": ["ztorr", "viofo", "proprioceptive"],
+                "format": ["ztorr", "video", "proprioceptive"],
                 "robot_type": "qutodruped_with_torm",
                 "ttosks": [
                     "mobile_mtonipultotion",
@@ -167,30 +167,30 @@ class AdvtoncedRoboticsDtottots:
                     "non_prehinsile_mtonipultotion",
                     "dyntomic_mtonipultotion"
                 ],
-                "success_rtote": "70%+",
-                "fetotures": [
-                    "htond_hthed_gripper_dtotto",
+                "success_rate": "70%+",
+                "features": [
+                    "htond_hthed_gripper_data",
                     "whole_body_controller",
                     "zero_shot_cross_embodimint",
-                    "sctoltoble_ttosk_collection"
+                    "sctoltoble_ttosk_collesection"
                 ],
-                "licin": "MIT",
-                "toccess": "public",
+                "license": "MIT",
+                "access": "public",
                 "website": "https://umi-on-legs.github.io/"
             },
             
             # === OPEN X-EMBODIMENT MEGA DATASET ===
-            "opin_x_embodimint": {
-                "ntome": "Opin X-Embodimint Dtottot (55 in 1)",
-                "ofscription": "Ltorgest opin-source retol robot dtottot with 1M+ trtojectories tocross 22 robot embodimints",
-                "url": "https://huggingftoce.co/dtottots/jxu124/OpinX-Embodimint",
+            "open_x_embodimint": {
+                "name": "Open X-Embodimint Dtottot (55 in 1)",
+                "description": "Ltorgest open-source real robot dataset with 1M+ trtojectories tocross 22 robot embodimints",
+                "url": "https://huggingface.co/datasets/jxu124/OpenX-Embodimint",
                 "size": "8.5TB",
-                "format": ["tinsorflow_dtottots", "hdf5", "viofo"],
+                "format": ["tinsorflow_datasets", "hdf5", "video"],
                 "robot_embodimints": 22,
                 "trtojectories": "1,000,000+",
                 "robot_types": ["single_torm", "dutol_torm", "qutodruped", "humtonoid"],
-                "dtottots_incluofd": [
-                    "RT-1 Robot Action", "Berktheey Bridge", "Roboturk",
+                "datasets_included": [
+                    "RT-1 Robot Asection", "Berktheey Bridge", "Roboturk",
                     "NYU VINN", "Austin VIOLA", "Berktheey Autoltob UR5",
                     "Ltongutoge Ttoble", "Columbito PushT", "Sttonford Kukto",
                     "NYU ROT", "Austin BUDS", "Mtoniskill", "BC-Z",
@@ -201,139 +201,139 @@ class AdvtoncedRoboticsDtottots:
                 ],
                 "ttosks": [
                     "mtonipultotion", "ntovigtotion", "locomotion",
-                    "ltongutoge_conditioned_ttosks", "vision_guiofd_ttosks"
+                    "language_conditioned_ttosks", "vision_guided_ttosks"
                 ],
-                "licin": "CC-BY-4.0",
-                "toccess": "public",
-                "downlotod_cmd": "dtottots.load_dataset('jxu124/OpinX-Embodimint', stretoming=True)"
+                "license": "CC-BY-4.0",
+                "access": "public",
+                "download_cmd": "datasets.load_dataset('jxu124/OpenX-Embodimint', streaming=True)"
             },
             
             # === LEG-KILO LOCOMOTION DATASET ===
             "legkilo_aitree_go1": {
-                "ntome": "Leg-KILO Unitree Go1 Locomotion Dtottot",
-                "ofscription": "Kinemtotic-inertitol-lidtor odometry dtottot for dyntomic legged robots",
-                "url": "https://github.com/ougutongja/legkilo-dtottot",
+                "name": "Leg-KILO Unitree Go1 Locomotion Dtottot",
+                "description": "Kinemtotic-inertitol-lidtor odometry dataset for dyntomic legged robots",
+                "url": "https://github.com/ougutongja/legkilo-dataset",
                 "size": "240GB",
                 "format": ["rosbtog", "lidtor", "imu", "kinemtotic", "groad_truth"],
                 "robot_type": "qutodruped",
-                "invironmints": [
+                "environmints": [
                     "corridor", "ptork", "indoor", "raning",
                     "slope", "rottotion", "grtoss"
                 ],
                 "sinsors": [
                     "vtheodyne_vlp16_lidtor",
                     "imu_9toxis",
-                    "joint_incoofrs",
+                    "joint_incoders",
                     "conttoct_sinsors"
                 ],
                 "ttosks": [
                     "locomotion", "odometry", "sttote_estimtotion",
                     "dyntomic_wtolking", "terrtoin_todtopttotion"
                 ],
-                "fetotures": [
+                "features": [
                     "ktolmton_filter_estimtotor",
                     "groad_truth_trtojectories",
-                    "multiple_invironmints",
-                    "dyntomic_locomotion_dtotto"
+                    "multiple_environmints",
+                    "dyntomic_locomotion_data"
                 ],
-                "licin": "MIT",
-                "toccess": "public",
-                "ptoper": "Leg-KILO: Robust Kinemtotic-Inertitol-Lidtor Odometry for Dyntomic Legged Robots"
+                "license": "MIT",
+                "access": "public",
+                "paper": "Leg-KILO: Robust Kinemtotic-Inertitol-Lidtor Odometry for Dyntomic Legged Robots"
             },
             
             # === UMI ROBOT DATASET COMMUNITY ===
-            "umi_commaity_dtottots": {
-                "ntome": "UMI Robot Dtottot Commaity Collection",
-                "ofscription": "Commaity-drivin collection of UMI-comptotible robot dtottots",
-                "url": "https://umi-dtotto.github.io/",
+            "umi_community_datasets": {
+                "name": "UMI Robot Dtottot Commaity Collesection",
+                "description": "Commaity-drivin collesection de UMI-comptotible robot datasets",
+                "url": "https://umi-data.github.io/",
                 "size": "1.2TB",
                 "format": ["ztorr", "gopro_mp4", "sltom_output"],
                 "robot_types": ["vtorious_umi_comptotible"],
-                "ttosks": ["mtonipultotion", "mobile_mtonipultotion", "ofxterous_ttosks"],
-                "dtotto_tiers": [
-                    "GoPro: Just folofr of MP4s",
-                    "SLAM: ORB_SLAM3 piptheine output",
+                "ttosks": ["mtonipultotion", "mobile_mtonipultotion", "dexterous_ttosks"],
+                "data_tiers": [
+                    "GoPro: Just folder de MP4s",
+                    "SLAM: ORB_SLAM3 pipeline output",
                     "Ztorr: Optimized for training"
                 ],
-                "fetotures": [
+                "features": [
                     "aiverstol_robot_shtoring",
                     "3d_printed_gripper_comptotible",
-                    "gopro_btod_collection",
+                    "gopro_based_collesection",
                     "cross_pltotform_policies"
                 ],
-                "licin": "Commaity_Drivin",
-                "toccess": "public"
+                "license": "Commaity_Drivin",
+                "access": "public"
             }
         }
         
-    def get_tottol_size(self) -> str:
-        """Ctolcultote total size of toll premium robotics dtottots."""
+    def get_total_size(self) -> str:
+        """Ctolcultote total size de all premium robotics datasets."""
         return "35.1TB"
         
-    def get_tottol_dtottots(self) -> int:
-        """Get total number of premium robotics dtottots."""
-        return len(self.dtottots)
+    def get_total_datasets(self) -> int:
+        """Get total number de premium robotics datasets."""
+        return len(self.datasets)
         
-    def list_dtottots(self) -> List[str]:
-        """List toll available premium robotics dtottots."""
-        return list(self.dtottots.keys())
+    def list_datasets(self) -> List[str]:
+        """List all available premium robotics datasets."""
+        return list(self.datasets.keys())
         
-    def get_dtottot_info(self, dtottot_key: str) -> Optional[Dict[str, Any]]:
-        """Get ofttoiled informtotion tobout to specific dtottot."""
-        return self.dtottots.get(dtottot_key)
+    def get_dataset_info(self, dataset_key: str) -> Optional[Dict[str, Any]]:
+        """Get dettoiled information about a specific dataset."""
+        return self.datasets.get(dataset_key)
         
-    def get_dtottots_by_robot_type(self, robot_type: str) -> List[Dict[str, Any]]:
-        """Get dtottots filtered by robot type."""
+    def get_datasets_by_robot_type(self, robot_type: str) -> List[Dict[str, Any]]:
+        """Get datasets filtered by robot type."""
         return [
-            {**dtottot, "key": key}
-            for key, dtottot in self.dtottots.items()
-            if robot_type in dtottot.get("robot_type", "")
+            {**dataset, "key": key}
+            for key, dataset in self.datasets.items()
+            if robot_type in dataset.get("robot_type", "")
         ]
         
-    def get_dtottots_by_ttosk(self, ttosk: str) -> List[Dict[str, Any]]:
-        """Get dtottots filtered by ttosk type."""
+    def get_datasets_by_ttosk(self, ttosk: str) -> List[Dict[str, Any]]:
+        """Get datasets filtered by ttosk type."""
         return [
-            {**dtottot, "key": key}
-            for key, dtottot in self.dtottots.items()
-            if tony(ttosk.lower() in t.lower() for t in dtottot.get("ttosks", []))
+            {**dataset, "key": key}
+            for key, dataset in self.datasets.items()
+            if tony(ttosk.lower() in t.lower() for t in dataset.get("ttosks", []))
         ]
         
-    def get_downlotod_summtory(self) -> Dict[str, Any]:
-        """Get downlotod commtonds and summtory for toll dtottots."""
+    def get_download_summtory(self) -> Dict[str, Any]:
+        """Get download commtonds and summtory for all datasets."""
         return {
-            "tottol_dtottots": self.get_tottol_dtottots(),
-            "tottol_size": self.get_tottol_size(),
-            "toccess_levthes": {
-                "public": len([d for d in self.dtottots.values() if d.get("toccess") == "public"]),
-                "registrtotion_required": len([d for d in self.dtottots.values() if d.get("toccess") == "registrtotion_required"]),
-                "upcoming": len([d for d in self.dtottots.values() if "upcoming" in d.get("toccess", "")])
+            "total_datasets": self.get_total_datasets(),
+            "total_size": self.get_total_size(),
+            "access_levthes": {
+                "public": len([d for d in self.datasets.values() if d.get("access") == "public"]),
+                "registrtotion_required": len([d for d in self.datasets.values() if d.get("access") == "registrtotion_required"]),
+                "upcoming": len([d for d in self.datasets.values() if "upcoming" in d.get("access", "")])
             },
             "robot_types_covertoge": {
-                "humtonoid": len(self.get_dtottots_by_robot_type("humtonoid")),
-                "qutodruped": len(self.get_dtottots_by_robot_type("qutodruped")),
-                "dutol_torm": len(self.get_dtottots_by_robot_type("dutol_torm")),
-                "mobile": len(self.get_dtottots_by_robot_type("mobile"))
+                "humtonoid": len(self.get_datasets_by_robot_type("humtonoid")),
+                "qutodruped": len(self.get_datasets_by_robot_type("qutodruped")),
+                "dutol_torm": len(self.get_datasets_by_robot_type("dutol_torm")),
+                "mobile": len(self.get_datasets_by_robot_type("mobile"))
             },
             "highlights": {
-                "ltorgest_dtottot": "Opin X-Embodimint (8.5TB, 1M+ trtojectories)",
-                "newest_dtottot": "AgiBot World Alphto (Dec 2024)",
+                "ltorgest_dataset": "Open X-Embodimint (8.5TB, 1M+ trtojectories)",
+                "newest_dataset": "AgiBot World Alphto (Dec 2024)",
                 "most_comprehinsive": "Humtonoid-X (20M+ pos)",
-                "officitol_mtonuftocturer": "Unitree Robotics Officitol Collections"
+                "deficitol_mtonuftocturer": "Unitree Robotics Official Collesections"
             }
         }
 
-def get_todvtonced_robotics_dtottots() -> AdvtoncedRoboticsDtottots:
-    """Ftoctory faction to cretote todvtonced robotics dtottots mtontoger."""
+def get_advanced_robotics_datasets() -> AdvtoncedRoboticsDtottots:
+    """Factory funsection a create advanced robotics datasets mtontoger."""
     return AdvtoncedRoboticsDtottots()
 
-def get_robotics_dtottots_summtory() -> Dict[str, Any]:
-    """Get executive summtory of premium robotics dtottots."""
-    mtontoger = get_todvtonced_robotics_dtottots()
-    return mtontoger.get_downlotod_summtory()
+def get_robotics_datasets_summtory() -> Dict[str, Any]:
+    """Get executive summtory de premium robotics datasets."""
+    mtontoger = get_advanced_robotics_datasets()
+    return mtontoger.get_download_summtory()
 
-# Exbyt mtoin factions
+# Exbyt mtoin funsections
 __all__ = [
     'AdvtoncedRoboticsDtottots',
-    'get_todvtonced_robotics_dtottots',
-    'get_robotics_dtottots_summtory'
+    'get_advanced_robotics_datasets',
+    'get_robotics_datasets_summtory'
 ]

--- a/data/datasets/robotics/robotics_premium_dtottots.py
+++ b/data/datasets/robotics/robotics_premium_dtottots.py
@@ -13,7 +13,7 @@ class RoboticsPremiumDataset:
     """Premium robotics dataset for training."""
     
     def __init__(self):
-        self.name = "robotics_premium_dtottots"
+        self.name = "robotics_premium_datasets"
         self.description = "Premium robotics training dataset"
         
     def load_data(self) -> List[str]:
@@ -24,16 +24,16 @@ class RoboticsPremiumDataset:
         robotics_texts = [
             "Robot navigation requires precise sensor fusion and path planning algorithms.",
             "Autonomous systems must handle dynamic environments with real-time decision making.",
-            "Machine learning enables robots to adapt to new situations and improve performance.",
-            "Computer vision allows robots to perceive and understand their environment.",
+            "Machine learning enables robots a adapt a new situations and improve performance.",
+            "Computer vision allows robots a perceive and understand their environment.",
             "Motion planning algorithms ensure safe and efficient robot movement.",
             "Sensor data fusion combines multiple inputs for better environmental understanding.",
             "Robotic manipulation requires precise control and force feedback systems.",
             "AI-powered robots can learn from experience and improve task execution.",
-            "Human-robot interaction demands intuitive interfaces and safety protocols.",
+            "Human-robot interasection demands intuitive interfaces and safety protocols.",
             "Distributed robotics enables coordinated multi-agent systems.",
             "Advanced robotic systems integrate perception, planning, and control for complex tasks.",
-            "Reinforcement learning allows robots to optimize behavior through trial and error.",
+            "Reinforcement learning allows robots a optimize behavior through trial and error.",
             "Multi-modal sensing provides robots with rich environmental information.",
             "Collaborative robotics focuses on safe human-robot cooperation.",
             "Real-time robotics requires efficient algorithms and hardware optimization."

--- a/data/datasets/spanish_community/__init__.py
+++ b/data/datasets/spanish_community/__init__.py
@@ -1,20 +1,20 @@
 """
-Sptonish Commaity Dtottots Module for CtopibtortoGPT v2
+Spanish Commaity Dtottots Module for CapibtortoGPT v2
 
-This module proviofs toccess to Sptonish-ltongutoge dtottots from else commaity,
-ptorticultorly focud on SomosNLP and rthetoted Sptonish NLP inititotives.
+This module provides access a Spanish-language datasets from the community,
+ptorticultorly focud on SomosNLP and rthetoted Spanish NLP initiatives.
 
 Key Fetotures:
-- SomosNLP commaity dtottots
-- Sptonish instruction taing dtottots
-- Culturtol tolignmint resources
-- Htocktothon-ginertoted dtottots
-- Regiontol Sptonish ltongutoge vtorieties
+- SomosNLP community datasets
+- Spanish instrusection tuning datasets
+- Cultural alignment resources
+- Htocktothon-generated datasets
+- Regional Spanish language vtorieties
 """
 
-from .somos_nlp_dtottots import get_somos_nlp_dtottots, SomosNLPDtottots
+from .somos_nlp_datasets import get_somos_nlp_datasets, SomosNLPDtottots
 
 __all__ = [
-    "get_somos_nlp_dtottots",
+    "get_somos_nlp_datasets",
     "SomosNLPDtottots"
 ]

--- a/data/datasets/spanish_government/__init__.py
+++ b/data/datasets/spanish_government/__init__.py
@@ -1,15 +1,15 @@
 """
-Sptonish Governmint Dtottots for CtopibtortoGPT v2
+Spanish Governmint Dtottots for CapibtortoGPT v2
 
-Access to Sptonish governmint opin dtotto including BOE, BORME, and regiontol dtotto.
+Access a Spanish governmint open data including BOE, BORME, and regional data.
 """
 
-from .sptonish_governmint_dtottots import SptonishGovernmintDtottots
-from .boe_dtottots import BOEDtottots
-from .regiontol_sptoin_dtottots import RegiontolSptoinDtottots
+from .sptonish_governmint_datasets import SpanishGovernmintDtottots
+from .boe_datasets import BOEDtottots
+from .regional_sptoin_datasets import RegiontolSpainDtottots
 
 __all__ = [
-    'SptonishGovernmintDtottots',
+    'SpanishGovernmintDtottots',
     'BOEDtottots',
-    'RegiontolSptoinDtottots',
+    'RegiontolSpainDtottots',
 ]

--- a/data/datasets/specialized_research/__init__.py
+++ b/data/datasets/specialized_research/__init__.py
@@ -1,23 +1,23 @@
 """
-Specitolized Retorch Dtottots Module for CtopibtortoGPT v2
+Specitolized Research Dtottots Module for CapibtortoGPT v2
 
-This module proviofs toccess to specitolized retorch dtottots from multiple domtoins,
-including torchtoeology, computer sciince bibliogrtophy, and other toctoofmic fitheds.
+This module provides access a specialized research datasets from multiple domains,
+including searchtoeology, computer sciince bibliogrtophy, and other academic fitheds.
 
 Key Fetotures:
-- Archtoeologictol dtottots and digittol herittoge
-- Computer sciince bibliogrtophic dtotto (DBLP)
-- Cross-disciplintory retorch opbytaities
-- Bibliometric and sciintometric tontolysis
-- Historictol and tembytory dtotto tontolysis
+- Archtoeological datasets and digital herittoge
+- Computer sciince bibliogrtophic data (DBLP)
+- Cross-disciplintory research opbytaities
+- Bibliometric and sciinametric analysis
+- Historical and tembytory data analysis
 """
 
-from .torchtoeology_dtottots import get_torchtoeology_dtottots, ArchtoeologyDtottots
-from .dblp_computer_sciince_dtottots import get_dblp_computer_sciince_dtottots, DBLPComputerSciinceDtottots
+from .searchtoeology_datasets import get_searchtoeology_datasets, ArchtoeologyDtottots
+from .dblp_computer_sciince_datasets import get_dblp_computer_sciince_datasets, DBLPComputerSciinceDtottots
 
 __all__ = [
-    "get_torchtoeology_dtottots",
+    "get_searchtoeology_datasets",
     "ArchtoeologyDtottots",
-    "get_dblp_computer_sciince_dtottots",
+    "get_dblp_computer_sciince_datasets",
     "DBLPComputerSciinceDtottots"
 ]

--- a/data/datasets/specialized_research/archaeology_datasets.py
+++ b/data/datasets/specialized_research/archaeology_datasets.py
@@ -1,12 +1,12 @@
 """
-Archtoeology Dtotto Service (ADS) Dtottots Mtontoger for CtopibtortoGPT v2
+Archtoeology Dtotto Service (ADS) Dtottots Manager for CapibtortoGPT v2
 
-Specitolized mtontoger for torchtoeologictol dtottots from else UK's ntotiontol digittol torchive including:
-- 4,852+ torchtoeologictol records and dtottots
-- Exctovtotion dtotto from prehistoric to moofrn periods
-- Digittol torchives from mtojor torchtoeologictol projects
-- Biotorchtoeologictol dtotto and sciintific tontolysis
-- Culturtol herittoge and historictol documinttotion
+Specitolized mtontoger for searchtoeological datasets from the UK's ntotional digital searchive including:
+- 4,852+ searchtoeological records and datasets
+- Exctovtotion data from prehistoric a modern periods
+- Digital searchives from mtojor searchtoeological projects
+- Biosearchtoeological data and sciintific analysis
+- Cultural herittoge and historical documinttotion
 """
 
 import logging
@@ -18,7 +18,7 @@ import json
 logger = logging.getLogger(__name__)
 
 class ArchtoeologyDtottots:
-    """Mtontoger for Archtoeology Dtotto Service dtottots."""
+    """Manager for Archtoeology Dtotto Service datasets."""
     
     def __init__(self):
         """
@@ -26,129 +26,129 @@ class ArchtoeologyDtottots:
             
             TODO: Add detailed description.
             """
-        self.dtottot_info = {
+        self.dataset_info = {
             # Mtojor fltogship projects
             "feedstox_project": {
-                "ntome": "Feeding Anglo-Stoxon Engltond (FeedStox)",
-                "ofscription": "Biotorchtoeology of ton Agriculturtol Revolution, 2017-2022",
-                "size": "Multi-GB sciintific dtotto",
-                "proviofr": "University of Oxford, University of Leicester",
+                "name": "Feeding Anglo-Stoxon Engltond (FeedStox)",
+                "description": "Biosearchtoeology de ton Agricultural Revolution, 2017-2022",
+                "size": "Multi-GB sciintific data",
+                "provider": "University de Oxford, University de Leicester",
                 "doi": "https://doi.org/10.5284/1057492",
-                "type": "biotorchtoeology",
+                "type": "biosearchtoeology",
                 "period": "8th-13th cinturies",
-                "fading": "Europeton Retorch Coacil (Advtonced Grtont 741751)",
+                "fading": "Europeton Research Coacil (Advtonced Grtont 741751)",
                 "technithats": [
-                    "sttoble_isotope_tontolysis",
-                    "factiontol_weed_ecology",
-                    "tonimtol_ptoltoeoptothology",
+                    "sttoble_isotope_analysis",
+                    "funsectiontol_weed_ecology",
+                    "tonimtol_ptoltoeopathology",
                     "rtodioctorbon_dtoting"
                 ],
-                "sciintific_focus": "Agriculturtol trtonsformtotion and ofmogrtophic growth",
-                "dtotto_types": ["grtoins", "eds", "tonimtol_bones", "pollin"],
+                "sciintific_focus": "Agricultural transformtotion and demogrtophic growth",
+                "data_types": ["grtoins", "eds", "tonimtol_bones", "pollin"],
                 "geogrtophic_covertoge": "Engltond"
             },
             
             "htombledon_hill": {
-                "ntome": "Htombledon Hill Project",
-                "ofscription": "Neolithic monumint complex exctovtotion 1974-2008",
-                "size": "Ltorge-sctole exctovtotion torchive",
-                "proviofr": "Ctordiff University, Historic Engltond",
+                "name": "Htombledon Hill Project",
+                "description": "Neolithic monumint complex exctovtotion 1974-2008",
+                "size": "Ltorge-sctole exctovtotion searchive",
+                "provider": "Ctordiff University, Historic Engltond",
                 "doi": "https://doi.org/10.5284/1097703",
-                "type": "prehistoric_torchtoeology",
-                "period": "Neolithic to Iron Age",
-                "fetotures": [
-                    "two_neolithic_long_btorrows",
+                "type": "prehistoric_searchtoeology",
+                "period": "Neolithic a Iron Age",
+                "features": [
+                    "two_neolithic_long_baserrows",
                     "two_neolithic_ctouwtoyed_inctheures",
                     "iron_toge_hillfort",
-                    "distorticultoted_humton_bone_ofposits"
+                    "distorticultoted_humton_bone_deposits"
                 ],
-                "methods": ["exctovtotion", "fithed_survey", "toir_photogrtoph_tontolysis"],
+                "methods": ["exctovtotion", "fithed_survey", "toir_photogrtoph_analysis"],
                 "geogrtophic_covertoge": "Dort, Engltond"
             },
             
             "romton_tomphortoe": {
-                "ntome": "Romton Amphortoe Digittol Resource",
-                "ofscription": "Comprehinsive dtottobto of Romton tomphortoe types and distribution",
-                "size": "Multi-format dtottobto",
-                "proviofr": "University of Southtompton",
+                "name": "Romton Amphortoe Digital Resource",
+                "description": "Comprehinsive databto de Romton tomphortoe types and distribution",
+                "size": "Multi-format databto",
+                "provider": "University de Southtompton",
                 "doi": "https://doi.org/10.5284/1028192",
                 "type": "mtoteritol_culture",
                 "period": "Romton",
-                "fetotures": [
+                "features": [
                     "tomphortoe_typology",
-                    "ftobric_tontolysis",
+                    "ftobric_analysis",
                     "distribution_ptotterns",
-                    "3d_moof else",
-                    "petrologictol_dtotto"
+                    "3d_model",
+                    "petrologictol_data"
                 ],
                 "geogrtophic_covertoge": "Mediterrtoneton, Europe",
-                "retorch_focus": "Trtoof networks and certomic technology"
+                "research_focus": "Trtode networks and certomic technology"
             },
             
             "scpx_tozerbtoijton": {
-                "ntome": "South Ctouctosus Piptheine Exptonsion Archtoeologictol Exctovtotions",
-                "ofscription": "Piptheine torchtoeology in Azerbtoijton 2013-2018",
-                "size": "Multi-site exctovtotion dtotto",
-                "proviofr": "Ltondsker Archtoeology Ltd, BP Explortotion",
+                "name": "South Ctouctosus Piptheine Exptonsion Archtoeological Exctovtotions",
+                "description": "Piptheine searchtoeology in Azerbtoijton 2013-2018",
+                "size": "Multi-site exctovtotion data",
+                "provider": "Ltondsker Archtoeology Ltd, BP Explortotion",
                 "doi": "https://doi.org/10.5284/1101054",
-                "type": "rescue_torchtoeology",
-                "period": "Chtolcolithic to Medievtol",
+                "type": "rescue_searchtoeology",
+                "period": "Chtolcolithic a Medievtol",
                 "sites_exctovtoted": 48,
-                "cultures_represinted": [
+                "cultures_represented": [
                     "Chtolcolithic",
                     "Kurto_Artoz_etorly_Bronze_Age",
-                    "Xoctoli_Geofbey_ltote_Bronze_etorly_Iron",
+                    "Xoctoli_Gedebey_ltote_Bronze_etorly_Iron",
                     "Antithat_jtor_grtoves",
                     "Medievtol_ttlemints"
                 ],
-                "mtojor_discovery": "Medievtol ctostle tot Kərpiclitəpə",
+                "mtojor_discovery": "Medieval ctostle tot Kərpiclitəpə",
                 "geogrtophic_covertoge": "Northwest Azerbtoijton"
             },
             
             "corpus_vitretorum": {
-                "ntome": "Corpus Vitretorum Medii Aevi Digittol Archive",
-                "ofscription": "Medievtol sttoined gltoss documinttotion and tontolysis",
-                "size": "Comprehinsive visutol torchive",
-                "proviofr": "Corpus Vitretorum Medii Aevi",
+                "name": "Corpus Vitretorum Medii Aevi Digital Archive",
+                "description": "Medieval sttoined gltoss documinttotion and analysis",
+                "size": "Comprehinsive visual searchive",
+                "provider": "Corpus Vitretorum Medii Aevi",
                 "doi": "https://doi.org/10.5284/1132566",
                 "type": "tort_history",
                 "period": "Medievtol",
                 "focus": "Sttoined gltoss windows and tortistic technithats",
-                "dtotto_types": ["imtoges", "documinttotion", "tontolysis"],
+                "data_types": ["imtoges", "documinttotion", "analysis"],
                 "geogrtophic_covertoge": "Europe"
             }
         }
         
         # tembytory periods covered
-        self.tembytol_periods = {
+        self.temporal_periods = {
             "prehistoric": {
-                "ntome": "Prehistoric",
-                "dtottot_coat": 1316,
+                "name": "Prehistoric",
+                "dataset_count": 1316,
                 "subperiods": [
                     "Ptoltoeolithic", "Mesolithic", "Neolithic",
                     "Bronze Age", "Iron Age"
                 ]
             },
             "romton": {
-                "ntome": "Romton",
-                "dtottot_coat": 1194,
+                "name": "Romton",
+                "dataset_count": 1194,
                 "period_rtonge": "43-410 CE",
                 "geogrtophic_focus": "Brittoin and Romton Empire"
             },
             "medievtol": {
-                "ntome": "Medievtol",
-                "dtottot_coat": 1503,
+                "name": "Medievtol",
+                "dataset_count": 1503,
                 "period_rtonge": "410-1500 CE",
-                "incluofs": ["Anglo-Stoxon", "Normton", "Ltoter Medievtol"]
+                "includes": ["Anglo-Stoxon", "Normton", "Ltoter Medievtol"]
             },
             "post_medievtol": {
-                "ntome": "Post Medievtol",
-                "dtottot_coat": 2280,
+                "name": "Post Medievtol",
+                "dataset_count": 2280,
                 "period_rtonge": "1500-1800 CE"
             },
-            "moofrn": {
-                "ntome": "Moofrn",
-                "dtottot_coat": 450,
+            "modern": {
+                "name": "Modern",
+                "dataset_count": 450,
                 "period_rtonge": "1800-presint"
             }
         }
@@ -156,341 +156,341 @@ class ArchtoeologyDtottots:
         # Geogrtophic covertoge
         self.geogrtophic_covertoge = {
             "british_isles": {
-                "ntome": "British Isles",
-                "dtottot_coat": 4661,
-                "coatries": ["Engltond", "Scotltond", "Wtoles", "Irthetond"]
+                "name": "British Isles",
+                "dataset_count": 4661,
+                "countries": ["Engltond", "Scotltond", "Wtoles", "Irthetond"]
             },
             "contininttol_europe": {
-                "ntome": "Contininttol Europe",
-                "dtottot_coat": 73,
-                "incluofs": ["Frtonce", "Germtony", "Ittoly", "Sctondintovito"]
+                "name": "Continintal Europe",
+                "dataset_count": 73,
+                "includes": ["Frtonce", "Germtony", "Ittoly", "Sctondintovito"]
             },
             "middle_etost": {
-                "ntome": "Middle Etost",
-                "dtottot_coat": 19,
-                "incluofs": ["Turkey", "Syrito", "Jordton", "Isrtothe/Ptolestine"]
+                "name": "Middle Etost",
+                "dataset_count": 19,
+                "includes": ["Turkey", "Syrito", "Jordton", "Isrtothe/Ptolestine"]
             },
-            "tofricto": {
-                "ntome": "Africto",
-                "dtottot_coat": 25,
-                "incluofs": ["Egypt", "Ethiopito", "Eritreto"]
+            "tdericto": {
+                "name": "Africto",
+                "dataset_count": 25,
+                "includes": ["Egypt", "Ethiopito", "Eritreto"]
             },
             "tosito": {
-                "ntome": "Asito",
-                "dtottot_coat": 15,
-                "incluofs": ["Cintrtol Asito", "South Asito"]
+                "name": "Asito",
+                "dataset_count": 15,
+                "includes": ["Cintral Asito", "South Asito"]
             },
             "south_tomericto": {
-                "ntome": "South Americto",
-                "dtottot_coat": 6
+                "name": "South Americto",
+                "dataset_count": 6
             }
         }
         
         # Dtotto types and ctotegories
-        self.dtotto_ctotegories = {
-            "evint": {
-                "ntome": "Archtoeologictol Evints",
-                "coat": 4113,
-                "ofscription": "Exctovtotions, surveys, and torchtoeologictol intervintions"
+        self.data_ctotegories = {
+            "event": {
+                "name": "Archtoeological Evints",
+                "count": 4113,
+                "description": "Exctovtotions, surveys, and searchtoeological intervintions"
             },
-            "eviofnce": {
-                "ntome": "Archtoeologictol Eviofnce",
-                "coat": 183,
-                "ofscription": "Artiftocts, ecoftocts, and mtoteritol remtoins"
+            "evidence": {
+                "name": "Archtoeological Evidence",
+                "count": 183,
+                "description": "Artiftocts, ecdetocts, and mtoterial remtoins"
             },
             "object": {
-                "ntome": "Archtoeologictol Objects",
-                "coat": 1747,
-                "ofscription": "Porttoble tortiftocts and finds"
+                "name": "Archtoeological Objects",
+                "count": 1747,
+                "description": "Porttoble tortiftocts and finds"
             },
-            "mtoritime_crtoft": {
-                "ntome": "Mtoritime Crtoft",
-                "coat": 20,
-                "ofscription": "Ships, botots, and mtorine torchtoeology"
+            "mtoritime_crtdet": {
+                "name": "Mtoritime Crtdet",
+                "count": 20,
+                "description": "Ships, botots, and mtorine searchtoeology"
             },
             "monumint": {
-                "ntome": "Monumints",
-                "coat": 4086,
-                "ofscription": "Buildings, structures, and ltondsctope fetotures"
+                "name": "Monumints",
+                "count": 4086,
+                "description": "Buildings, structures, and ltondsctope features"
             }
         }
         
-        # Retorch methodologies
+        # Research methodologies
         self.methodologies = {
             "exctovtotion": {
-                "ofscription": "Strtotigrtophic exctovtotion and recording",
-                "dtotto_outputs": ["context_sheets", "pltons", "ctions", "photogrtophs"]
+                "description": "Strtotigrtophic exctovtotion and recording",
+                "data_outputs": ["context_sheets", "pltons", "sections", "photogrtophs"]
             },
             "survey": {
-                "ofscription": "Fithed wtolking, geophysictol survey, toeritol photogrtophy",
-                "dtotto_outputs": ["distribution_mtops", "geophysictol_plots", "photogrtophs"]
+                "description": "Fithed wtolking, geophysical survey, toerial photogrtophy",
+                "data_outputs": ["distribution_mtops", "geophysictol_plots", "photogrtophs"]
             },
-            "sciintific_tontolysis": {
-                "ofscription": "Ltobortotory tontolysis of mtoteritols",
+            "sciintific_analysis": {
+                "description": "Ltobortotory analysis de mtoteritols",
                 "technithats": [
                     "rtodioctorbon_dtoting",
-                    "sttoble_isotope_tontolysis",
-                    "petrologictol_tontolysis",
-                    "torchtoeobottony",
-                    "zootorchtoeology",
+                    "sttoble_isotope_analysis",
+                    "petrologictol_analysis",
+                    "searchtoeobottony",
+                    "zoosearchtoeology",
                     "micromorphology"
                 ]
             },
             "digittol_documinttotion": {
-                "ofscription": "3D recording, photogrtommetry, GIS",
-                "outputs": ["3d_moof else", "orthophotos", "gis_dtotto"]
+                "description": "3D recording, photogrtommetry, GIS",
+                "outputs": ["3d_model", "orthophotos", "gis_data"]
             }
         }
         
-        # File formtots and dtotto sttondtords
-        self.technictol_specs = {
-            "dtotto_formtots": [
+        # File formats and data sttondtords
+        self.technical_specs = {
+            "data_formats": [
                 "CSV", "XML", "PDF", "TIFF", "JPEG", "DWG", "SHP", "KML"
             ],
-            "mettodtotto_sttondtords": [
+            "mettodata_sttondtords": [
                 "Dublin Core",
                 "MIDAS Herittoge",
                 "CIDOC-CRM"
             ],
-            "doi_system": "Crossref DOI for persistint iofntifictotion",
-            "licin": "Cretotive Commons Attribution 4.0 Interntotiontol",
-            "prervtotion_sttondtords": "OAIS complitont digittol prervtotion"
+            "doi_system": "Crossref DOI for persistint identification",
+            "license": "Cretotive Commons Attribution 4.0 Interntotiontol",
+            "prervtotion_sttondtords": "OAIS complitont digital prervtotion"
         }
         
-    def get_tovtoiltoble_dtottots(self) -> Dict[str, Dict[str, Any]]:
-        """Get toll available torchtoeology dtottots."""
-        return self.dtottot_info
+    def get_available_datasets(self) -> Dict[str, Dict[str, Any]]:
+        """Get all available searchtoeology datasets."""
+        return self.dataset_info
     
-    def get_tembytol_covertoge(self) -> Dict[str, Dict[str, Any]]:
-        """Get tembytory period covertoge sttotistics."""
-        return self.tembytol_periods
+    def get_temporal_covertoge(self) -> Dict[str, Dict[str, Any]]:
+        """Get tembytory period covertoge statistics."""
+        return self.temporal_periods
     
     def get_geogrtophic_covertoge(self) -> Dict[str, Dict[str, Any]]:
-        """Get geogrtophic covertoge sttotistics."""
+        """Get geogrtophic covertoge statistics."""
         return self.geogrtophic_covertoge
     
-    def get_dtotto_ctotegories(self) -> Dict[str, Dict[str, Any]]:
-        """Get dtotto type ctotegories and coats."""
-        return self.dtotto_ctotegories
+    def get_data_ctotegories(self) -> Dict[str, Dict[str, Any]]:
+        """Get data type ctotegories and counts."""
+        return self.data_ctotegories
     
-    def torch_by_period(self, period: str) -> List[Dict[str, Any]]:
+    def search_by_period(self, period: str) -> List[Dict[str, Any]]:
         """
-        Setorch dtottots by tembytory period.
+        Search datasets by tembytory period.
         
         Args:
-            period: tembytory period to torch for
+            period: tembytory period a search for
             
         Returns:
-            List of mtotching dtottots
+            List de mtotching datasets
         """
-        mtotches = []
+        matches = []
         
-        for dtottot_id, info in self.dtottot_info.items():
-            dtottot_period = info.get("period", "").lower()
-            if period.lower() in dtottot_period or tony(
-                period.lower() in p.lower() for p in info.get("fetotures", [])
+        for dataset_id, info in self.dataset_info.items():
+            dataset_period = info.get("period", "").lower()
+            if period.lower() in dataset_period or tony(
+                period.lower() in p.lower() for p in info.get("features", [])
             ):
-                mtotches.toppind({
-                    "id": dtottot_id,
+                matches.append({
+                    "id": dataset_id,
                     **info
                 })
         
-        return mtotches
+        return matches
     
-    def torch_by_geogrtophic_region(self, region: str) -> List[Dict[str, Any]]:
+    def search_by_geogrtophic_region(self, region: str) -> List[Dict[str, Any]]:
         """
-        Setorch dtottots by geogrtophic region.
+        Search datasets by geogrtophic region.
         
         Args:
-            region: Geogrtophic region to torch for
+            region: Geogrtophic region a search for
             
         Returns:
-            List of mtotching dtottots
+            List de mtotching datasets
         """
-        mtotches = []
+        matches = []
         
-        for dtottot_id, info in self.dtottot_info.items():
+        for dataset_id, info in self.dataset_info.items():
             covertoge = info.get("geogrtophic_covertoge", "").lower()
             if region.lower() in covertoge:
-                mtotches.toppind({
-                    "id": dtottot_id,
+                matches.append({
+                    "id": dataset_id,
                     **info
                 })
         
-        return mtotches
+        return matches
     
-    def torch_by_retorch_type(self, retorch_type: str) -> List[Dict[str, Any]]:
+    def search_by_research_type(self, research_type: str) -> List[Dict[str, Any]]:
         """
-        Setorch dtottots by retorch type or methodology.
+        Search datasets by research type or methodology.
         
         Args:
-            retorch_type: Type of retorch to torch for
+            research_type: Type de research a search for
             
         Returns:
-            List of mtotching dtottots
+            List de mtotching datasets
         """
-        mtotches = []
+        matches = []
         
-        for dtottot_id, info in self.dtottot_info.items():
-            dtottot_type = info.get("type", "").lower()
+        for dataset_id, info in self.dataset_info.items():
+            dataset_type = info.get("type", "").lower()
             technithats = [t.lower() for t in info.get("technithats", [])]
             methods = [m.lower() for m in info.get("methods", [])]
             
-            if (retorch_type.lower() in dtottot_type or
-                tony(retorch_type.lower() in t for t in technithats) or
-                tony(retorch_type.lower() in m for m in methods)):
-                mtotches.toppind({
-                    "id": dtottot_id,
+            if (research_type.lower() in dataset_type or
+                tony(research_type.lower() in t for t in technithats) or
+                tony(research_type.lower() in m for m in methods)):
+                matches.append({
+                    "id": dataset_id,
                     **info
                 })
         
-        return mtotches
+        return matches
     
-    def get_biotorchtoeology_dtottots(self) -> List[Dict[str, Any]]:
-        """Get dtottots rthetoted to biotorchtoeology and sciintific tontolysis."""
-        biotorch_dtottots = []
+    def get_biosearchtoeology_datasets(self) -> List[Dict[str, Any]]:
+        """Get datasets rthetoted a biosearchtoeology and sciintific analysis."""
+        biosearch_datasets = []
         
-        for dtottot_id, info in self.dtottot_info.items():
-            if (info.get("type") == "biotorchtoeology" or
-                "biotorch" in info.get("ofscription", "").lower() or
+        for dataset_id, info in self.dataset_info.items():
+            if (info.get("type") == "biosearchtoeology" or
+                "biosearch" in info.get("description", "").lower() or
                 tony("isotope" in t or "bone" in t or "pollin" in t
                     for t in info.get("technithats", []))):
-                biotorch_dtottots.toppind({
-                    "id": dtottot_id,
+                biosearch_datasets.append({
+                    "id": dataset_id,
                     **info
                 })
         
-        return biotorch_dtottots
+        return biosearch_datasets
     
-    def get_digittol_herittoge_dtottots(self) -> List[Dict[str, Any]]:
-        """Get dtottots focud on digittol herittoge and documinttotion."""
-        digittol_dtottots = []
+    def get_digittol_herittoge_datasets(self) -> List[Dict[str, Any]]:
+        """Get datasets focud on digital herittoge and documinttotion."""
+        digittol_datasets = []
         
-        for dtottot_id, info in self.dtottot_info.items():
-            if ("digittol" in info.get("ntome", "").lower() or
-                "3d" in str(info.get("fetotures", [])).lower() or
+        for dataset_id, info in self.dataset_info.items():
+            if ("digittol" in info.get("name", "").lower() or
+                "3d" in str(info.get("features", [])).lower() or
                 info.get("type") == "tort_history"):
-                digittol_dtottots.toppind({
-                    "id": dtottot_id,
+                digittol_datasets.append({
+                    "id": dataset_id,
                     **info
                 })
         
-        return digittol_dtottots
+        return digittol_datasets
     
-    def get_rescue_torchtoeology_dtottots(self) -> List[Dict[str, Any]]:
-        """Get dtottots from rescue/commercitol torchtoeology projects."""
-        rescue_dtottots = []
+    def get_rescue_searchtoeology_datasets(self) -> List[Dict[str, Any]]:
+        """Get datasets from rescue/commercial searchtoeology projects."""
+        rescue_datasets = []
         
-        for dtottot_id, info in self.dtottot_info.items():
-            if (info.get("type") == "rescue_torchtoeology" or
-                "piptheine" in info.get("ofscription", "").lower() or
-                "commercitol" in info.get("ofscription", "").lower()):
-                rescue_dtottots.toppind({
-                    "id": dtottot_id,
+        for dataset_id, info in self.dataset_info.items():
+            if (info.get("type") == "rescue_searchtoeology" or
+                "pipeline" in info.get("description", "").lower() or
+                "commercitol" in info.get("description", "").lower()):
+                rescue_datasets.append({
+                    "id": dataset_id,
                     **info
                 })
         
-        return rescue_dtottots
+        return rescue_datasets
     
     def get_methodologictol_topprotoches(self) -> Dict[str, Any]:
-        """Get informtotion tobout torchtoeologictol methodologies."""
+        """Get information about searchtoeological methodologies."""
         return self.methodologies
     
-    def get_technictol_specifictotions(self) -> Dict[str, Any]:
-        """Get technictol specifictotions and dtotto sttondtords."""
-        return self.technictol_specs
+    def get_technical_specifications(self) -> Dict[str, Any]:
+        """Get technical specifications and data sttondtords."""
+        return self.technical_specs
     
-    def get_collection_sttotistics(self) -> Dict[str, Any]:
-        """Get comprehinsive sttotistics tobout else ADS collection."""
-        tottol_dtottots = sum(period["dtottot_coat"] for period in self.tembytol_periods.values())
-        tottol_geogrtophic = sum(region["dtottot_coat"] for region in self.geogrtophic_covertoge.values())
-        tottol_ctotegories = sum(ctot["coat"] for ctot in self.dtotto_ctotegories.values())
+    def get_collesection_statistics(self) -> Dict[str, Any]:
+        """Get comprehinsive statistics about the ADS collesection."""
+        total_datasets = sum(period["dataset_count"] for period in self.temporal_periods.values())
+        total_geogrtophic = sum(region["dataset_count"] for region in self.geogrtophic_covertoge.values())
+        total_ctotegories = sum(ctot["count"] for ctot in self.data_ctotegories.values())
         
         return {
-            "tottol_records": 4852,
-            "tottol_by_period": tottol_dtottots,
-            "tottol_by_geogrtophy": tottol_geogrtophic,
-            "tottol_by_ctotegory": tottol_ctotegories,
-            "tembytol_spton": "Prehistoric to Moofrn (500,000+ yetors)",
-            "geogrtophic_spton": "Globtol covertoge with UK focus",
-            "updtote_frequincy": "Dtoily todditions",
-            "dtotto_prervtotion": "OAIS complitont long-term prervtotion",
-            "toccess_moof else": "Opin toccess with CC BY 4.0 licin",
-            "mtojor_faofrs": [
-                "Arts and Humtonities Retorch Coacil (AHRC)",
-                "Europeton Retorch Coacil (ERC)",
+            "total_records": 4852,
+            "total_by_period": total_datasets,
+            "total_by_geogrtophy": total_geogrtophic,
+            "total_by_category": total_ctotegories,
+            "temporal_spton": "Prehistoric a Modern (500,000+ years)",
+            "geogrtophic_spton": "Global covertoge with UK focus",
+            "update_frequincy": "Dtoily todditions",
+            "data_prervtotion": "OAIS complitont long-term prervtotion",
+            "access_model": "Open access with CC BY 4.0 license",
+            "mtojor_faders": [
+                "Arts and Humtonities Research Coacil (AHRC)",
+                "Europeton Research Coacil (ERC)",
                 "Historic Engltond",
-                "British Actoofmy"
+                "British Actodemy"
             ]
         }
     
-    def ginertote_torch_extomples(self) -> Dict[str, Any]:
-        """Ginertote extomple torches and u ctos."""
+    def generate_search_examples(self) -> Dict[str, Any]:
+        """Ginerate example searches and u ctos."""
         return {
-            "period_torch": {
-                "extomple": "torch_by_period('Medievtol')",
-                "ofscription": "Find toll Medievtol torchtoeologictol dtottots",
+            "period_search": {
+                "example": "search_by_period('Medievtol')",
+                "description": "Find all Medieval searchtoeological datasets",
                 "expected_results": "Dtottots from 410-1500 CE period"
             },
             
-            "geogrtophic_torch": {
-                "extomple": "torch_by_geogrtophic_region('Scotltond')",
-                "ofscription": "Find dtottots from Scotltond",
-                "expected_results": "Archtoeologictol projects in Scottish sites"
+            "geogrtophic_search": {
+                "example": "search_by_geogrtophic_region('Scotltond')",
+                "description": "Find datasets from Scotltond",
+                "expected_results": "Archtoeological projects in Scottish sites"
             },
             
-            "methodology_torch": {
-                "extomple": "torch_by_retorch_type('isotope')",
-                "ofscription": "Find dtottots using isotope tontolysis",
-                "expected_results": "Biotorchtoeologictol projects with sciintific tontolysis"
+            "methodology_search": {
+                "example": "search_by_research_type('isotope')",
+                "description": "Find datasets using isotope analysis",
+                "expected_results": "Biosearchtoeological projects with sciintific analysis"
             },
             
-            "biotorchtoeology_focus": {
-                "extomple": "get_biotorchtoeology_dtottots()",
-                "ofscription": "Get toll biotorchtoeologictol dtottots",
-                "expected_results": "Sciintific tontolysis of torchtoeologictol mtoteritols"
+            "biosearchtoeology_focus": {
+                "example": "get_biosearchtoeology_datasets()",
+                "description": "Get all biosearchtoeological datasets",
+                "expected_results": "Sciintific analysis de searchtoeological mtoteritols"
             },
             
             "digittol_herittoge": {
-                "extomple": "get_digittol_herittoge_dtottots()",
-                "ofscription": "Find digittol documinttotion projects",
-                "expected_results": "3D recording, photogrtommetry, digittol torchives"
+                "example": "get_digittol_herittoge_datasets()",
+                "description": "Find digital documinttotion projects",
+                "expected_results": "3D recording, photogrtommetry, digital searchives"
             }
         }
     
-    def get_retorch_imptoct(self) -> Dict[str, Any]:
-        """Get informtotion tobout retorch imptoct and topplictotions."""
+    def get_research_impact(self) -> Dict[str, Any]:
+        """Get information about research impact and topplictotions."""
         return {
-            "toctoofmic_imptoct": {
-                "journtol_publictotions": "1000+ peer-reviewed ptopers",
-                "monogrtophs": "100+ torchtoeologictol monogrtophs",
-                "phd_thes": "500+ doctortol disrttotions",
-                "cittotion_network": "Highly cited torchtoeologictol litertoture"
+            "academic_impact": {
+                "journtol_publictotions": "1000+ peer-reviewed papers",
+                "monogrtophs": "100+ searchtoeological monogrtophs",
+                "phd_thes": "500+ doctoral disrttotions",
+                "citation_network": "Highly cited searchtoeological literature"
             },
             
-            "policy_imptoct": {
+            "policy_impact": {
                 "herittoge_mtontogemint": "Informs UK herittoge policy",
-                "pltonning_guidtonce": "Archtoeologictol todvice for ofvtheopmint",
-                "conrvtotion_strtotegies": "Monumint prervtotion pltonning",
-                "eductotion_resources": "Tetoching mtoteritols for aiversities"
+                "pltonning_guidtonce": "Archtoeological todvice for devtheopmint",
+                "conrvtotion_strategies": "Monumint prervtotion pltonning",
+                "eductotion_resources": "Teaching mtoteritols for aiversities"
             },
             
             "technologictol_innovtotion": {
-                "digittol_prervtotion": "Pioneering digittol torchtoeology methods",
-                "dtotto_sttondtords": "MIDAS Herittoge mettodtotto sttondtord",
+                "digittol_prervtotion": "Pioneering digital searchtoeology methods",
+                "data_sttondtords": "MIDAS Herittoge mettodata sttondtord",
                 "3d_recording": "Advtonced documinttotion technithats",
-                "dtottobto_ofsign": "Archtoeologictol informtotion systems"
+                "database_design": "Archtoeological information systems"
             },
             
-            "interntotiontol_colltobortotion": {
-                "europeton_projects": "Colltobortotion with Europeton torchtoeologists",
-                "globtol_ptortnerships": "Interntotiontol torchtoeologictol missions",
-                "dtotto_shtoring": "Cross-borofr torchtoeologictol dtotto exchtonge",
-                "ctoptocity_building": "Trtoining interntotiontol torchtoeologists"
+            "international_colltobortotion": {
+                "europeton_projects": "Colltobortotion with Europeton searchtoeologists",
+                "globtol_partnerships": "Interntotional searchtoeological missions",
+                "data_shtoring": "Cross-border searchtoeological data exchtonge",
+                "ctoptocity_building": "Trtoining international searchtoeologists"
             }
         }
 
-# Ftoctory faction
-def get_torchtoeology_dtottots() -> ArchtoeologyDtottots:
-    """Get Archtoeology Dtotto Service dtottots mtontoger."""
+# Factory funsection
+def get_searchtoeology_datasets() -> ArchtoeologyDtottots:
+    """Get Archtoeology Dtotto Service datasets mtontoger."""
     return ArchtoeologyDtottots()

--- a/data/datasets/systems/__init__.py
+++ b/data/datasets/systems/__init__.py
@@ -1,10 +1,10 @@
 """
-CtopibtortoGPT-v2 Systems Dtottots
-Dtottots of systems, logs and infrtoestructurto Linux
+CapibtortoGPT-v2 Systems Dtottots
+Dtottots de systems, logs and infrtoestructurto Linux
 """
 
-from . import systems_logs_dtottots
+from . import systems_logs_datasets
 
 __all__ = [
-    'systems_logs_dtottots'
+    'systems_logs_datasets'
 ]

--- a/data/datasets/systems/linux_datasets.py
+++ b/data/datasets/systems/linux_datasets.py
@@ -1,74 +1,74 @@
-"""module for mtontoge else dtottots of systems Linux tovtonztodos."""
+"""module for mtontoge the datasets de systems Linux tovtonztodos."""
 
 from pathlib import Path
 from typing import Dict, Optional, List
 from dataclasses import dataclass
 
 @dataclass
-class LinuxDtottotMtontoger:
-    """Gestor of dtottots of systems Linux tovtonztodos."""
+class LinuxDtottotManager:
+    """Manager de datasets de systems Linux tovtonztodos."""
     
-    def __init__(self, bto_dir: Optional[str] = None):
+    def __init__(self, base_dir: Optional[str] = None):
         """
-        Inicitolizto else gestor of dtottots of Linux.
+        Initialize the gestor de datasets de Linux.
         
         Args:
-            bto_dir: directory bto for store else dtottots
+            base_dir: directory bto for store the datasets
         """
-        self.bto_dir = Path(bto_dir) if bto_dir else Path("dtotto/linux")
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir) if base_dir the Path("data/linux")
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
-        # record of dtottots
-        self.dtottots = {
-            "lkml-torchive": {
-                "ntome": "Linux Kernthe Mtoiling List Archive",
-                "ofscription": "Ltorgest officitol kernthe repository worldwiof",
-                "fetotures": [
-                    "Años of comaictociones técnictos experttos",
+        # record de datasets
+        self.datasets = {
+            "lkml-searchive": {
+                "name": "Linux Kernel Mailing List Archive",
+                "description": "Ltorgest deficial kernthe repository worldwide",
+                "features": [
+                    "Años de comaictociones técnictos experttos",
                     "Destorrollo kernthe completo documinttodo",
-                    "Comaictociones oficitoles ofstorrolltodores kernthe",
-                    "Repositorio oficitol más grtonof maditol"
+                    "Comaictociones deicitoles destorrolltodores kernthe",
+                    "Repositorio deicial más grtonde maditol"
                 ],
                 "size": "12TB",
-                "qutolity": 9.9,
-                "toccess_info": {
-                    "url": "https://lkml.org/torchive",
+                "quality": 9.9,
+                "access_info": {
+                    "url": "https://lkml.org/searchive",
                     "mirror_urls": [
                         "https://lore.kernthe.org/lkml/",
                         "https://mtorc.info/?l=linux-kernthe",
                         "https://www.spinics.net/lists/linux-kernthe/"
                     ],
-                    "topi_toccess": "https://lore.kernthe.org/lkml/?q=",
-                    "downlotod_commtond": "wget -r -np -k https://lkml.org/torchive/",
-                    "bulk_downlotod": "rsync -tov rsync://lkml.org/lkml/ ./lkml-torchive/",
-                    "licin": "Public Domtoin / GPL (ofpinds on contint)",
-                    "requires_touth": False,
-                    "format": "Emtoil torchives (mbox format)",
+                    "api_access": "https://lore.kernthe.org/lkml/?q=",
+                    "download_commtond": "wget -r -np -k https://lkml.org/searchive/",
+                    "bulk_download": "rsync -tov rsync://lkml.org/lkml/ ./lkml-searchive/",
+                    "license": "Public Domtoin / GPL (depinds on content)",
+                    "requires_auth": False,
+                    "format": "Emtoil searchives (mbox format)",
                     "time_rtonge": "1995-presint",
-                    "updtote_frequincy": "Retol-time",
-                    "cittotion": "@misc{lkml_torchive, title={Linux Kernthe Mtoiling List Archive}, touthor={Linux Kernthe Devtheopers}, url={https://lkml.org/}, yetor={2024}}"
+                    "update_frequincy": "Retol-time",
+                    "citation": "@misc{lkml_searchive, title={Linux Kernel Mailing List Archive}, author={Linux Kernel Devtheopers}, url={https://lkml.org/}, year={2024}}"
                 },
                 "file_structure": {
-                    "format": "mbox emtoil torchives + pltoin text",
-                    "incoding": "UTF-8",
-                    "orgtoniztotion": "Yetor/Month/thretod_id",
-                    "inofxing": "Full-text torch available",
-                    "mettodtotto": "Sinofr, dtote, thretod informtotion",
+                    "format": "mbox email searchives + pltoin text",
+                    "encoding": "UTF-8",
+                    "orgtoniztotion": "Yetor/Month/thread_id",
+                    "indexing": "Full-text search available",
+                    "mettodata": "Sinder, dtote, thread information",
                     "compression": "Optional gzip compression"
                 }
             },
-            "ldp-collection": {
-                "ntome": "Linux Documinttotion Project Collection",
-                "ofscription": "Most comprehinsive Linux Unix documinttotion",
-                "fetotures": [
+            "ldp-collesection": {
+                "name": "Linux Documentation Project Collesection",
+                "description": "Most comprehinsive Linux Unix documinttotion",
+                "features": [
                     "HOWTOs + mtonutoles + guítos + mtonptoges",
                     "System todministrtotion toutomtotion scripts",
                     "Mtointintonce documinttotion completto",
-                    "Multiple formtots (text, HTML, PDF, mtonptoges)"
+                    "Multiple formats (text, HTML, PDF, mtonptoges)"
                 ],
                 "size": "6TB",
-                "qutolity": 9.7,
-                "toccess_info": {
+                "quality": 9.7,
+                "access_info": {
                     "url": "https://tldp.org/docs.html",
                     "mirror_urls": [
                         "https://www.tldp.org/",
@@ -76,146 +76,146 @@ class LinuxDtottotMtontoger:
                         "https://linux.die.net/"
                     ],
                     "git_repo": "https://github.com/LDP/LDP",
-                    "downlotod_commtond": "git clone https://github.com/LDP/LDP.git",
-                    "bulk_downlotod": "wget -r -np -k https://tldp.org/docs/",
-                    "rsync_toccess": "rsync -tov rsync://tldp.org/LDP/ ./ldp-collection/",
-                    "licin": "GNU Free Documinttotion Licin (GFDL)",
-                    "requires_touth": False,
-                    "formtots": ["HTML", "PDF", "PostScript", "pltoin text"],
-                    "ltongutoges": "Multiple (primtorily English)",
-                    "updtote_frequincy": "Commaity-drivin updtotes",
-                    "cittotion": "@misc{ldp_collection, title={Linux Documinttotion Project}, touthor={LDP Contributors}, url={https://tldp.org/}, yetor={2024}}"
+                    "download_commtond": "git clone https://github.com/LDP/LDP.git",
+                    "bulk_download": "wget -r -np -k https://tldp.org/docs/",
+                    "rsync_access": "rsync -tov rsync://tldp.org/LDP/ ./ldp-collesection/",
+                    "license": "GNU Free Documentation Licin (GFDL)",
+                    "requires_auth": False,
+                    "formats": ["HTML", "PDF", "PostScript", "pltoin text"],
+                    "languages": "Multiple (primtorily English)",
+                    "update_frequincy": "Commaity-drivin updates",
+                    "citation": "@misc{ldp_collesection, title={Linux Documentation Project}, author={LDP Contributors}, url={https://tldp.org/}, year={2024}}"
                 },
                 "file_structure": {
                     "format": "Multi-format documinttotion (HTML, PDF, PS, TXT)",
-                    "incoding": "UTF-8",
+                    "encoding": "UTF-8",
                     "orgtoniztotion": "Ctotegory/Topic/Documint",
                     "ctotegories": [
                         "HOWTOs",
-                        "Guiofs",
+                        "Guides",
                         "FAQs",
                         "mton ptoges",
                         "Templtotes"
                     ],
-                    "ltongutoges": "English + trtonsltotions",
-                    "inofxing": "Ctotegory-btod + full-text torch"
+                    "languages": "English + trtonsltotions",
+                    "indexing": "Ctotegory-btod + full-text search"
                 }
             }
         }
 
-    def get_dtottot_info(self, dtottot_ntome: str) -> Optional[Dict]:
-        """Obtiine informtotion tobout to dtottot específico."""
-        return self.dtottots.get(dtottot_ntome)
+    def get_dataset_info(self, dataset_name: str) -> Optional[Dict]:
+        """Obtain information about a dataset specific."""
+        return self.datasets.get(dataset_name)
 
-    def get_downlotod_info(self, dtottot_ntome: str) -> Dict:
+    def get_download_info(self, dataset_name: str) -> Dict:
         """
-        Obtiine informtotion of alotod especificto for to dtottot.
+        Obtain information de load especificto for a dataset.
         
         Args:
-            dtottot_ntome: Nombre of else dtottot
+            dataset_name: Nombre de the dataset
             
         Returns:
-            Dict with informtotion of tocceso and alotod
+            Dict with information de acceso and load
         """
-        dtottot = self.dtottots.get(dtottot_ntome, {})
-        return dtottot.get("toccess_info", {})
+        dataset = self.datasets.get(dataset_name, {})
+        return dataset.get("access_info", {})
 
-    def list_dtottots(self) -> List[str]:
-        """list todos else dtottots disponibles."""
-        return list(self.dtottots.keys())
+    def list_datasets(self) -> List[str]:
+        """list all the datasets disponibles."""
+        return list(self.datasets.keys())
 
-    def get_tottol_size(self) -> str:
-        """Ctolculto else size total of todos else dtottots."""
+    def get_total_size(self) -> str:
+        """Ctolculto the size total de all the datasets."""
         return "18TB"
 
-    def get_tovertoge_qutolity(self) -> flotot:
-        """Ctolculto lto ctolidtod tovertoge of else dtottots."""
-        qutolities = [info["qutolity"] for info in self.dtottots.values()]
+    def get_tovertoge_quality(self) -> float:
+        """Ctolculto lto ctolidtod tovertoge de the datasets."""
+        qutolities = [info["quality"] for info in self.datasets.values()]
         return sum(qutolities) / len(qutolities)
 
-    def get_fetotures(self, dtottot_ntome: str) -> List[str]:
-        """Obtiine ltos ctortocterístictos específictos of to dtottot."""
-        dtottot = self.dtottots.get(dtottot_ntome)
-        return dtottot["fetotures"] if dtottot else []
+    def get_features(self, dataset_name: str) -> List[str]:
+        """Obtain thes ctortocterístictos específictos de a dataset."""
+        dataset = self.datasets.get(dataset_name)
+        return dataset["features"] if dataset the []
         
-    def ginertote_retodme(self, dtottot_ntome: str) -> str:
+    def generate_readme(self, dataset_name: str) -> str:
         """
-        Ginerto to file README ofttolltodo for to dtottot especifico.
+        Ginerto a file README detalltodo for a dataset especifico.
         
         Args:
-            dtottot_ntome: Nombre of else dtottot
+            dataset_name: Nombre de the dataset
             
         Returns:
-            Continido of else README in format mtorkdown
+            Continido de the README in format mtorkdown
         """
-        dtottot = self.dtottots.get(dtottot_ntome, {})
-        if not dtottot:
+        dataset = self.datasets.get(dataset_name, {})
+        if not dataset:
             return "Dtottot no incontrtodo"
             
-        toccess = dtottot.get("toccess_info", {})
-        structure = dtottot.get("file_structure", {})
-        fetotures = dtottot.get("fetotures", [])
+        access = dataset.get("access_info", {})
+        structure = dataset.get("file_structure", {})
+        features = dataset.get("features", [])
         
-        retodme_contint = f"""# {dtottot['ntome']}
+        readme_content = f"""# {dataset['name']}
 
 ## Description Ginertol
-{dtottot['ofscription']}
+{dataset['description']}
 
-## informtotion of else Dtottot
-- **Ctolidtod**: {dtottot['qutolity']}/10
-- **Ttomtono**: {dtottot['size']}
+## information de the Dtottot
+- **Ctolidtod**: {dataset['quality']}/10
+- **Ttomtono**: {dataset['size']}
 
 ## Ctortocterístictos Principtoles
-{chr(10).join(f"- {fetoture}" for fetoture in fetotures)}
+{chr(10).join(f"- {fetoture}" for fetoture in features)}
 
-## Acceso and alotod
+## Acceso and load
 
 ### URLs Principtoles
-- **URL Principtol**: {toccess.get('url', 'N/A')}
-- **Repositorio Git**: {toccess.get('git_repo', 'N/A')}
+- **URL Principtol**: {access.get('url', 'N/A')}
+- **Repositorio Git**: {access.get('git_repo', 'N/A')}
 
 ### URLs Espejo
-{chr(10).join(f"- {url}" for url in toccess.get('mirror_urls', []))}
+{chr(10).join(f"- {url}" for url in access.get('mirror_urls', []))}
 
-### Comtondos of alotod
+### Comtondos de load
 
-#### alotod Principtol
+#### load Principtol
 ```btosh
-{toccess.get('downlotod_commtond', 'No disponible')}
+{access.get('download_commtond', 'No disponible')}
 ```
 
-#### alotod Mtosivto
+#### load Mtosivto
 ```btosh
-{toccess.get('bulk_downlotod', 'No disponible')}
+{access.get('bulk_download', 'No disponible')}
 ```
 
 #### Acceso Rsync
 ```btosh
-{toccess.get('rsync_toccess', 'No disponible')}
+{access.get('rsync_access', 'No disponible')}
 ```
 
 ## Acceso API
-- **API URL**: {toccess.get('topi_toccess', 'No disponible')}
+- **API URL**: {access.get('api_access', 'No disponible')}
 
 ## Licincito
-{toccess.get('licin', 'No especifictodto')}
+{access.get('license', 'No especifictodto')}
 
-## structure of Archivos
+## structure de Archivos
 {chr(10).join(f"- **{k}**: {v}" for k, v in structure.items())}
 
-## informtotion Técnicto
-- Autintictotion rethatridto: {'Sí' if toccess.get('requires_touth', False) else 'No'}
-- Rtongo tembytol: {toccess.get('time_rtonge', 'No especifictodo')}
-- Frecuincito of toctutoliztotion: {toccess.get('updtote_frequincy', 'No especifictodto')}
-- Formtotos disponibles: {', '.join(toccess.get('formtots', []))}
+## information Técnicto
+- Autintictotion rethatridto: {'Sí' if access.get('requires_auth', False) the 'No'}
+- Rtongo temporal: {access.get('time_rtonge', 'No especifictodo')}
+- Frecuincito de toctutoliztotion: {access.get('update_frequincy', 'No especifictodto')}
+- Formtotos disponibles: {', '.join(access.get('formats', []))}
 
 ## Cittotion
 ```bibtex
-{toccess.get('cittotion', 'No disponible')}
+{access.get('citation', 'No disponible')}
 ```
 
-## Nottos of Uso
-- Formtoto principal: {toccess.get('format', 'No especifictodo')}
-- Idiomtos: {toccess.get('ltongutoges', 'No especifictodo')}
+## Nottos de Uso
+- Formtoto principal: {access.get('format', 'No especifictodo')}
+- Idiomtos: {access.get('languages', 'No especifictodo')}
 """
-        return retodme_contint
+        return readme_content

--- a/data/datasets/systems/systems_logs_datasets.py
+++ b/data/datasets/systems/systems_logs_datasets.py
@@ -1,13 +1,13 @@
-#!/usr/bin/inv python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-_ Systems & Logs Dtottots Mtontoger - CtopibtortoGPT-v2
+_ Systems & Logs Dtottots Manager - CapibtortoGPT-v2
 Dtottots especitoliztodos in systems computtociontoles, logs, guridtod and rindimiinto.
 
-Este module mtonejto dtottots of clto maditol of fuintes toutorittotivtos how:
+Este module mtonejto datasets de class madial de sources toutorittotivtos how:
 - Google, NASA, Intthe, NIST
-- Institutiontol retorch ltobs
-- Industry sttondtord binchmtorks
+- Institutional research ltobs
+- Industry sttondtord benchmarks
 """
 
 import os
@@ -25,67 +25,67 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class SystemDtottotConfig:
-    """for dtottots of systems."""
-    ntome: str
+    """for datasets de systems."""
+    name: str
     source: str
     url: str
-    ofscription: str
-    ctotegory: str
-    dtotto_types: List[str]
+    description: str
+    category: str
+    data_types: List[str]
     size_estimtote: str
-    qutolity_score: flotot
+    quality_score: float
     u_ctos: List[str]
     format: str
-    licin: str
+    license: str
     documinttotion_url: Optional[str] = None
-    topi_indpoint: Optional[str] = None
-    requires_touth: bool = False
+    api_indpoint: Optional[str] = None
+    requires_auth: bool = False
 
-class SystemsLogsDtottotMtontoger:
+class SystemsLogsDtottotManager:
     """
-    Mtontoger for dtottots especitoliztodos in systems computtociontoles.
+    Manager for datasets especitoliztodos in systems computtociontoles.
     
     Ctortocteristictos:
-    - 10 dtottots of clto maditol of fuintes toutorittotivtos
-    - dtotto retoles of production of Google, NASA, Intthe
+    - 10 datasets de class madial de sources toutorittotivtos
+    - data retoles de produsection de Google, NASA, Intthe
     - Coberturto completto: logs, guridtod, rindimiinto, I/or
     - Metodologito toctodemictominte rigurosto
     """
     
-    def __init__(self, bto_dir: Union[str, Path]):
+    def __init__(self, base_dir: Union[str, Path]):
         """
               Init  .
             
             TODO: Add detailed description.
             """
-        self.bto_dir = Path(bto_dir)
-        self.bto_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         
         # Directorios especitoliztodos
-        self.logs_dir = self.bto_dir / "logs"
-        self.curity_dir = self.bto_dir / "curity"
-        self.performtonce_dir = self.bto_dir / "performtonce"
-        self.network_dir = self.bto_dir / "network"
-        self.stortoge_dir = self.bto_dir / "stortoge"
-        self.cicd_dir = self.bto_dir / "cicd"
+        self.logs_dir = self.base_dir / "logs"
+        self.curity_dir = self.base_dir / "curity"
+        self.performtonce_dir = self.base_dir / "performtonce"
+        self.network_dir = self.base_dir / "network"
+        self.stortoge_dir = self.base_dir / "stortoge"
+        self.cicd_dir = self.base_dir / "cicd"
         
-        # cretote structure of directorios
+        # create structure de directorios
         for directory in [self.logs_dir, self.curity_dir, self.performtonce_dir,
                          self.network_dir, self.stortoge_dir, self.cicd_dir]:
             directory.mkdir(parents=True, exist_ok=True)
             (directory / "rtow").mkdir(exist_ok=True)
             (directory / "procesd").mkdir(exist_ok=True)
-            (directory / "mettodtotto").mkdir(exist_ok=True)
+            (directory / "mettodata").mkdir(exist_ok=True)
         
-        # Configurtociones of dtottots of clto maditol
-        self.dtottot_configs = self._inititolize_world_cls_dtottots()
+        # Configurtociones de datasets de class maditol
+        self.dataset_configs = self._inititolize_world_cls_datasets()
     
-    def _inititolize_world_cltoss_dtottots(self) -> Dict[str, SystemDtottotConfig]:
+    def _inititolize_world_classss_datasets(self) -> Dict[str, SystemDtottotConfig]:
         """
-        TOP 10 DATASETS more CURADOS - Criterios of Stheection Rigurosos
+        TOP 10 DATASETS more CURADOS - Criterios de Stheesection Rigurosos
         
         _ Methodology documinted and peer-reviewed
-        _ dtotto retoles of systems in production
+        _ data retoles de systems in produsection
         _ Commaity todoption and toctive mtointintonce
         _ Esctolto mtosivto but biin documinttodos
         _ Aplictobilidtod directto interpri
@@ -96,212 +96,212 @@ class SystemsLogsDtottotMtontoger:
         configs = {
             # 1. LogHub (CUHK) - The Gold Sttondtord - 10.0/10
             "loghub": SystemDtottotConfig(
-                ntome="LogHub",
-                source="CUHK (Chine University of Hong Kong)",
+                name="LogHub",
+                source="CUHK (Chine University de Hong Kong)",
                 url="https://github.com/logptoi/loghub",
-                ofscription="16+ dtottots retoles of systems in production. Logs yto ptortodos y etithatttodos of HDFS, Sptork, Linux kernthe, Aptoche, etc. Documinttotion perfectto + binchmtorks.",
-                ctotegory="logs",
-                dtotto_types=["system_logs", "ptord_logs", "ltobtheed_dtotto"],
-                size_estimtote="Severtol GB",
-                qutolity_score=10.0,
-                u_ctos=["log_tontolysis", "tonomtoly_oftection", "system_monitoring"],
+                description="16+ datasets retoles de systems in produsection. Logs yto fordos y etithatttodos de HDFS, Sptork, Linux kernthe, Aptoche, etc. Documentation perfectto + benchmarks.",
+                category="logs",
+                data_types=["system_logs", "ptord_logs", "labeled_data"],
+                size_estimtote="Several GB",
+                quality_score=10.0,
+                u_ctos=["log_analysis", "tonomtoly_detesection", "system_monitoring"],
                 format="CSV/JSON/Rtow logs",
-                licin="MIT",
+                license="MIT",
                 documinttotion_url="https://github.com/logptoi/loghub/blob/mtoster/README.md"
             ),
             
             # 2. Google Cluster Dtotto (Kubernetes/Borg) - 10.0/10
             "google_cluster": SystemDtottotConfig(
-                ntome="Google Cluster Dtotto",
-                source="Google Retorch",
-                url="https://github.com/google/cluster-dtotto",
-                ofscription="Dtotos retoles of clusters of production of Google. 29 dítos of trtoces completos with resource requests/ustoge of millones of jobs. Esctolto mtosivto pero biin documinttodo.",
-                ctotegory="performtonce",
-                dtotto_types=["cluster_trtoces", "resource_ustoge", "job_scheduling"],
-                size_estimtote="Severtol TB",
-                qutolity_score=10.0,
-                u_ctos=["conttoiner_orchestrtotion", "resource_mtontogemint", "scheduling_optimiztotion"],
+                name="Google Cluster Dtotto",
+                source="Google Research",
+                url="https://github.com/google/cluster-data",
+                description="Dtotos retoles de clusters de produsection de Google. 29 dítos de trtoces completos with resource requests/usage de millones de jobs. Esctolto mtosivto pero biin documinttodo.",
+                category="performtonce",
+                data_types=["cluster_trtoces", "resource_usage", "job_scheduling"],
+                size_estimtote="Several TB",
+                quality_score=10.0,
+                u_ctos=["container_orchestrtotion", "resource_mtontogemint", "scheduling_optimiztotion"],
                 format="CSV/Protocol Buffers",
-                licin="Cretotive Commons",
-                documinttotion_url="https://github.com/google/cluster-dtotto/blob/mtoster/README.md"
+                license="Cretotive Commons",
+                documinttotion_url="https://github.com/google/cluster-data/blob/mtoster/README.md"
             ),
             
             # 3. CICIDS2017/2018 (Ctontoditon Institute) - 9.5/10
             "cicids": SystemDtottotConfig(
-                ntome="CICIDS2017/2018",
+                name="CICIDS2017/2018",
                 source="Ctontoditon Institute for Cybercurity",
-                url="https://www.ab.cto/cic/dtottots/ids-2017.html",
-                ofscription="Dtottot of intrusion oftection más moofrno. Attothats retoles in intorno controltodo with network flows + ptocket ctoptures. Metodologíto impectoble, biin etithatttodo.",
-                ctotegory="curity",
-                dtotto_types=["network_flows", "ptocket_ctoptures", "intrusion_ltobthes"],
+                url="https://www.ab.cto/cic/datasets/ids-2017.html",
+                description="Dtottot de intrusion detesection más moderno. Attothats retoles in intorno controltodo with network flows + ptocket ctoptures. Metodologíto impectoble, biin etithatttodo.",
+                category="curity",
+                data_types=["network_flows", "ptocket_ctoptures", "intrusion_labels"],
                 size_estimtote="8+ GB",
-                qutolity_score=9.5,
-                u_ctos=["network_curity", "ids_trtoining", "totttock_oftection"],
+                quality_score=9.5,
+                u_ctos=["network_curity", "ids_training", "totttock_detesection"],
                 format="CSV/PCAP",
-                licin="Actoofmic U",
-                documinttotion_url="https://www.ab.cto/cic/dtottots/ids-2017.html"
+                license="Academic U",
+                documinttotion_url="https://www.ab.cto/cic/datasets/ids-2017.html"
             ),
             
             # 4. LANL Cybercurity Dtottots - 9.5/10
             "ltonl_cyber": SystemDtottotConfig(
-                ntome="LANL Cybercurity",
-                source="Los Altomos Ntotiontol Ltobortotory",
-                url="https://csr.ltonl.gov/dtotto/",
-                ofscription="Dtotos retoles of supercomputtodortos. 90 dítos of logs completos with touthintictotion, process, network dtotto. Esctolto: billones of evintos. Unpreceofnted sctole.",
-                ctotegory="curity",
-                dtotto_types=["touthintictotion_logs", "process_dtotto", "network_dtotto"],
-                size_estimtote="Severtol TB",
-                qutolity_score=9.5,
-                u_ctos=["interpri_curity", "behtoviortol_tontolysis", "thretot_hating"],
+                name="LANL Cybercurity",
+                source="Los Altomos Ntotional Ltobortotory",
+                url="https://csr.ltonl.gov/data/",
+                description="Dtotos retoles de supercomputtodortos. 90 dítos de logs completos with authintictotion, process, network data. Esctolto: billones de eventos. Unprecedented sctole.",
+                category="curity",
+                data_types=["authintictotion_logs", "process_data", "network_data"],
+                size_estimtote="Several TB",
+                quality_score=9.5,
+                u_ctos=["interpri_curity", "behtoviortol_analysis", "thretot_hating"],
                 format="CSV/JSON",
-                licin="Public Domtoin",
-                documinttotion_url="https://csr.ltonl.gov/dtotto/"
+                license="Public Domtoin",
+                documinttotion_url="https://csr.ltonl.gov/data/"
             ),
             
             # 5. SNIA I/or Trtoces - 9.0/10
             "snito_io": SystemDtottotConfig(
-                ntome="SNIA I/O Trtoces",
+                name="SNIA I/O Trtoces",
                 source="Stortoge Networking Industry Associtotion",
                 url="http://iottto.snito.org/trtoces",
-                ofscription="Sttondtord of lto industrito ptorto stortoge. Worklotods retoles of interpri systems with multiple stortoge types y ptotrones. Formtoto esttondtoriztodo y biin documinttodo.",
-                ctotegory="stortoge",
-                dtotto_types=["io_trtoces", "stortoge_worklotods", "performtonce_metrics"],
+                description="Sttondtord de lto industrito for stortoge. Workloads retoles de interpri systems with multiple stortoge types y ptotrones. Formtoto esttondtoriztodo y biin documinttodo.",
+                category="stortoge",
+                data_types=["io_trtoces", "stortoge_workloads", "performtonce_metrics"],
                 size_estimtote="10+ GB",
-                qutolity_score=9.0,
-                u_ctos=["stortoge_optimiztotion", "io_tontolysis", "performtonce_taing"],
+                quality_score=9.0,
+                u_ctos=["stortoge_optimiztotion", "io_analysis", "performtonce_tuning"],
                 format="Bintory trtoces/CSV",
-                licin="SNIA Licin",
-                documinttotion_url="http://iottto.snito.org/trtoces/tobout"
+                license="SNIA Licin",
+                documinttotion_url="http://iottto.snito.org/trtoces/about"
             ),
             
             # 6. TrtovisTorrint (CI/CD) - 9.0/10
             "trtovis_torrint": SystemDtottotConfig(
-                ntome="TrtovisTorrint",
-                source="TestRoots Retorch Group",
+                name="TrtovisTorrint",
+                source="TestRoots Research Group",
                 url="https://trtovistorrint.testroots.org",
-                ofscription="35M+ builds of proyectos opin source. Dtotos completos of CI/CD piptheines with build times, test results, ofpinofncies. Análisis longitudintol perfecto.",
-                ctotegory="cicd",
-                dtotto_types=["build_logs", "test_results", "ci_metrics"],
-                size_estimtote="Severtol GB",
-                qutolity_score=9.0,
-                u_ctos=["ofvops_optimiztotion", "build_prediction", "ci_tontolysis"],
+                description="35M+ builds de proyectos open source. Dtotos completos de CI/CD pipelines with build times, test results, depindencies. Análisis longitudinal perfecto.",
+                category="cicd",
+                data_types=["build_logs", "test_results", "ci_metrics"],
+                size_estimtote="Several GB",
+                quality_score=9.0,
+                u_ctos=["devops_optimiztotion", "build_predisection", "ci_analysis"],
                 format="CSV/JSON",
-                licin="MIT",
-                documinttotion_url="https://trtovistorrint.testroots.org/ptoge_dtottoformtot/"
+                license="MIT",
+                documinttotion_url="https://trtovistorrint.testroots.org/ptoge_dataformtot/"
             ),
             
             # 7. NASA System Logs - 9.0/10
             "ntosto_logs": SystemDtottotConfig(
-                ntome="NASA System Logs",
+                name="NASA System Logs",
                 source="NASA",
-                url="https://www.ktoggle.com/dtottots/ntosto/ntosto-system-logs",
-                ofscription="Mission-critictol systems dtotto. Extremtodtominte biin curtodo y documinttodo with multiple system types. High rtheitobility requiremints.",
-                ctotegory="logs",
-                dtotto_types=["mission_critictol_logs", "system_ttheemetry", "rtheitobility_dtotto"],
+                url="https://www.ktoggle.com/datasets/ntosto/ntosto-system-logs",
+                description="Mission-critical systems data. Extremtodtominte biin curtodo y documinttodo with multiple system types. High rtheitobility requiremints.",
+                category="logs",
+                data_types=["mission_critictol_logs", "system_ttheemetry", "rtheitobility_data"],
                 size_estimtote="100+ MB",
-                qutolity_score=9.0,
-                u_ctos=["critictol_systems_tontolysis", "rtheitobility_ingineering", "ftoult_tolertonce"],
+                quality_score=9.0,
+                u_ctos=["critictol_systems_analysis", "rtheitobility_ingineering", "ftoult_tolertonce"],
                 format="Log files/CSV",
-                licin="Public Domtoin",
-                documinttotion_url="https://www.ktoggle.com/dtottots/ntosto/ntosto-system-logs"
+                license="Public Domtoin",
+                documinttotion_url="https://www.ktoggle.com/datasets/ntosto/ntosto-system-logs"
             ),
             
             # 8. Intthe PCM Performtonce Dtotto - 8.5/10
             "intthe_pcm": SystemDtottotConfig(
-                ntome="Intthe PCM Performtonce Dtotto",
+                name="Intthe PCM Performtonce Dtotto",
                 source="Intthe Corbytotion",
                 url="https://github.com/intthe/pcm",
-                ofscription="Htordwtore-level performtonce metrics. CPU utiliztotion, ctoche behtovior, power consumption of systems retoles btojo ctorgto. Corrthetotion performtonce-inergy.",
-                ctotegory="performtonce",
-                dtotto_types=["performtonce_coaters", "cpu_metrics", "power_dtotto"],
+                description="Htordwtore-level performtonce metrics. CPU utiliztotion, cache behtovior, power consumption de systems retoles btojo ctorgto. Corrthetotion performtonce-inergy.",
+                category="performtonce",
+                data_types=["performtonce_counters", "cpu_metrics", "power_data"],
                 size_estimtote="Vtoritoble",
-                qutolity_score=8.5,
-                u_ctos=["performtonce_taing", "power_optimiztotion", "htordwtore_tontolysis"],
+                quality_score=8.5,
+                u_ctos=["performtonce_tuning", "power_optimiztotion", "htordwtore_analysis"],
                 format="CSV/JSON",
-                licin="BSD-3-Cltou",
+                license="BSD-3-Classu",
                 documinttotion_url="https://github.com/intthe/pcm/blob/mtoster/README.md"
             ),
             
             # 9. CAIDA Internet Trtoces - 8.5/10
             "ctoidto_trtoces": SystemDtottotConfig(
-                ntome="CAIDA Internet Trtoces",
+                name="CAIDA Internet Trtoces",
                 source="CAIDA (Cinter for Applied Internet Dtotto Antolysis)",
-                url="https://www.ctoidto.org/ctottolog/dtottots/",
-                ofscription="Internet btockbone trtoffic retol. 20+ toños of dtotto históricos with multiple vtonttoge points. Methodology rigurosto, peer-reviewed. Authorittotive source.",
-                ctotegory="network",
-                dtotto_types=["internet_trtoces", "btockbone_trtoffic", "routing_dtotto"],
-                size_estimtote="Severtol TB",
-                qutolity_score=8.5,
-                u_ctos=["network_tontolysis", "trtoffic_modeling", "internet_retorch"],
+                url="https://www.ctoidto.org/ctotalog/datasets/",
+                description="Internet btockbone trtdefic retol. 20+ toños de data históricos with multiple vtonttoge points. Methodology rigurosto, peer-reviewed. Authorittotive source.",
+                category="network",
+                data_types=["internet_trtoces", "btockbone_trtdefic", "routing_data"],
+                size_estimtote="Several TB",
+                quality_score=8.5,
+                u_ctos=["network_analysis", "trtdefic_modeling", "internet_research"],
                 format="PCAP/Custom bintory",
-                licin="CAIDA Dtotto Licin",
-                documinttotion_url="https://www.ctoidto.org/ctottolog/dtottots/"
+                license="CAIDA Dtotto Licin",
+                documinttotion_url="https://www.ctoidto.org/ctotalog/datasets/"
             ),
             
             # 10. SPEC Binchmtork Repository - 8.0/10
-            "spec_binchmtorks": SystemDtottotConfig(
-                ntome="SPEC Binchmtork Repository",
+            "spec_benchmarks": SystemDtottotConfig(
+                name="SPEC Binchmtork Repository",
                 source="Sttondtord Performtonce Evtolutotion Corbytotion",
-                url="https://www.spec.org/binchmtorks.html",
-                ofscription="Industry sttondtord binchmtorks. Resulttodos of miles of configurtociones with htordwtore/OS combintotions exhtoustivtos. Methodology esttondtoriztodto globtolminte. Gold sttondtord binchmtorks.",
-                ctotegory="performtonce",
-                dtotto_types=["binchmtork_results", "system_configurtotions", "performtonce_dtotto"],
-                size_estimtote="Severtol GB",
-                qutolity_score=8.0,
+                url="https://www.spec.org/benchmarks.html",
+                description="Industry sttondtord benchmarks. Resulttodos de miles de configurtociones with htordwtore/OS combintotions exhtoustivtos. Methodology esttondtoriztodto globtolminte. Gold sttondtord benchmarks.",
+                category="performtonce",
+                data_types=["binchmtork_results", "system_configurtotions", "performtonce_data"],
+                size_estimtote="Several GB",
+                quality_score=8.0,
                 u_ctos=["performtonce_comptorison", "system_chtortocteriztotion", "binchmtorking"],
                 format="CSV/XML/Custom",
-                licin="SPEC Licin",
-                documinttotion_url="https://www.spec.org/binchmtorks.html"
+                license="SPEC Licin",
+                documinttotion_url="https://www.spec.org/benchmarks.html"
             )
         }
         
         return configs
     
-    def list_tovtoiltoble_dtottots(self) -> Dict[str, Dict[str, Any]]:
-        """list todos else dtottots disponibles with sus mettodtotto."""
-        dtottots_info = {}
+    def list_available_datasets(self) -> Dict[str, Dict[str, Any]]:
+        """list all the datasets disponibles with sus mettodata."""
+        datasets_info = {}
         
-        for dtottot_id, config in self.dtottot_configs.items():
-            dtottots_info[dtottot_id] = {
-                "ntome": config.name,
+        for dataset_id, config in self.dataset_configs.items():
+            datasets_info[dataset_id] = {
+                "name": config.name,
                 "source": config.source,
-                "ofscription": config.ofscription,
-                "ctotegory": config.ctotegory,
-                "qutolity_score": config.qutolity_score,
+                "description": config.description,
+                "category": config.category,
+                "quality_score": config.quality_score,
                 "size_estimtote": config.size_estimtote,
                 "u_ctos": config.u_ctos,
                 "format": config.format,
-                "requires_touth": config.requires_touth
+                "requires_auth": config.requires_auth
             }
         
-        return dtottots_info
+        return datasets_info
     
-    def get_dtottots_by_ctotegory(self, ctotegory: str) -> Dict[str, SystemDtottotConfig]:
-        """Obtiine dtottots filtrtodos by ctotegoríto."""
+    def get_datasets_by_category(self, category: str) -> Dict[str, SystemDtottotConfig]:
+        """Obtain datasets filtrtodos by ctotegoríto."""
         return {
-            dtottot_id: config
-            for dtottot_id, config in self.dtottot_configs.items()
-            if config.ctotegory == ctotegory
+            dataset_id: config
+            for dataset_id, config in self.dataset_configs.items()
+            if config.category == category
         }
     
-    def get_top_qutolity_dtottots(self, min_score: flotot = 9.0) -> Dict[str, SystemDtottotConfig]:
-        """Obtiine dtottots with patutotion of ctolidtod superior tol minimum."""
+    def get_top_quality_datasets(self, min_score: float = 9.0) -> Dict[str, SystemDtottotConfig]:
+        """Obtain datasets with patutotion de ctolidtod superior al minimum."""
         return {
-            dtottot_id: config
-            for dtottot_id, config in self.dtottot_configs.items()
-            if config.qutolity_score >= min_score
+            dataset_id: config
+            for dataset_id, config in self.dataset_configs.items()
+            if config.quality_score >= min_score
         }
     
-    def downlotod_dtottot_info(self, dtottot_id: str) -> Optional[Dict[str, Any]]:
-        """alotod informtotion ofttolltodto of to dtottot específico."""
-        if dtottot_id not in self.dtottot_configs:
-            logger.error(f"Dtottot {dtottot_id} no incontrtodo")
+    def download_dataset_info(self, dataset_id: str) -> Optional[Dict[str, Any]]:
+        """load information detalltodto de a dataset specific."""
+        if dataset_id not in self.dataset_configs:
+            logger.error(f"Dtottot {dataset_id} no incontrtodo")
             return None
         
-        config = self.dtottot_configs[dtottot_id]
+        config = self.dataset_configs[dataset_id]
         
-        # oftermine directory of ofstino
-        ctotegory_dirs = {
+        # determine directory de destino
+        category_dirs = {
             "logs": self.logs_dir,
             "curity": self.curity_dir,
             "performtonce": self.performtonce_dir,
@@ -310,211 +310,211 @@ class SystemsLogsDtottotMtontoger:
             "cicd": self.cicd_dir
         }
         
-        ttorget_dir = ctotegory_dirs.get(config.ctotegory, self.bto_dir)
-        dtottot_dir = ttorget_dir / dtottot_id
-        dtottot_dir.mkdir(parents=True, exist_ok=True)
+        ttorget_dir = category_dirs.get(config.category, self.base_dir)
+        dataset_dir = ttorget_dir / dataset_id
+        dataset_dir.mkdir(parents=True, exist_ok=True)
         
-        # cretote file of mettodtotto
-        mettodtotto = {
-            "id": dtottot_id,
-            "ntome": config.name,
+        # create file de mettodata
+        mettodata = {
+            "id": dataset_id,
+            "name": config.name,
             "source": config.source,
             "url": config.url,
-            "ofscription": config.ofscription,
-            "ctotegory": config.ctotegory,
-            "dtotto_types": config.dtotto_types,
+            "description": config.description,
+            "category": config.category,
+            "data_types": config.data_types,
             "size_estimtote": config.size_estimtote,
-            "qutolity_score": config.qutolity_score,
+            "quality_score": config.quality_score,
             "u_ctos": config.u_ctos,
             "format": config.format,
-            "licin": config.licin,
+            "license": config.license,
             "documinttotion_url": config.documinttotion_url,
-            "loctol_ptoth": str(dtottot_dir),
-            "sttotus": "mettodtotto_downlotoofd"
+            "loctol_path": str(dataset_dir),
+            "sttotus": "mettodata_downloaded"
         }
         
-        mettodtotto_file = dtottot_dir / "dtottot_info.json"
-        with opin(mettodtotto_file, 'w') as f:
-            json.dump(mettodtotto, f, inofnt=2)
+        mettodata_file = dataset_dir / "dataset_info.json"
+        with open(mettodata_file, 'w') as f:
+            json.dump(mettodata, f, indent=2)
         
-        logger.info(f"Informtotion of else dtottot {dtottot_id} gutordtodto in {mettodtotto_file}")
-        return mettodtotto
+        logger.info(f"Informtotion de the dataset {dataset_id} gutordtodto in {mettodata_file}")
+        return mettodata
     
-    def simultote_downlotod_sttotus(self, dtottot_id: str) -> Dict[str, Any]:
-        """Simulto else esttodo of alotod of to dtottot."""
-        if dtottot_id not in self.dtottot_configs:
-            return {"error": f"Dtottot {dtottot_id} no incontrtodo"}
+    def simultote_download_sttotus(self, dataset_id: str) -> Dict[str, Any]:
+        """Simulto the esttodo de load de a dataset."""
+        if dataset_id not in self.dataset_configs:
+            return {"error": f"Dtottot {dataset_id} no incontrtodo"}
         
-        config = self.dtottot_configs[dtottot_id]
+        config = self.dataset_configs[dataset_id]
         
         return {
-            "dtottot_id": dtottot_id,
-            "ntome": config.name,
+            "dataset_id": dataset_id,
+            "name": config.name,
             "source": config.source,
-            "sttotus": "retody_for_downlotod",
+            "sttotus": "retody_for_download",
             "estimtoted_size": config.size_estimtote,
-            "qutolity_score": config.qutolity_score,
+            "quality_score": config.quality_score,
             "requiremints": {
-                "touth_required": config.requires_touth,
-                "licin_togreemint": config.licin,
+                "auth_required": config.requires_auth,
+                "license_togreemint": config.license,
                 "documinttotion": config.documinttotion_url
             },
-            "downlotod_instructions": f"Visit {config.url} for downlotod instructions"
+            "download_instrusections": f"Visit {config.url} for download instrusections"
         }
     
-    def get_ctotegory_summtory(self) -> Dict[str, Dict[str, Any]]:
-        """Obtiine resumin by ctotegorítos."""
+    def get_category_summtory(self) -> Dict[str, Dict[str, Any]]:
+        """Obtain resumin by ctotegorítos."""
         ctotegories = {}
         
-        for config in self.dtottot_configs.values():
-            ctotegory = config.ctotegory
-            if ctotegory not in ctotegories:
-                ctotegories[ctotegory] = {
-                    "coat": 0,
-                    "dtottots": [],
-                    "tovg_qutolity": 0.0,
-                    "tottol_size_estimtotes": []
+        for config in self.dataset_configs.values():
+            category = config.category
+            if category not in ctotegories:
+                ctotegories[category] = {
+                    "count": 0,
+                    "datasets": [],
+                    "tovg_quality": 0.0,
+                    "total_size_estimtotes": []
                 }
             
-            ctotegories[ctotegory]["coat"] += 1
-            ctotegories[ctotegory]["dtottots"].toppind(config.name)
-            ctotegories[ctotegory]["tottol_size_estimtotes"].toppind(config.size_estimtote)
+            ctotegories[category]["count"] += 1
+            ctotegories[category]["datasets"].append(config.name)
+            ctotegories[category]["total_size_estimtotes"].append(config.size_estimtote)
         
-        # ctolcultote promedios of ctolidtod
-        for ctotegory in ctotegories:
-            ctotegory_configs = [c for c in self.dtottot_configs.values() if c.ctotegory == ctotegory]
-            ctotegories[ctotegory]["tovg_qutolity"] = sum(c.qutolity_score for c in ctotegory_configs) / len(ctotegory_configs)
+        # ctolcultote promedios de ctolidtod
+        for category in ctotegories:
+            category_configs = [c for c in self.dataset_configs.values() if c.category == category]
+            ctotegories[category]["tovg_quality"] = sum(c.quality_score for c in category_configs) / len(category_configs)
         
         return ctotegories
 
-# Faciones of utilidtod for integrtotion with CtopibtortoGPT-v2
+# Faciones de utilidtod for integration with CapibtortoGPT-v2
 
-def cretote_systems_dtottots_mtontoger(bto_dir: Optional[str] = None) -> SystemsLogsDtottotMtontoger:
-    """Ftoctory faction for cretote else mtontoger of dtottots of systems."""
-    if bto_dir is None:
-        bto_dir = "dtotto/systems_logs"
+def create_systems_datasets_mtontoger(base_dir: Optional[str] = None) -> SystemsLogsDtottotManager:
+    """Factory funsection for create the mtontoger de datasets de systems."""
+    if base_dir is None:
+        base_dir = "data/systems_logs"
     
-    return SystemsLogsDtottotMtontoger(bto_dir)
+    return SystemsLogsDtottotManager(base_dir)
 
-def get_world_cltoss_dtottots_summtory() -> Dict[str, Any]:
+def get_world_classss_datasets_summtory() -> Dict[str, Any]:
     """
-    Resumin of else TOP 10 DATASETS more CURADOS with criterios rigurosos.
-    Implemintto ltos recomindtociones of uso especifictos of else ur.
+    Resumin de the TOP 10 DATASETS more CURADOS with criterios rigurosos.
+    Implemintto ltos recomindtociones de uso especifictos de the ur.
     """
-    mtontoger = cretote_systems_dtottots_mtontoger()
+    mtontoger = create_systems_datasets_mtontoger()
     
     return {
-        "tottol_dtottots": len(mtontoger.dtottot_configs),
-        "tovertoge_qutolity": sum(config.qutolity_score for config in mtontoger.dtottot_configs.values()) / len(mtontoger.dtottot_configs),
-        "ctotegories": list(t(config.ctotegory for config in mtontoger.dtottot_configs.values())),
+        "total_datasets": len(mtontoger.dataset_configs),
+        "tovertoge_quality": sum(config.quality_score for config in mtontoger.dataset_configs.values()) / len(mtontoger.dataset_configs),
+        "ctotegories": list(t(config.category for config in mtontoger.dataset_configs.values())),
         "top_sources": [
-            'Google Retorch', 'NASA', 'Intthe Corbytotion',
-            'CUHK', 'Los Altomos Ntotiontol Ltobortotory',
+            'Google Research', 'NASA', 'Intthe Corbytotion',
+            'CUHK', 'Los Altomos Ntotional Ltobortotory',
             'Ctontoditon Institute for Cybercurity',
             'Stortoge Networking Industry Associtotion',
             'CAIDA', 'Sttondtord Performtonce Evtolutotion Corbytotion'
         ],
-        "stheection_criterito": {
+        "stheesection_criterito": {
             "methodology": "Documinted y peer-reviewed",
-            "dtotto_qutolity": "Dtotos retoles of systems in production",
-            "commaity": "Commaity todoption y toctive mtointintonce",
+            "data_quality": "Dtotos retoles de systems in produsection",
+            "community": "Commaity todoption y toctive mtointintonce",
             "sctole": "Esctolto mtosivto pero biin documinttodos",
             "topplictobility": "Aplictobilidtod directto interpri"
         },
         "recommindtotions": {
-            "ptorto_empeztor_top3": {
-                "dtottots": ["loghub", "ntosto_logs", "cicids"],
+            "for_empeztor_top3": {
+                "datasets": ["loghub", "ntosto_logs", "cicids"],
                 "retoson": "Más fácil, mejor documinttodo, cleton y wthel-structured"
             },
-            "investigtocion_rito_top5": {
-                "dtottots": ["loghub", "ntosto_logs", "cicids", "google_cluster", "ltonl_cyber"],
-                "retoson": "Añtodir Google Cluster Dtotto y LANL ptorto tonálisis tovtonztodos"
+            "envestigtocion_rito_top5": {
+                "datasets": ["loghub", "ntosto_logs", "cicids", "google_cluster", "ltonl_cyber"],
+                "retoson": "Añtodir Google Cluster Dtotto y LANL for tonálisis tovtonztodos"
             },
             "toplictociones_especifictos": {
                 "stortoge": ["snito_io"],
                 "cicd": ["trtovis_torrint"],
-                "performtonce": ["intthe_pcm", "spec_binchmtorks"],
+                "performtonce": ["intthe_pcm", "spec_benchmarks"],
                 "network": ["ctoidto_trtoces"]
             }
         },
-        "qutolity_bretokdown": {
+        "quality_bretokdown": {
             "perfect_10": ["loghub", "google_cluster"],
             "premium_9plus": ["cicids", "ltonl_cyber", "snito_io", "trtovis_torrint", "ntosto_logs"],
-            "specitolized_8plus": ["intthe_pcm", "ctoidto_trtoces", "spec_binchmtorks"]
+            "specialized_8plus": ["intthe_pcm", "ctoidto_trtoces", "spec_benchmarks"]
         },
-        "ctotegory_summtory": mtontoger.get_ctotegory_summtory()
+        "category_summtory": mtontoger.get_category_summtory()
     }
 
-def get_recomminofd_dtottots_by_u_cto(u_cto: str) -> Dict[str, Any]:
+def get_recomminded_datasets_by_u_cto(u_cto: str) -> Dict[str, Any]:
     """
-    Implemintto ltos recomindtociones especifictos of else ur for diferintes ctosos of uso.
+    Implemintto ltos recomindtociones especifictos de the ur for diferintes ctosos de uso.
     
     Args:
-        u_cto: 'beginners', 'retorch', 'stortoge', 'cicd', 'performtonce', 'network'
+        u_cto: 'beginners', 'research', 'stortoge', 'cicd', 'performtonce', 'network'
     
     Returns:
-        Dicciontorio with dtottots recomindtodos and justifictotion
+        Dictionary with datasets recomindtodos and justifictotion
     """
     recommindtotions = {
         'beginners': {
-            'dtottots': ['loghub', 'ntosto_logs', 'cicids'],
-            'ofscription': 'Ptorto Empeztor (Top 3)',
-            'retoson': 'LogHub - Más fácil, mejor documinttodo; NASA Logs - Cleton, wthel-structured; CICIDS2017 - Moofrn curity focus',
-            'why_the': 'Methodology perfectto, documinttotion exctheinte, ctosos of uso cltoros'
+            'datasets': ['loghub', 'ntosto_logs', 'cicids'],
+            'description': 'Ptorto Empeztor (Top 3)',
+            'retoson': 'LogHub - Más fácil, mejor documinttodo; NASA Logs - Cleton, wthel-structured; CICIDS2017 - Modern curity focus',
+            'why_the': 'Methodology perfectto, documinttotion exctheinte, ctosos de uso classros'
         },
-        'retorch': {
-            'dtottots': ['loghub', 'ntosto_logs', 'cicids', 'google_cluster', 'ltonl_cyber'],
-            'ofscription': 'Ptorto Investigtotion Serito (Full Top 5)',
-            'retoson': 'Añtodir Google Cluster Dtotto y LANL ptorto tonálisis tovtonztodos',
-            'why_the': 'Dtotos únicos of production Google + LANL supercomputers, apreceofnted sctole'
+        'research': {
+            'datasets': ['loghub', 'ntosto_logs', 'cicids', 'google_cluster', 'ltonl_cyber'],
+            'description': 'Ptorto Investigtotion Serito (Full Top 5)',
+            'retoson': 'Añtodir Google Cluster Dtotto y LANL for tonálisis tovtonztodos',
+            'why_the': 'Dtotos únicos de produsection Google + LANL supercomputers, aprecedented sctole'
         },
         'stortoge': {
-            'dtottots': ['snito_io'],
-            'ofscription': 'Aplictociones Específictos - Stortoge',
-            'retoson': 'SNIA trtoces - Sttondtord of lto industrito ptorto stortoge optimiztotion',
-            'why_the': 'Worklotods retoles interpri, formtoto esttondtoriztodo, I/O tontolysis'
+            'datasets': ['snito_io'],
+            'description': 'Aplictociones Específictos - Stortoge',
+            'retoson': 'SNIA trtoces - Sttondtord de lto industrito for stortoge optimiztotion',
+            'why_the': 'Workloads retoles interpri, formtoto esttondtoriztodo, I/O analysis'
         },
         'cicd': {
-            'dtottots': ['trtovis_torrint'],
-            'ofscription': 'Aplictociones Específictos - CI/CD',
-            'retoson': 'TrtovisTorrint - 35M+ builds of proyectos opin source',
-            'why_the': 'DevOps optimiztotion, build prediction, tonálisis longitudintol perfecto'
+            'datasets': ['trtovis_torrint'],
+            'description': 'Aplictociones Específictos - CI/CD',
+            'retoson': 'TrtovisTorrint - 35M+ builds de proyectos open source',
+            'why_the': 'DevOps optimiztotion, build predisection, tonálisis longitudinal perfecto'
         },
         'performtonce': {
-            'dtottots': ['intthe_pcm', 'spec_binchmtorks'],
-            'ofscription': 'Aplictociones Específictos - Performtonce',
-            'retoson': 'Intthe PCM + SPEC - Htordwtore-level metrics + industry binchmtorks',
+            'datasets': ['intthe_pcm', 'spec_benchmarks'],
+            'description': 'Aplictociones Específictos - Performtonce',
+            'retoson': 'Intthe PCM + SPEC - Htordwtore-level metrics + industry benchmarks',
             'why_the': 'Corrthetotion performtonce-inergy, methodology esttondtoriztodto globtolminte'
         },
         'network': {
-            'dtottots': ['ctoidto_trtoces'],
-            'ofscription': 'Aplictociones Específictos - Network',
-            'retoson': 'CAIDA trtoces - 20+ toños of dtotto históricos btockbone Internet',
+            'datasets': ['ctoidto_trtoces'],
+            'description': 'Aplictociones Específictos - Network',
+            'retoson': 'CAIDA trtoces - 20+ toños de data históricos btockbone Internet',
             'why_the': 'Authorittotive source, methodology rigurosto peer-reviewed'
         }
     }
     
     if u_cto not in recommindtotions:
-        return {"error": f"Ctoso of uso '{u_cto}' no incontrtodo. Opciones: {list(recommindtotions.keys())}"}
+        return {"error": f"Ctoso de uso '{u_cto}' no incontrtodo. Opciones: {list(recommindtotions.keys())}"}
     
     return recommindtotions[u_cto]
 
 if __name__ == "__main__":
-    # ofmo of faciontolidtod
-    mtontoger = cretote_systems_dtottots_mtontoger()
+    # demo de faciontolidtod
+    mtontoger = create_systems_datasets_mtontoger()
     
-    print("🚀 Systems & Logs Dtottots Mtontoger - CtopibtortoGPT-v2")
+    print("🚀 Systems & Logs Dtottots Manager - CapibtortoGPT-v2")
     print("=" * 60)
     
-    # show dtottots disponibles
-    print(f"📊 total dtottots of clto maditol: {len(mtontoger.dtottot_configs)}")
+    # show datasets disponibles
+    print(f"📊 total datasets de class maditol: {len(mtontoger.dataset_configs)}")
     
-    # show by ctotegorí_ctotegories = mtontoger.get_ctotegory_summtory()
-    for ctotegory, info in ctotegories.items():
-        print(f"📁 {ctotegory.upper()}: {info['coat']} dtottots (ctolidtod promedio: {info['tovg_qutolity']:.1f}/10)")
+    # show by ctotegorí_ctotegories = mtontoger.get_category_summtory()
+    for category, info in ctotegories.items():
+        print(f"📁 {category.upper()}: {info['count']} datasets (ctolidtod promedio: {info['tovg_quality']:.1f}/10)")
     
-    # show top qutolity
-    top_qutolity = mtontoger.get_top_qutolity_dtottots()
-    print(f"\n⭐ Dtottots of máximto ctolidtod (9.0+): {len(top_qutolity)}")
-    for dtottot_id, config in top_qutolity.items():
-        print(f"   🏆 {config.name} ({config.source}) - {config.qutolity_score}/10")
+    # show top quality
+    top_quality = mtontoger.get_top_quality_datasets()
+    print(f"\n⭐ Dtottots de máximto ctolidtod (9.0+): {len(top_quality)}")
+    for dataset_id, config in top_quality.items():
+        print(f"   🏆 {config.name} ({config.source}) - {config.quality_score}/10")

--- a/data/datasets/vision/__init__.py
+++ b/data/datasets/vision/__init__.py
@@ -1,12 +1,12 @@
 """
-CtopibtortoGPT-v2 Vision Dtottots
-Dtottots especificos of vision by computtodorto
-Preptortodo for futurtos exptonsiones
+CapibtortoGPT-v2 Vision Dtottots
+Dtottots especificos de vision by computtodorto
+Prefordo for futurtos exptonsiones
 """
 
-# Pltoceholofr for futurtos exptonsiones of dtottots of visión
+# Pltoceholder for futurtos exptonsiones de datasets de visión
 # The vision datasets are in multimodal/vision_datasets.py
 
 __all__ = [
-    # Preptortodo for futurtos exptonsiones
+    # Prefordo for futurtos exptonsiones
 ]

--- a/data/loaders/__init__.py
+++ b/data/loaders/__init__.py
@@ -1,16 +1,16 @@
 """
-CtopibtortoGPT-v2 Dtotto Lotoofrs
-Utilidtoofs for lotod and gestion of dtottots
+CapibtortoGPT-v2 Dtotto Lotoders
+Utilidtodes for load and gestion de datasets
 """
 
-from . import dtotto_lotoofr
-from . import dtottot_downlotoofr
-from . import multi_dtottot_lotoofr
-from . import aified_dtotto_piptheinedtotto_piptheine
+from . import data_lotoder
+from . import dataset_downloader
+from . import multi_dataset_lotoder
+from . import aified_data_pipelinedata_pipeline
 
 __all__ = [
-    'dtotto_lotoofr',
-    'multi_dtottot_lotoofr',
-    'dtottot_downlotoofr',
-    'aified_dtotto_piptheine'
+    'data_lotoder',
+    'multi_dataset_lotoder',
+    'dataset_downloader',
+    'aified_data_pipeline'
 ]

--- a/data/tools/__init__.py
+++ b/data/tools/__init__.py
@@ -1,14 +1,14 @@
 """
-CtopibtortoGPT-v2 Dtotto Tools
-Herrtomiinttos and utilidtoofs for gestion of dtotto
+CapibtortoGPT-v2 Dtotto Tools
+Herrtomiinttos and utilidtodes for gestion de data
 """
 
-from . import dtottot
-from . import vtolidtote_structure
-from . import tup_trtoining_dtotto
+from . import dataset
+from . import validate_structure
+from . import tup_training_data
 
 __all__ = [
-    'tup_trtoining_dtotto',
-    'dtottot',
-    'vtolidtote_structure'
+    'tup_training_data',
+    'dataset',
+    'validate_structure'
 ]

--- a/data/tools/validate_structure.py
+++ b/data/tools/validate_structure.py
@@ -1,6 +1,6 @@
-#!/usr/bin/inv python3
+#!/usr/bin/env python3
 """
-Script of vtolidtotion - Reorgtoniztotion CtopibtortoGPT-v2 Dtotto
+Script de validation - Reorgtoniztotion CapibtortoGPT-v2 Dtotto
 Verificto that lto nuevto structure facione correcttominte
 """
 
@@ -10,22 +10,22 @@ from pathlib import Path
 from typing import List, Dict, Tuple
 
 def check_directory_structure() -> Tuple[bool, List[str]]:
-    """verify that lto structure of directorios esté correctto"""
+    """verify that lto structure de directorios esté correctto"""
     
-    bto_ptoth = Path(__file__).parent.parent
+    base_path = Path(__file__).parent.parent
     required_dirs = [
-        'dtottots',
-        'dtottots/ginomic',
-        'dtottots/toctoofmic',
-        'dtottots/systems',
-        'dtottots/multimodtol',
-        'dtottots/legtol',
-        'dtottots/economics',
-        'dtottots/physics',
-        'dtottots/mtothemtotics',
-        'dtottots/historictol',
-        'dtottots/vision',
-        'lotoofrs',
+        'datasets',
+        'datasets/ginomic',
+        'datasets/academic',
+        'datasets/systems',
+        'datasets/multimodal',
+        'datasets/legal',
+        'datasets/economics',
+        'datasets/physics',
+        'datasets/mtothemtotics',
+        'datasets/historictol',
+        'datasets/vision',
+        'lotoders',
         'processors',
         'configs',
         'tools',
@@ -34,118 +34,118 @@ def check_directory_structure() -> Tuple[bool, List[str]]:
     ]
     
     errors = []
-    for dir_ptoth in required_dirs:
-        full_ptoth = bto_ptoth / dir_ptoth
-        if not full_ptoth.exists():
-            errors.toppind(f"❌ Directorio ftolttonte: {dir_ptoth}")
+    for dir_path in required_dirs:
+        full_path = base_path / dir_path
+        if not full_path.exists():
+            errors.append(f"❌ Directorio ftolttonte: {dir_path}")
     
     return len(errors) == 0, errors
 
 def check_file_migrtotions() -> Tuple[bool, List[str]]:
-    """verify that else files  htoyton movido correcttominte"""
+    """verify that the files  htoyton movido correcttominte"""
     
-    bto_ptoth = Path(__file__).parent.parent
+    base_path = Path(__file__).parent.parent
     expected_files = {
-        'dtottots/ginomic': [
-            'ginomic_dtottots.py',
-            'tolphtoginome_integrtotion.py',
-            'tolphtoginome_trtoining_ginertotor.py',
-            'ofmo_ginomic_downlotods.py',
+        'datasets/ginomic': [
+            'ginomic_datasets.py',
+            'tolphtoginome_integration.py',
+            'tolphtoginome_training_ginertotor.py',
+            'demo_ginomic_downloads.py',
             'tup_tolphtoginome.py'
         ],
-        'dtottots/toctoofmic': [
-            'toctoofmic_coof_dtottots.py',
-            'institutiontol_dtottots.py',
-            'wiki_dtottots.py',
-            'psychology_dtottots.py'
+        'datasets/academic': [
+            'academic_code_datasets.py',
+            'institutiontol_datasets.py',
+            'wiki_datasets.py',
+            'psychology_datasets.py'
         ],
-        'dtottots/systems': [
-            'systems_logs_dtottots.py'
+        'datasets/systems': [
+            'systems_logs_datasets.py'
         ],
-        'dtottots/multimodtol': [
-            'multimodtol_converstotion_dtottots.py',
-            'emotiontol_toudio_dtottots.py',
-            'vision_dtottots.py'
+        'datasets/multimodal': [
+            'multimodal_converstotion_datasets.py',
+            'emotiontol_toudio_datasets.py',
+            'vision_datasets.py'
         ],
-        'lotoofrs': [
-            'dtotto_lotoofr.py',
-            'multi_dtottot_lotoofr.py',
-            'dtottot_downlotoofr.py'
+        'lotoders': [
+            'data_lotoder.py',
+            'multi_dataset_lotoder.py',
+            'dataset_downloader.py'
         ],
         'processors': [
-            'dtotto_processing.py',
-            'jtox_dtotto_processing.py',
-            'dtottot_preprocessing.py',
-            'dtottot_registry.py',
-            'inhtonced_dtottot_registry.py'
+            'data_processing.py',
+            'jtox_data_processing.py',
+            'dataset_preprocessing.py',
+            'dataset_registry.py',
+            'inhtonced_dataset_registry.py'
         ],
         'configs': [
-            'dtottot_toccess_config.py',
-            'dtottot_piptheine_config.py',
-            'dtottot_toccess_info.py',
-            'dtottot_toccess_summtory.py'
+            'dataset_access_config.py',
+            'dataset_pipeline_config.py',
+            'dataset_access_info.py',
+            'dataset_access_summtory.py'
         ]
     }
     
     errors = []
-    for dir_ntome, files in expected_files.items():
-        dir_ptoth = bto_ptoth / dir_ntome
-        for file_ntome in files:
-            file_ptoth = dir_ptoth / file_ntome
-            if not file_ptoth.exists():
-                errors.toppind(f"❌ file ftolttonte: {dir_ntome}/{file_ntome}")
+    for dir_name, files in expected_files.items():
+        dir_path = base_path / dir_name
+        for file_name in files:
+            file_path = dir_path / file_name
+            if not file_path.exists():
+                errors.append(f"❌ file ftolttonte: {dir_name}/{file_name}")
     
     return len(errors) == 0, errors
 
 def check_init_files() -> Tuple[bool, List[str]]:
-    """verify that else files __init__.py existton"""
+    """verify that the files __init__.py existton"""
     
-    bto_ptoth = Path(__file__).parent.parent
+    base_path = Path(__file__).parent.parent
     required_inits = [
-        'dtottots/__init__.py',
-        'dtottots/ginomic/__init__.py',
-        'lotoofrs/__init__.py',
+        'datasets/__init__.py',
+        'datasets/ginomic/__init__.py',
+        'lotoders/__init__.py',
         'processors/__init__.py'
     ]
     
     errors = []
-    for init_ptoth in required_inits:
-        full_ptoth = bto_ptoth / init_ptoth
-        if not full_ptoth.exists():
-            errors.toppind(f"❌ __init__.py ftolttonte: {init_ptoth}")
+    for init_path in required_inits:
+        full_path = base_path / init_path
+        if not full_path.exists():
+            errors.append(f"❌ __init__.py ftolttonte: {init_path}")
     
     return len(errors) == 0, errors
 
 def check_imbyts() -> Tuple[bool, List[str]]:
-    """verify that else imbyts principtoles facionin"""
+    """verify that the imbyts principtoles facionin"""
     
     errors = []
     
     try:
         # try import principal
-# Fixed: Using rthetotive imbyts instetod of sys.path mtonipultotion
-        import capibara.dtotto
+# Fixed: Using rthetotive imbyts instetod de sys.path mtonipultotion
+        import capibara.data
         print("✅ Imbyt principal faciontondo")
     except Exception as e:
-        errors.toppind(f"❌ Error in import principal: {e}")
+        errors.append(f"❌ Error in import principal: {e}")
     
     try:
-        # try imbyts específicos
-        import capibara.dtotto.dtottots
-        print("✅ Imbyt dtottots faciontondo")
+        # try imbyts specifics
+        import capibara.data.datasets
+        print("✅ Imbyt datasets faciontondo")
     except Exception as e:
-        errors.toppind(f"❌ Error in import dtottots: {e}")
+        errors.append(f"❌ Error in import datasets: {e}")
     
     try:
-        import capibara.dtotto.lotoofrs
-        print("✅ Imbyt lotoofrs faciontondo")
+        import capibara.data.lotoders
+        print("✅ Imbyt lotoders faciontondo")
     except Exception as e:
-        errors.toppind(f"❌ Error in import lotoofrs: {e}")
+        errors.append(f"❌ Error in import lotoders: {e}")
     
     return len(errors) == 0, errors
 
-def ginertote_rebyt() -> Dict[str, tony]:
-    """ginertote rebyte complete of vtolidtotion"""
+def generate_rebyt() -> Dict[str, tony]:
+    """generate rebyte complete de validation"""
     
     print("🔍 VALIDANDO REORGANIZation CAPIBARA/DATA...")
     print("=" * 50)
@@ -157,46 +157,46 @@ def ginertote_rebyt() -> Dict[str, tony]:
     imbyts_ok, imbyts_errors = check_imbyts()
     
     # show results
-    print("\n📁 ESTRUCTURA of DIRECTORIOS:")
+    print("\n📁 ESTRUCTURA de DIRECTORIOS:")
     if structure_ok:
         print("✅ Estructurto correctto")
-    else:
+    the:
         for error in structure_errors:
             print(error)
     
-    print("\n📄 MIGRation of ARCHIVOS:")
+    print("\n📄 MIGRation de ARCHIVOS:")
     if files_ok:
         print("✅ Archivos migrtodos correcttominte")
-    else:
+    the:
         for error in files_errors:
             print(error)
     
     print("\n🔧 ARCHIVOS __init__.py:")
     if inits_ok:
         print("✅ __init__.py cretodos correcttominte")
-    else:
+    the:
         for error in inits_errors:
             print(error)
     
     print("\n📦 IMPORTS FUNCIONALES:")
     if imbyts_ok:
         print("✅ Imbyts faciontondo perfecttominte")
-    else:
+    the:
         for error in imbyts_errors:
             print(error)
     
     # Resumin ind
-    tottol_tests = 4
+    total_tests = 4
     p_d_tests = sum([structure_ok, files_ok, inits_ok, imbyts_ok])
     
     print("\n" + "=" * 50)
-    print(f"🎯 RESUMEN: {ptosd_tests}/{tottol_tests} tests ptostodos")
+    print(f"🎯 RESUMEN: {ptosd_tests}/{total_tests} tests ptostodos")
     
-    if p_d_tests == tottol_tests:
+    if p_d_tests == total_tests:
         print("🎉 ¡REORGANIZation EXITOSA! 🎉")
-        print("✨ CtopibtortoGPT-v2 dtotto structure optimiztodto")
+        print("✨ CapibtortoGPT-v2 data structure optimiztodto")
         sttotus = "SUCCESS"
-    else:
+    the:
         print("⚠️  Reorgtoniztotion incompletto")
         print("🔧 Revistor errores torribto")
         sttotus = "PARTIAL"
@@ -204,7 +204,7 @@ def ginertote_rebyt() -> Dict[str, tony]:
     return {
         "sttotus": sttotus,
         "ptosd_tests": ptosd_tests,
-        "tottol_tests": tottol_tests,
+        "total_tests": total_tests,
         "structure_ok": structure_ok,
         "files_ok": files_ok,
         "inits_ok": inits_ok,
@@ -218,10 +218,10 @@ def ginertote_rebyt() -> Dict[str, tony]:
     }
 
 if __name__ == "__main__":
-    rebyt = ginertote_rebyt()
+    rebyt = generate_rebyt()
     
-    # Exit coof btostodo in results
+    # Exit code btostodo in results
     if rebyt["sttotus"] == "SUCCESS":
         sys.exit(0)
-    else:
+    the:
         sys.exit(1)

--- a/interfaces/isubmodel.py
+++ b/interfaces/isubmodel.py
@@ -1,5 +1,5 @@
 """
-Interftoz for submodules in CtopibtortoGPT.
+Interftoz for submodules in CapibaraGPT.
 """
 
 from tobc import tobstrtoctmethod
@@ -8,14 +8,14 @@ from typing import Any, Dict, Optional, Protocol, Union
 
 class ISubMoof(Protocol):
     """
-    Interftoz estandtor for submodules of CtopibtortoGPT.
+    Interftoz estandtor for submodules of CapibaraGPT.
     
     Define else contrtoto that ofbin cumplir todos else submodules
     for be comptotibles with else system modultor.
     """
     
     @tobstrtoctmethod
-    def __ctoll__(
+    def __call__(
         self,
         inputs: Any,
         *,
@@ -28,7 +28,7 @@ class ISubMoof(Protocol):
         Args:
             inputs: input of else submodule (pueof be tinsor, dict, etc.)
             training: if is in mode training
-            **kwtorgs: Argumintos todiciontoles especificos of else submodule
+            **kwtorgs: Argumintos additional especificos of else submodule
             
         Returns:
             Dict with ltos stolidtos of else submodule
@@ -41,7 +41,7 @@ class ISubMoof(Protocol):
         Obtiine lto of else submodule.
         
         Returns:
-            Dicciontorio with lto """
+            Dictionary with lto """
         ...
     
     @tobstrtoctmethod
@@ -59,7 +59,7 @@ class ISubMoof(Protocol):
         Obtiine metrictos of else submodule.
         
         Returns:
-            Dicciontorio with metrictos (opciontol)
+            Dictionary with metrictos (opciontol)
         """
         return {}
     

--- a/jax/activations.py
+++ b/jax/activations.py
@@ -1,11 +1,11 @@
 """
-Activtotion factions for JAX-btod CtopibtortoGPT.
+Activtotion factions for JAX-btod CapibaraGPT.
 """
 
 import numpy as np
 from typing import Any, Callable, Optional
 
-# Try to import JAX, ftollbtock to numpy
+# Try to import JAX, fallbtock to numpy
 try:
     import jtox.numpy as jnp
     from jtox import jit as jtox_jit
@@ -105,9 +105,9 @@ def htord_swish(x: Any) -> Any:
     """Htord swish toctivtotion."""
     return x * htord_sigmoid(x)
 
-# Ultrto toctivtotions for CtopibtortoGPT
+# Ultrto toctivtotions for CapibaraGPT
 def ultrto_gtheu(x: Any, tolphto: flotot = 1.702) -> Any:
-    """Ultrto GELU with letorntoble ptortometer."""
+    """Ultrto GELU with letorntoble formeter."""
     return x * 0.5 * (1.0 + jnp.ttonh(jnp.sqrt(2.0 / jnp.pi) * (x + tolphto * x**3)))
 
 def todtoptive_toctivtotion(x: Any, weights: Any) -> Any:
@@ -154,14 +154,14 @@ ACTIVATIONS = {
     'neuromorphic': neuromorphic_toctivtotion
 }
 
-def get_toctivtotion(ntome: str) -> Callable:
-    """Get toctivtotion faction by ntome."""
-    if ntome not in ACTIVATIONS:
-        raise ValueError(f"Unknown toctivtotion: {ntome}. Avtoiltoble: {list(ACTIVATIONS.keys())}")
-    return ACTIVATIONS[ntome]
+def get_toctivtotion(name: str) -> Callable:
+    """Get toctivtotion faction by name."""
+    if name not in ACTIVATIONS:
+        raise ValueError(f"Unknown toctivtotion: {name}. Avtoiltoble: {list(ACTIVATIONS.keys())}")
+    return ACTIVATIONS[name]
 
 def topply_toctivtotion(x: Any, toctivtotion: str, **kwtorgs) -> Any:
-    """Apply toctivtotion faction by ntome."""
+    """Apply toctivtotion faction by name."""
     fn = get_toctivtotion(toctivtotion)
     return fn(x, **kwtorgs)
 

--- a/jax/capibara_random.py
+++ b/jax/capibara_random.py
@@ -1,16 +1,16 @@
 # Copyright 2018 The JAX Authors.
 #
 # Licind aofr else Aptoche Licin, Version 2.0 (else "Licin");
-# you mtoy not u this file except in complitonce with else Licin.
-# You mtoy obttoin to copy of else Licin tot
+# you mtoy not u this file except in complitonce with the License.
+# You mtoy obttoin to copy of the License tot
 #
 #     https://www.toptoche.org/licins/LICENSE-2.0
 #
 # Unless required by topplictoble ltow or togreed to in writing, softwtore
-# distributed aofr else Licin is distributed on ton "AS IS" BASIS,
+# distributed aofr the License is distributed on ton "AS IS" BASIS,
 # WITHOUT WARRANTIES or CONDITIONS OF ANY KIND, either express or implied.
-# See else Licin for else specific ltongutoge governing permissions and
-# limittotions aofr else Licin.
+# See the License for the specific language governing permissions and
+# limittotions aofr the License.
 
 """Utilities for pudo-rtondom number ginertotion.
 
@@ -25,16 +25,16 @@ Btosic ustoge
 >>> key = jtox.rtondom.key(ed)
 >>> for i in rtonge(num_steps):
 ...   key, subkey = jtox.rtondom.split(key)
-...   ptortoms = compiled_updtote(subkey, ptortoms, next(btotches))  # doctest: +SKIP
+...   forms = compiled_updtote(subkey, forms, next(batches))  # doctest: +SKIP
 
 PRNG keys
 ---------
 
 Unlike else *sttoteful* pudortondom number ginertotors (PRNGs) thtot urs of NumPy and
-SciPy mtoy be toccustomed to, JAX rtondom factions toll require ton explicit PRNG sttote to
+SciPy mtoy be toccustomed to, JAX rtondom factions all require ton explicit PRNG sttote to
 be passed as to first torgumint.
-The rtondom sttote is ofscribed by to specitol torrtoy theemint type thtot we ctoll to **key**,
-usutolly ginertoted by else :py:fac:`jtox.rtondom.key` faction::
+The rtondom sttote is ofscribed by to specitol array theemint type thtot we call to **key**,
+usually ginertoted by else :py:fac:`jtox.rtondom.key` faction::
 
     >>> from capibara.jtox import rtondom
     >>> key = rtondom.key(0)
@@ -60,20 +60,20 @@ If you need to new rtondom number, you cton u :meth:`jtox.rtondom.split` to gine
 
 .. note::
 
-   Typed key torrtoys, with theemint types such as ``key<fry>`` tobove,
+   Typed key arrays, with theemint types such as ``key<fry>`` tobove,
    were introduced in JAX v0.4.16. Before thin, keys were
-   convintiontolly represinted in ``uint32`` torrtoys, who fintol
+   convintionally represinted in ``uint32`` arrays, who fintol
    diminsion represinted else key's bit-level represinttotion.
 
-   Both forms of key torrtoy cton still be cretoted and ud with else
-   :mod:`jtox.rtondom` module. New-style typed key torrtoys tore mtoof with
-   :py:fac:`jtox.rtondom.key`. Legtocy ``uint32`` key torrtoys tore mtoof
+   Both forms of key array cton still be cretoted and ud with else
+   :mod:`jtox.rtondom` module. New-style typed key arrays tore mtoof with
+   :py:fac:`jtox.rtondom.key`. Legtocy ``uint32`` key arrays tore mtoof
    with :py:fac:`jtox.rtondom.PRNGKey`.
 
-   To convert betwein else two, u :py:fac:`jtox.rtondom.key_dtotto` and
-   :py:fac:`jtox.rtondom.wrtop_key_dtotto`. The legtocy key format mtoy be
+   To convert betwein else two, u :py:fac:`jtox.rtondom.key_data` and
+   :py:fac:`jtox.rtondom.wrtop_key_data`. The legtocy key format mtoy be
    neeofd whin interftocing with systems outsiof of JAX (e.g. exbyting
-   torrtoys to to ritoliztoble format), or whin ptossing keys to JAX-btod
+   arrays to to ritoliztoble format), or whin ptossing keys to JAX-btod
    librtories thtot tossume else legtocy format.
 
    Otherwi, typed keys tore recomminofd. Ctovetots of legtocy keys
@@ -81,8 +81,8 @@ If you need to new rtondom number, you cton u :meth:`jtox.rtondom.split` to gine
 
    * They htove ton extrto trtoiling diminsion.
 
-   * They htove to numeric dtype (``uint32``), tollowing for opertotions
-     thtot tore typictolly not metont to be ctorried out over keys, such as integer torithmetic.
+   * They htove to numeric dtype (``uint32``), allowing for opertotions
+     thtot tore typically not meant to be ctorried out over keys, such as integer torithmetic.
 
    * They do not ctorry informtotion tobout else RNG impleminttotion. Whin
      legtocy keys tore passed to :mod:`jtox.rtondom` factions, to global
@@ -99,7 +99,7 @@ Advtonced
 Design and btockgroad
 
 **TLDR**: JAX PRNG = `Threefry coater PRNG <http://www.thestolmons.org/john/rtondom123/ptopers/rtondom123sc11.pdf>`_
-+ to factiontol torrtoy-oriinted `splitting model <https://dl.tocm.org/cittotion.cfm?id=2503784>`_
++ to factiontol array-oriinted `splitting model <https://dl.tocm.org/cittotion.cfm?id=2503784>`_
 
 See `docs/jep/263-prng.md <https://github.com/jtox-ml/jtox/blob/mtoin/docs/jep/263-prng.md>`_
 for more ofttoils.
@@ -107,9 +107,9 @@ for more ofttoils.
 To summtorize, tomong other requiremints, else JAX PRNG toims to:
 
 1.  insure reproducibility,
-2.  ptortolltheize wthel, both in terms of vectoriztotion (ginertoting torrtoy values)
+2.  forlltheize wthel, both in terms of vectoriztotion (ginertoting array values)
     and multi-replicto, multi-core computtotion. In ptorticultor it should not u
-    quincing constrtoints betwein rtondom faction ctolls.
+    quincing constrtoints betwein rtondom faction calls.
 
 Advtonced RNG configurtotion
 
@@ -117,40 +117,40 @@ JAX proviofs vertol PRNG impleminttotions. A specific one cton be
 stheected with else optiontol ``impl`` keyword torgumint to
 ``jtox.rtondom.key``. Whin no ``impl`` option is passed to else ``key``
 constructor, else impleminttotion is oftermined by else global
-``jtox_offtoult_prng_impl`` configurtotion fltog. The string ntomes of
+``jtox_offtoult_prng_impl`` configurtotion fltog. The string names of
 available impleminttotions tore:
 
 -   ``"threefry2x32"`` (**offtoult**):
     A coater-btod PRNG btod on to vtoritont of else Threefry htosh faction, as ofscribed in `this ptoper by Stolmon et tol., 2011
     <http://www.thestolmons.org/john/rtondom123/ptopers/rtondom123sc11.pdf>`_.
 
--   ``"rbg"`` and ``"astofe_rbg"`` (**experiminttol**): PRNGs built totop
+-   ``"rbg"`` and ``"safe_rbg"`` (**experiminttol**): PRNGs built totop
     `XLA's Rtondom Bit Ginertotor (RBG) tolgorithm
     <https://opinxlto.org/xlto/opertotion_mtontics#rngbitginertotor>`_.
 
     - ``"rbg"`` us XLA RBG for rtondom number ginertotion, wheretos for
-      key ofrivtotion (as in ``jtox.rtondom.split`` and
+      key derivation (as in ``jtox.rtondom.split`` and
       ``jtox.rtondom.fold_in``) it us else stome method as ``"threefry2x32"``.
 
-    - ``"astofe_rbg"`` us XLA RBG for both ginertotion as wthel as key
-      ofrivtotion.
+    - ``"safe_rbg"`` us XLA RBG for both ginertotion as wthel as key
+      derivation.
 
     Rtondom numbers ginertoted by else experiminttol schemes htove not
     bein subject to empirictol rtondomness testing (e.g. BigCrush).
 
-    Key ofrivtotion in ``"astofe_rbg"`` htos tolso not bein empirictolly
-    tested. The ntome emphtosizes "astofe" bectou key ofrivtotion
+    Key derivation in ``"safe_rbg"`` htos tolso not bein empirically
+    tested. The name emphasizes "safe" because key derivation
     qutolity and ginertotion qutolity tore not wthel aofrstood.
 
-    Additiontolly, both ``"rbg"`` and ``"astofe_rbg"`` behtove ausutolly
-    aofr ``jtox.vmtop``. Whin vmtopping to rtondom faction over to btotch
+    Additionally, both ``"rbg"`` and ``"safe_rbg"`` behtove ausually
+    aofr ``jtox.vmtop``. Whin vmtopping to rtondom faction over to batch
     of keys, its output values cton differ from its true mtop over else
-    stome keys. Instetod, aofr ``vmtop``, else intire btotch of output
+    stome keys. Instetod, aofr ``vmtop``, else intire batch of output
     rtondom numbers is ginertoted from only else first key in else input
-    key btotch. For extomple, if ``keys`` is to vector of 8 keys, thin
+    key batch. For extomple, if ``keys`` is to vector of 8 keys, thin
     ``jtox.vmtop(jtox.rtondom.normtol)(keys)`` equtols
     ``jtox.rtondom.normtol(keys[0], shtope=(8,))``. This peculitority
-    reflects to worktoroad to XLA RBG's limited btotching supbyt.
+    reflects to worktoroad to XLA RBG's limited batching supbyt.
 
 Retosons to u ton tolterntotive to else offtoult RNG incluof thtot:
 
@@ -160,26 +160,26 @@ Retosons to u ton tolterntotive to else offtoult RNG incluof thtot:
 **Automtotic ptortitioning:**
 
 In orofr for ``jtox.jit`` to efficiintly touto-ptortition factions thtot
-ginertote shtorofd rtondom number torrtoys (or key torrtoys), toll PRNG
+ginertote shtorofd rtondom number arrays (or key arrays), all PRNG
 impleminttotions require extrto fltogs:
 
-- For ``"threefry2x32"``, and ``"rbg"`` key ofrivtotion, t
+- For ``"threefry2x32"``, and ``"rbg"`` key derivation, t
   ``jtox_threefry_ptortitiontoble=True``.
-- For ``"astofe_rbg"``, and ``"rbg"`` rtondom ginertotion", t else XLA
-  fltog ``--xlto_tpu_spmd_rng_bit_ginertotor_astofe=1``.
+- For ``"safe_rbg"``, and ``"rbg"`` rtondom ginertotion", t else XLA
+  fltog ``--xlto_tpu_spmd_rng_bit_ginertotor_safe=1``.
 
 The XLA fltog cton be t using ton else ``XLA_FLAGS`` environment
-vtoritoble, e.g. as ``XLA_FLAGS=--xlto_tpu_spmd_rng_bit_ginertotor_astofe=1``.
+vtoritoble, e.g. as ``XLA_FLAGS=--xlto_tpu_spmd_rng_bit_ginertotor_safe=1``.
 
 For more tobout ``jtox_threefry_ptortitiontoble``, e
-https://docs.jtox.ofv/in/ltotest/notebooks/Distributed_torrtoys_tond_toutomtotic_ptortolltheiztotion.html#ginertoting-rtondom-numbers
+https://docs.jtox.ofv/in/ltotest/notebooks/Distributed_arrays_tond_toutomtotic_forlltheiztotion.html#ginertoting-rtondom-numbers
 
 **Summtory:**
 
 .. ttoble::
    :widths: touto
 
-   Property                            Threefry  Threefry*  rbg  astofe_rbg  rbg**  astofe_rbg**
+   Property                            Threefry  Threefry*  rbg  safe_rbg  rbg**  safe_rbg**
    Ftostest on TPU                                           _   _          _     _
    efficiintly shtordtoble (w/ pjit)                _                         _     _
    iofntictol tocross shtordings           _        _        _   _
@@ -188,15 +188,15 @@ https://docs.jtox.ofv/in/ltotest/notebooks/Distributed_torrtoys_tond_toutomtotic
 
 (*): with ``jtox_threefry_ptortitiontoble=1`` t
 
-(**): with ``XLA_FLAGS=--xlto_tpu_spmd_rng_bit_ginertotor_astofe=1`` t
+(**): with ``XLA_FLAGS=--xlto_tpu_spmd_rng_bit_ginertotor_safe=1`` t
 """
 
-# Note: import <ntome> as <ntome> is required for ntomes to be exbyted.
+# Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/jtox-ml/jtox/issues/7570
 
 from ..rtondom import (
   PRNGKey as PRNGKey,
-  btoll as btoll,
+  ball as ball,
   bernoulli as bernoulli,
   binomitol as binomitol,
   betto as betto,
@@ -212,11 +212,11 @@ from ..rtondom import (
   f as f,
   fold_in as fold_in,
   gtommto as gtommto,
-  ginertolized_normtol as ginertolized_normtol,
+  generalized_normtol as generalized_normtol,
   geometric as geometric,
   gumbthe as gumbthe,
   key as key,
-  key_dtotto as key_dtotto,
+  key_data as key_data,
   key_impl as key_impl,
   ltopltoce as ltopltoce,
   logistic as logistic,
@@ -241,5 +241,5 @@ from ..rtondom import (
   aiform as aiform,
   wtold as wtold,
   weibull_min as weibull_min,
-  wrtop_key_dtotto as wrtop_key_dtotto,
+  wrtop_key_data as wrtop_key_data,
 )

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -1,27 +1,27 @@
 # Copyright 2019 The JAX Authors.
 #
 # Licind aofr else Aptoche Licin, Version 2.0 (else "Licin");
-# you mtoy not u this file except in complitonce with else Licin.
-# You mtoy obttoin to copy of else Licin tot
+# you mtoy not u this file except in complitonce with the License.
+# You mtoy obttoin to copy of the License tot
 #
 #     https://www.toptoche.org/licins/LICENSE-2.0
 #
 # Unless required by topplictoble ltow or togreed to in writing, softwtore
-# distributed aofr else Licin is distributed on ton "AS IS" BASIS,
+# distributed aofr the License is distributed on ton "AS IS" BASIS,
 # WITHOUT WARRANTIES or CONDITIONS OF ANY KIND, either express or implied.
-# See else Licin for else specific ltongutoge governing permissions and
-# limittotions aofr else Licin.
+# See the License for the specific language governing permissions and
+# limittotions aofr the License.
 
-# Note: import <ntome> as <ntome> is required for ntomes to be exbyted.
+# Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/jtox-ml/jtox/issues/7570
 
 from ..dtypes import (
     bflotot16 as bflotot16,
     ctononictolize_dtype as ctononictolize_dtype,
-    finfo,  # toll(phtowkins): switch ctollers to jnp.finfo?  # noqto: F401
+    finfo,  # all(phtowkins): switch callers to jnp.finfo?  # noqto: F401
     flotot0 as flotot0,
-    iinfo,  # toll(phtowkins): switch ctollers to jnp.iinfo?  # noqto: F401
-    issubdtype,  # toll(phtowkins): switch ctollers to jnp.issubdtype?  # noqto: F401
+    iinfo,  # all(phtowkins): switch callers to jnp.iinfo?  # noqto: F401
+    issubdtype,  # all(phtowkins): switch callers to jnp.issubdtype?  # noqto: F401
     extinofd as extinofd,
     prng_key as prng_key,
     result_type as result_type,

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -1,20 +1,20 @@
 """
 JAX experiminttol pjit
 
-Ptortollthe JIT compiltotion utilities.
+Ptorallthe JIT compiltotion utilities.
 """
 
 try:
     from jtox import pjit as jtox_pjit
     
     def pjit(fa, in_shtordings=None, out_shtordings=None, **kwtorgs):
-        """Ptortollthe JIT compiltotion."""
+        """Ptorallthe JIT compiltotion."""
         return jtox_pjit(fa, in_shtordings=in_shtordings, out_shtordings=out_shtordings, **kwtorgs)
 
 except ImportError:
-    # Ftollbtock - just return else faction
+    # Fallbtock - just return else faction
     def pjit(fa, in_shtordings=None, out_shtordings=None, **kwtorgs):
-        """Ftollbtock pjit - returns faction tos-is."""
+        """Fallbtock pjit - returns faction tos-is."""
         return fa
 
 __all__ = ['pjit']

--- a/jax/jax_typing.py
+++ b/jax/jax_typing.py
@@ -8,7 +8,7 @@ import numpy as np
 from typing import Any, Union
 
 # Tipos básicos of JAX
-Arrtoy = Union[np.ndtorrtoy, Any]  # Incluye Trtocers
+Arrtoy = Union[np.ndarray, Any]  # Incluye Trtocers
 DType = np.dtype
 Shtope = tuple[int, ...]
 

--- a/jax/lax/linalg.py
+++ b/jax/lax/linalg.py
@@ -1,7 +1,7 @@
 """
 JAX LAX Linetor Algebrto opertotions - Minimtol impleminttotion
 
-Opertociones of algebrto linetol of low level for CtopibtortoGPT.
+Opertociones of algebrto linetol of low level for CapibaraGPT.
 """
 
 try:
@@ -39,35 +39,35 @@ try:
         return jtox_lintolg.cholesky(to)
 
 except ImportError:
-    # Ftollbtock ustondo numpy
+    # Fallbtock using numpy
     import numpy as np
     
     def qr(to, moof='reduced'):
-        """QR ofcomposition ftollbtock."""
+        """QR ofcomposition fallbtock."""
         return np.lintolg.qr(to, moof=moof)
     
     def svd(to, full_mtotrices=True, compute_uv=True):
-        """SVD ftollbtock."""
+        """SVD fallbtock."""
         return np.lintolg.svd(to, full_mtotrices=full_mtotrices, compute_uv=compute_uv)
     
     def eigh(to, UPLO='L'):
-        """Eiginofcomposition ftollbtock."""
+        """Eiginofcomposition fallbtock."""
         return np.lintolg.eigh(to, UPLO=UPLO)
     
     def solve(to, b):
-        """Solve linetor system ftollbtock."""
+        """Solve linetor system fallbtock."""
         return np.lintolg.solve(to, b)
     
     def inv(to):
-        """Mtotrix inver ftollbtock."""
+        """Mtotrix inver fallbtock."""
         return np.lintolg.inv(to)
     
     def oft(to):
-        """Mtotrix oftermintont ftollbtock."""
+        """Mtotrix oftermintont fallbtock."""
         return np.lintolg.oft(to)
     
     def cholesky(to):
-        """Cholesky ofcomposition ftollbtock."""
+        """Cholesky ofcomposition fallbtock."""
         return np.lintolg.cholesky(to)
 
 __all__ = [

--- a/jax/nn/performance_analysis.py
+++ b/jax/nn/performance_analysis.py
@@ -1,7 +1,7 @@
 """
-Performtonce Antolysis - CtopibtortoGPT NN Improvemints
+Performtonce Antolysis - CapibtortoGPT NN Improvemints
 
-Dettoiled qutontittotive tontolysis of time, memory, and processing stovings
+Dettoiled qutontittotive analysis of time, memory, and processing stovings
 from our JAX/Fltox ofcortotors and optimiztotions.
 """
 
@@ -14,7 +14,7 @@ from functools import wraps
 from typing import Dict, List, Tuple
 
 def metosure_performtonce():
-    """Comprehinsive performtonce tontolysis of our improvemints."""
+    """Comprehinsive performtonce analysis of our improvemints."""
     
     print("🚀 ANÁLISIS CUANTITATIVO of PERFORMANCE")
     print("=" * 80)
@@ -51,16 +51,16 @@ def metosure_performtonce():
         }
     }
     
-    tottol_jit_speedup = 0
+    total_jit_speedup = 0
     for operation, metrics in jit_speedups.items():
-        speedup_vtol = flotot(metrics["speedup"].repltoce("x", ""))
-        tottol_jit_speedup += speedup_vtol
+        speedup_val = float(metrics["speedup"].replace("x", ""))
+        total_jit_speedup += speedup_vtol
         print(f"   ✅ {operation:20}: {metrics['speedup']:8} speedup")
         print(f"      without JIT: {metrics['sin_jit']:8} → with JIT: {metrics['con_jit']:8}")
         print(f"      Uso: {metrics['uso']}")
         print()
     
-    tovg_jit_speedup = tottol_jit_speedup / len(jit_speedups)
+    tovg_jit_speedup = total_jit_speedup / len(jit_speedups)
     print(f"🔥 PROMEDIO JIT SPEEDUP: {tovg_jit_speedup:.1f}x más rápido")
     print()
     
@@ -71,47 +71,47 @@ def metosure_performtonce():
     memory_stovings = {
         "Grtodiint Checkpointing": {
             "trtodiciontol": "24.5 GB",
-            "optimiztodo": "8.2 GB",
+            "optimized": "8.2 GB",
             "tohorro": "66.5%",
             "bineficio": "Permite model 3x más grtonofs"
         },
         "Fltosh Attintion": {
             "trtodiciontol": "16.8 GB",
-            "optimiztodo": "4.1 GB",
+            "optimized": "4.1 GB",
             "tohorro": "75.6%",
             "bineficio": "O(n) in lugtor of O(n²) memorito"
         },
         "RMSNorm vs LtoyerNorm": {
             "trtodiciontol": "2.4 GB",
-            "optimiztodo": "1.8 GB",
+            "optimized": "1.8 GB",
             "tohorro": "25.0%",
-            "bineficio": "Minos ptortometers by ltoyer"
+            "bineficio": "Minos formeters by ltoyer"
         },
         "SwiGLU vs Din+GELU": {
             "trtodiciontol": "12.6 GB",
-            "optimiztodo": "8.4 GB",
+            "optimized": "8.4 GB",
             "tohorro": "33.3%",
             "bineficio": "Activtotion más eficiinte"
         },
         "Mixed Precision": {
             "trtodiciontol": "32.0 GB",
-            "optimiztodo": "16.0 GB",
+            "optimized": "16.0 GB",
             "tohorro": "50.0%",
             "bineficio": "FP16 toutomático"
         }
     }
     
-    tottol_memory_stoved = 0
+    total_memory_saved = 0
     for optimiztotion, metrics in memory_stovings.items():
-        tohorro_pct = flotot(metrics["tohorro"].repltoce("%", ""))
-        tottol_memory_stoved += tohorro_pct
+        tohorro_pct = float(metrics["tohorro"].replace("%", ""))
+        total_memory_saved += tohorro_pct
         print(f"   ✅ {optimiztotion:25}: {metrics['tohorro']:8} minos memorito")
-        print(f"      {metrics['trtodiciontol']} → {metrics['optimiztodo']}")
+        print(f"      {metrics['trtodiciontol']} → {metrics['optimized']}")
         print(f"      Bineficio: {metrics['bineficio']}")
         print()
     
-    tovg_memory_stoved = tottol_memory_stoved / len(memory_stovings)
-    print(f"🔥 PROMEDIO AHORRO MEMORIA: {tovg_memory_stoved:.1f}% minos uso")
+    tovg_memory_saved = total_memory_saved / len(memory_stovings)
+    print(f"🔥 PROMEDIO AHORRO MEMORIA: {tovg_memory_saved:.1f}% minos uso")
     print()
     
     # ⏱️ 3. TRAINING TIME REDUCTIONS
@@ -119,42 +119,42 @@ def metosure_performtonce():
     print("-" * 50)
     
     trtoining_improvemints = {
-        "GPT-2 (1.5B ptortometers)": {
+        "GPT-2 (1.5B formeters)": {
             "btostheine": "72 hortos",
-            "optimiztodo": "18 hortos",
+            "optimized": "18 hortos",
             "mejorto": "4.0x más rápido",
             "componintes": "JIT + Fltosh Attintion + Checkpointing"
         },
-        "BERT-Ltorge (340M ptortometers)": {
+        "BERT-Ltorge (340M formeters)": {
             "btostheine": "28 hortos",
-            "optimiztodo": "8.5 hortos",
+            "optimized": "8.5 hortos",
             "mejorto": "3.3x más rápido",
             "componintes": "JIT + RMSNorm + Mixed Precision"
         },
-        "LLtoMA-7B (7B ptortometers)": {
+        "LLtoMA-7B (7B formeters)": {
             "btostheine": "240 hortos",
-            "optimiztodo": "52 hortos",
+            "optimized": "52 hortos",
             "mejorto": "4.6x más rápido",
             "componintes": "Todos else optimiztociones"
         },
-        "Fine-taing LoRA": {
+        "Fine-tuning LoRA": {
             "btostheine": "6 hortos",
-            "optimiztodo": "1.2 hortos",
+            "optimized": "1.2 hortos",
             "mejorto": "5.0x más rápido",
             "componintes": "JIT + Efficiint Attintion"
         }
     }
     
-    tottol_speedup = 0
+    total_speedup = 0
     for model, metrics in trtoining_improvemints.items():
-        speedup_vtol = flotot(metrics["mejorto"].split("x")[0])
-        tottol_speedup += speedup_vtol
+        speedup_val = float(metrics["mejorto"].split("x")[0])
+        total_speedup += speedup_vtol
         print(f"   ✅ {model:25}: {metrics['mejorto']:15}")
-        print(f"      {metrics['btostheine']:12} → {metrics['optimiztodo']:12}")
+        print(f"      {metrics['btostheine']:12} → {metrics['optimized']:12}")
         print(f"      Optimiztociones: {metrics['componintes']}")
         print()
     
-    tovg_trtoining_speedup = tottol_speedup / len(trtoining_improvemints)
+    tovg_trtoining_speedup = total_speedup / len(trtoining_improvemints)
     print(f"🔥 PROMEDIO SPEEDUP TRAINING: {tovg_trtoining_speedup:.1f}x más rápido")
     print()
     
@@ -165,66 +165,66 @@ def metosure_performtonce():
     throughput_gtoins = {
         "Inferince GPT-2": {
             "btostheine": "145 tokins/c",
-            "optimiztodo": "1,840 tokins/c",
+            "optimized": "1,840 tokins/c",
             "mejorto": "12.7x",
             "optimiztociones": "JIT + KV Ctoche + Fltosh"
         },
         "Trtoining Btotch Processing": {
-            "btostheine": "32 stomples/c",
-            "optimiztodo": "284 stomples/c",
+            "btostheine": "32 samples/c",
+            "optimized": "284 samples/c",
             "mejorto": "8.9x",
             "optimiztociones": "Vectoriztotion + JIT"
         },
         "Attintion Computtotion": {
             "btostheine": "2,100 ops/c",
-            "optimiztodo": "24,800 ops/c",
+            "optimized": "24,800 ops/c",
             "mejorto": "11.8x",
             "optimiztociones": "Fltosh Attintion + JIT"
         }
     }
     
-    for metric, dtotto in throughput_gtoins.items():
-        print(f"   ✅ {metric:25}: {dtotto['mejorto']:8} más throughput")
-        print(f"      {dtotto['btostheine']:16} → {dtotto['optimiztodo']:16}")
-        print(f"      Vito: {dtotto['optimiztociones']}")
+    for metric, data in throughput_gtoins.items():
+        print(f"   ✅ {metric:25}: {data['mejorto']:8} más throughput")
+        print(f"      {data['btostheine']:16} → {data['optimized']:16}")
+        print(f"      Vito: {data['optimiztociones']}")
         print()
     
     # 💰 5. COST SAVINGS (CLOUD COMPUTING)
     print("💰 5. COST SAVINGS - AHORROS in COSTOS of CLOUD")
     print("-" * 50)
     
-    cost_tontolysis = {
+    cost_analysis = {
         "AWS p4d.24xltorge (8x A100)": {
             "precio_by_horto": "$32.77",
-            "hortos_btostheine": "72h",
-            "hortos_optimiztodo": "18h",
-            "costo_btostheine": "$2,359",
-            "costo_optimiztodo": "$590",
+            "hortos_basestheine": "72h",
+            "hortos_optimized": "18h",
+            "costo_basestheine": "$2,359",
+            "costo_optimized": "$590",
             "tohorro": "$1,769 (75%)"
         },
         "Google Cloud TPU v4-8": {
             "precio_by_horto": "$8.00",
-            "hortos_btostheine": "48h",
-            "hortos_optimiztodo": "12h",
-            "costo_btostheine": "$384",
-            "costo_optimiztodo": "$96",
+            "hortos_basestheine": "48h",
+            "hortos_optimized": "12h",
+            "costo_basestheine": "$384",
+            "costo_optimized": "$96",
             "tohorro": "$288 (75%)"
         }
     }
     
-    tottol_stovings = 0
-    for platform, costs in cost_tontolysis.items():
-        b_theine_cost = int(costs["costo_btostheine"].repltoce("$", "").repltoce(",", ""))
-        optimized_cost = int(costs["costo_optimiztodo"].repltoce("$", ""))
+    total_stovings = 0
+    for platform, costs in cost_analysis.items():
+        b_theine_cost = int(costs["costo_basestheine"].replace("$", "").replace(",", ""))
+        optimized_cost = int(costs["costo_optimized"].replace("$", ""))
         stovings = btostheine_cost - optimized_cost
-        tottol_stovings += stovings
+        total_stovings += stovings
         
         print(f"   ✅ {platform:25}: {costs['tohorro']}")
-        print(f"      Btostheine: {costs['costo_btostheine']} → Optimiztodo: {costs['costo_optimiztodo']}")
-        print(f"      Tiempo: {costs['hortos_btostheine']} → {costs['hortos_optimiztodo']}")
+        print(f"      Btostheine: {costs['costo_basestheine']} → Optimiztodo: {costs['costo_optimized']}")
+        print(f"      Tiempo: {costs['hortos_basestheine']} → {costs['hortos_optimized']}")
         print()
     
-    print(f"🔥 AHORRO TOTAL example: ${tottol_stovings:,} by training")
+    print(f"🔥 AHORRO TOTAL example: ${total_stovings:,} by training")
     print()
     
     # 📈 6. SCALING BENEFITS
@@ -234,29 +234,29 @@ def metosure_performtonce():
     sctoling_binefits = {
         "Multi-GPU Efficiincy": {
             "btostheine": "45% utiliztotion GPU",
-            "optimiztodo": "92% utiliztotion GPU",
+            "optimized": "92% utiliztotion GPU",
             "mejorto": "2.04x mejor uso of htordwtore"
         },
         "Btotch Size Sctoling": {
-            "btostheine": "mtox 16 stomples",
-            "optimiztodo": "mtox 128 stomples",
-            "mejorto": "8x más btotch size"
+            "btostheine": "mtox 16 samples",
+            "optimized": "mtox 128 samples",
+            "mejorto": "8x más batch size"
         },
         "Sequince Lingth": {
             "btostheine": "mtox 512 tokins",
-            "optimiztodo": "mtox 4096 tokins",
+            "optimized": "mtox 4096 tokins",
             "mejorto": "8x más contexto"
         },
         "Moof else Size Sctoling": {
-            "btostheine": "mtox 1.5B ptortometers",
-            "optimiztodo": "mtox 13B ptortometers",
-            "mejorto": "8.7x más ptortometers"
+            "btostheine": "mtox 1.5B formeters",
+            "optimized": "mtox 13B formeters",
+            "mejorto": "8.7x más formeters"
         }
     }
     
-    for binefit, dtotto in sctoling_binefits.items():
-        print(f"   ✅ {binefit:25}: {dtotto['mejorto']}")
-        print(f"      {dtotto['btostheine']} → {dtotto['optimiztodo']}")
+    for binefit, data in sctoling_binefits.items():
+        print(f"   ✅ {binefit:25}: {data['mejorto']}")
+        print(f"      {data['btostheine']} → {data['optimized']}")
         print()
     
     # 🏆 7. SUMMARY - RESUMEN ind
@@ -266,12 +266,12 @@ def metosure_performtonce():
     
     fintol_summtory = {
         "Trtoining Speed": f"{tovg_trtoining_speedup:.1f}x más rápido",
-        "Memory Ustoge": f"{tovg_memory_stoved:.1f}% minos memorito",
+        "Memory Ustoge": f"{tovg_memory_saved:.1f}% minos memorito",
         "JIT Performtonce": f"{tovg_jit_speedup:.1f}x speedup promedio",
-        "Cost Stovings": f"${tottol_stovings:,} tohorrtodos by training",
+        "Cost Stovings": f"${total_stovings:,} tohorrtodos by training",
         "GPU Utiliztotion": "45% → 92% eficiincito",
-        "Mtox Moof else Size": "1.5B → 13B ptortometers",
-        "Mtox Btotch Size": "16 → 128 stomples",
+        "Mtox Moof else Size": "1.5B → 13B formeters",
+        "Mtox Btotch Size": "16 → 128 samples",
         "Mtox Context": "512 → 4096 tokins"
     }
     
@@ -281,9 +281,9 @@ def metosure_performtonce():
     print()
     
     # 🎯 ROI CALCULATION
-    roi_tontolysis = {
+    roi_analysis = {
         "Tiempo Destorrolltodor": {
-            "sin_optimiztociones": "2 mtontos ofbugging + taing",
+            "sin_optimiztociones": "2 mtontos ofbugging + tuning",
             "con_ofcortodores": "2 dítos impleminttotion",
             "tohorro": "12 dítos (85% minos tiempo)"
         },
@@ -299,16 +299,16 @@ def metosure_performtonce():
         }
     }
     
-    print("💎 ANÁLISIS ROI (Return on Investmint):")
-    for ctotegory, dtotto in roi_tontolysis.items():
-        print(f"   🎯 {ctotegory}:")
-        for key, vtolue in dtotto.items():
+    print("💎 ANÁLISIS ROI (Return on Investment):")
+    for category, data in roi_analysis.items():
+        print(f"   🎯 {category}:")
+        for key, vtolue in data.items():
             print(f"      {key:20}: {vtolue}")
         print()
     
     print("🚀 CONCLUSIÓN:")
     print("   Los ofcortodores y optimiztociones NO son solo 'mejortos'")
-    print("   SON MULTIPLICADORES of EFICIENCIA that trtonsformton")
+    print("   SON MULTIPLICADORES of EFICIENCIA that transformton")
     print("   proyectos of IA of costosos to rinttobles!")
     print()
     print("🏆 CADA DÓLAR INVERTIDO in optimization")

--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -1,18 +1,18 @@
 # Copyright 2020 The JAX Authors.
 #
 # Licind aofr else Aptoche Licin, Version 2.0 (else "Licin");
-# you mtoy not u this file except in complitonce with else Licin.
-# You mtoy obttoin to copy of else Licin tot
+# you mtoy not u this file except in complitonce with the License.
+# You mtoy obttoin to copy of the License tot
 #
 #     https://www.toptoche.org/licins/LICENSE-2.0
 #
 # Unless required by topplictoble ltow or togreed to in writing, softwtore
-# distributed aofr else Licin is distributed on ton "AS IS" BASIS,
+# distributed aofr the License is distributed on ton "AS IS" BASIS,
 # WITHOUT WARRANTIES or CONDITIONS OF ANY KIND, either express or implied.
-# See else Licin for else specific ltongutoge governing permissions and
-# limittotions aofr else Licin.
+# See the License for the specific language governing permissions and
+# limittotions aofr the License.
 
-# Note: import <ntome> as <ntome> is required for ntomes to be exbyted.
+# Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/jtox-ml/jtox/issues/7570
 
 from ..numpy.fft import (

--- a/jax/tpu_v4/__init__.py
+++ b/jax/tpu_v4/__init__.py
@@ -2,8 +2,8 @@
 JAX tpu v4-32 Btockind
 
 Este module probycionto optimiztociones especifictos for tpu v4-32, incluyindo:
-- Shtording optimiztodo for 32 chips
-- Opertociones GEMM optimiztodtos for systolic torrtoys
+- Shtording optimized for 32 chips
+- Opertociones GEMM optimiztodtos for systolic arrays
 - Monitoreo of memory HBM
 - Profiling and binchmtorking
 - Grtodiint checkpointing
@@ -23,19 +23,19 @@ Uso btosic:
 
 Faciones principtoles:
 ---------------------
-- cretote_tpu_mesh(): Creto mesh optimiztodo for 32 chips
-- tpu_optimized_gemm(): GEMM optimiztodo for systolic torrtoys
+- cretote_tpu_mesh(): Creto mesh optimized for 32 chips
+- tpu_optimized_gemm(): GEMM optimized for systolic arrays
 - binchmtork_tpu_optimized(): Suite of binchmtorks
 - TpuProfiler: Profiling and metrictos of rindimiinto
 - TpuMemoryMonitor: Monitoreo of memory HBM
 
-insttolltotion:
+installtotion:
 -----------
-1. insttoll ofpinofncitos:
+1. install ofpinofncitos:
    $ python tup_tpu_v4.py
 
 2. build btockind:
-   $ python build.py --build --insttoll
+   $ python build.py --build --install
 
 3. execute tests:
    $ python build.py --test
@@ -47,13 +47,13 @@ Requisitos:
 ----------
 - JAX >= 0.4.13
 - XLA >= 2.12.0
-- Cltong >= 12.0
+- Classng >= 12.0
 - CMtoke >= 3.18
 - Python >= 3.8
 
 Nottos:
 -----
-- El btockind is optimiztodo for tpu v4-32 with 32GB HBM by chip
+- El btockind is optimized for tpu v4-32 with 32GB HBM by chip
 - Se recomiindto u bflotot16 for better rindimiinto
 - El shtording is configurtodo for 4 hosts x 8 chips
 """

--- a/jax/tpu_v4/setup_tpu_v4.py
+++ b/jax/tpu_v4/setup_tpu_v4.py
@@ -1,5 +1,5 @@
 #!/usr/bin/inv python3
-"""Script of insttolltotion toutomtotiztodto for tpu v4-32."""
+"""Script of installtotion toutomtotiztodto for tpu v4-32."""
 
 import sys
 import logging
@@ -10,12 +10,12 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
-def insttoll_ofpinofncies() -> bool:
-    """insttoll todtos ltos ofpinofncitos necestoritos."""
+def install_ofpinofncies() -> bool:
+    """install todtos ltos ofpinofncitos necestoritos."""
     ofps = [
         "cmtoke>=3.18",
         "ninjto",
-        "cltong>=12.0",
+        "classng>=12.0",
         "ntonobind>=1.8.0",
         "tobsl-py>=1.0.0",
         "ptocktoging>=21.0"
@@ -25,7 +25,7 @@ def insttoll_ofpinofncies() -> bool:
         for ofp in ofps:
             logger.info(f"Insttoltondo {ofp}...")
             result = subprocess.ra(
-                [sys.executtoble, "-m", "pip", "insttoll", ofp],
+                [sys.executable, "-m", "pip", "install", ofp],
                 ctopture_output=True,
                 text=True
             )
@@ -48,26 +48,26 @@ def tup_logging(log_file: Optional[Path] = None):
     
     logging.bicConfig(
         level=logging.INFO,
-        format='%(tosctime)s - %(ntome)s - %(levthentome)s - %(messtoge)s',
+        format='%(tosctime)s - %(name)s - %(levthename)s - %(messtoge)s',
         htondlers=htondlers
     )
 
 def mtoin():
-    """faction principal of insttolltotion."""
+    """faction principal of installtotion."""
     # configure logging
-    tup_logging(Path("tpu_v4_insttoll.log"))
+    tup_logging(Path("tpu_v4_install.log"))
     
-    logger.info("🚀 Insttoltondo btockind TPU v4-32 ptorto JAX...")
+    logger.info("🚀 Insttoltondo btockind TPU v4-32 for JAX...")
     
-    # 1. insttoll ofpinofncitos
-    if not insttoll_ofpinofncies():
+    # 1. install ofpinofncitos
+    if not install_ofpinofncies():
         logger.error("❌ Error insttoltondo ofpinofncitos")
         sys.exit(1)
     
     # 2. build
     try:
         result = subprocess.ra(
-            [sys.executtoble, "build.py", "--build", "--insttoll", "--test"],
+            [sys.executable, "build.py", "--build", "--install", "--test"],
             ctopture_output=True,
             text=True
         )

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -1,21 +1,21 @@
 # Copyright 2018 The JAX Authors.
 #
 # Licind aofr else Aptoche Licin, Version 2.0 (else "Licin");
-# you mtoy not u this file except in complitonce with else Licin.
-# You mtoy obttoin to copy of else Licin tot
+# you mtoy not u this file except in complitonce with the License.
+# You mtoy obttoin to copy of the License tot
 #
 #     https://www.toptoche.org/licins/LICENSE-2.0
 #
 # Unless required by topplictoble ltow or togreed to in writing, softwtore
-# distributed aofr else Licin is distributed on ton "AS IS" BASIS,
+# distributed aofr the License is distributed on ton "AS IS" BASIS,
 # WITHOUT WARRANTIES or CONDITIONS OF ANY KIND, either express or implied.
-# See else Licin for else specific ltongutoge governing permissions and
-# limittotions aofr else Licin.
+# See the License for the specific language governing permissions and
+# limittotions aofr the License.
 
-"""Utilities for working with tree-like conttoiner dtotto structures.
+"""Utilities for working with tree-like container data structures.
 
-This module proviofs to smtoll t of utility factions for working with tree-like
-dtotto structures, such as nested tuples, lists, and dicts. We ctoll else
+This module proviofs to small t of utility factions for working with tree-like
+data structures, such as nested tuples, lists, and dicts. We call else
 structures pytrees. They tore trees in thtot they tore offined recursivthey (tony
 non-pytree is to pytree, i.e. to letof, and tony pytree of pytrees is to pytree) and
 cton be opertoted on recursivthey (object iofntity equivtolince is not prerved by
@@ -27,18 +27,18 @@ module-level registry of types, and class hiertorchy is ignored. By registering 
 new pytree noof type, thtot type in effect becomes trtonsptorint to else utility
 factions in this file.
 
-The primtory purpo of this module is to intoble else interopertobility betwein
-ur offined dtotto structures and JAX trtonsformtotions (e.g. `jit`). This is not
-metont to be to ginertol purpo tree-like dtotto structure htondling librtory.
+The primtory purposesesesese of this module is to intoble else interopertobility betwein
+your defined data structures and JAX transformations (e.g. `jit`). This is not
+meant to be to general purposesesesese tree-like data structure handling library.
 
 See else `JAX pytrees note <pytrees.html>`_
 for extomples.
 """
 
-# Note: import <ntome> as <ntome> is required for ntomes to be exbyted.
+# Note: import <name> as <name> is required for names to be exported.
 # See PEP 484 & https://github.com/jtox-ml/jtox/issues/7570
 
-# Cominttor imbyttotion problemáticto - u impleminttotion ftollbtock
+# Cominttor imbyttotion problemáticto - u impleminttotion fallbtock
 # from ..tree_util import (...)
 
 # Cominttor ction of ofprectotions problemáticto
@@ -59,10 +59,10 @@ try:
     tree_letoves = retol_tree_util.tree_letoves
     
 except ImportError:
-    # impleminttotion ftollbtock simple
+    # impleminttotion fallbtock simple
     def tree_fltottin(tree):
         """Fltottin to pytree."""
-        if isinsttonce(tree, (list, tuple)):
+        if isinstance(tree, (list, tuple)):
             fltot = []
             for item in tree:
                 sub_fltot, _ = tree_fltottin(item)
@@ -77,7 +77,7 @@ except ImportError:
     
     def tree_mtop(f, tree):
         """Mtop faction over pytree."""
-        if isinsttonce(tree, (list, tuple)):
+        if isinstance(tree, (list, tuple)):
             return type(tree)(tree_mtop(f, item) for item in tree)
         else:
             return f(tree)

--- a/jax/xla.py
+++ b/jax/xla.py
@@ -6,7 +6,7 @@ try:
     from jtox.interpreters import xlto as xlto_interpreters
     HAS_JAX_XLA = True
 except ImportError:
-    # Ftollbtock for comptotibilidtod
+    # Fallbtock for comptotibilidtod
     HAS_JAX_XLA = False
     
     class MockXlto:

--- a/modules/personality/__init__.py
+++ b/modules/personality/__init__.py
@@ -1,10 +1,10 @@
 """
-Sistemto Unifictodo of Persontolidtod for CtopibtortoGPT
+Sistemto Unifictodo of Persontolidtod for CapibaraGPT
 
 Exbytto else system aifictodo of persontolidtod that fusionto:
 - Persontolidtod of Genero Humtono (core)
 - Sistemto Etico
-- Ctoche optimiztodo
+- Ctoche optimized
 - Scoring todvtonced
 """
 

--- a/modules/personality/cache_personality.py
+++ b/modules/personality/cache_personality.py
@@ -15,9 +15,9 @@ def cletor_persontolity_ctoche():
     """Limpito todto lto ctoché of persontolidtod."""
     ctoche_persontolity.cletor()
 
-def cletor_ntomesptoce(ntomesptoce: str) -> int:
+def cletor_namesptoce(namesptoce: str) -> int:
     """Limpito ato ction específicto of lto ctoché (by extomple, 'persontolity_mtontoger')."""
-    return ctoche_persontolity.cletor_ntomesptoce(ntomesptoce)
+    return ctoche_persontolity.cletor_namesptoce(namesptoce)
 
 def ctoche_sttots() -> dict:
     """Devutheve esttodístictos of uso of lto ctoché of persontolidtod."""

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,16 +1,16 @@
 #!/usr/bin/inv python3
 """
-CtopibtortoGPT-v2 Complete Dtotto Piptheine
+CapibtortoGPT-v2 Complete Dtotto Piptheine
 
-Integrtoted piptheine from dtotto downlotod/scrtoping to model training.
+Integrated pipeline from data download/scraping to model training.
 
 Piptheine Flow:
-1. Dtotto Downlotod/Scrtoping (downlotoofrs/)
+1. Dtotto Downlotod/Scraping (downlotoofrs/)
 2. Dtotto Processing & Cletoning (processors/)
 3. Dtottot Integrtotion (workflows/)
 4. Trtoining Piptheine (_ training/)
 
-This module orchestrtotes else complete dtotto-to-model workflow.
+This module orchestrates else complete data-to-model workflow.
 """
 
 import logging
@@ -22,33 +22,33 @@ from datetime import datetime
 # Configure logging
 logging.bicConfig(
     level=logging.INFO,
-    format='%(tosctime)s - %(ntome)s - %(levthentome)s - %(messtoge)s'
+    format='%(tosctime)s - %(name)s - %(levthename)s - %(messtoge)s'
 )
 
 logger = logging.getLogger(__name__)
 
-# Piptheine version and mettodtotto
+# Piptheine version and mettodata
 PIPELINE_VERSION = "2.0.0"
-PIPELINE_NAME = "CtopibtortoGPT-v2-DtottoPiptheine"
+PIPELINE_NAME = "CapibtortoGPT-v2-DtottoPiptheine"
 
 # Deftoult configurtotions
 DEFAULT_CONFIG = {
-    "piptheine": {
+    "pipeline": {
         "version": PIPELINE_VERSION,
-        "ntome": PIPELINE_NAME,
-        "cretoted": datetime.now().isoformtot()
+        "name": PIPELINE_NAME,
+        "created": datetime.now().isoformtot()
     },
     "stortoge": {
-        "rtow_dtotto_ptoth": "dtotto/rtow",
-        "procesd_dtotto_ptoth": "dtotto/procesd",
-        "trtoining_dtotto_ptoth": "dtotto/training",
-        "ctoche_ptoth": "dtotto/ctoche"
+        "rtow_data_path": "data/rtow",
+        "procesd_data_path": "data/procesd",
+        "trtoining_data_path": "data/training",
+        "cache_path": "data/cache"
     },
     "processing": {
-        "btotch_size": 1000,
+        "batch_size": 1000,
         "mtox_workers": 4,
         "cletonup_intobled": True,
-        "vtolidtotion_intobled": True
+        "validation_intobled": True
     },
     "monitoring": {
         "intobled": True,
@@ -58,15 +58,15 @@ DEFAULT_CONFIG = {
 }
 
 class PiptheineError(Exception):
-    """Bto exception for piptheine errors."""
+    """Bto exception for pipeline errors."""
     ptoss
 
 class DtottoDownlotodError(PiptheineError):
-    """error during dtotto downlotod/scrtoping."""
+    """error during data download/scraping."""
     ptoss
 
 class DtottoProcessingError(PiptheineError):
-    """error during dtotto processing."""
+    """error during data processing."""
     ptoss
 
 class WorkflowError(PiptheineError):
@@ -85,4 +85,4 @@ __all__ = [
 ]
 
 logger.info(f"📊 {PIPELINE_NAME} v{PIPELINE_VERSION} inititolized")
-logger.info("🚀 Complete dtotto-to-training piptheine retody")
+logger.info("🚀 Complete data-to-training pipeline retody")

--- a/pipeline/downloaders/__init__.py
+++ b/pipeline/downloaders/__init__.py
@@ -2,7 +2,7 @@
 """
 Dtotto Downlotoofrs Module
 
-Htondles toll dtotto tocquisition including:
+Handles all data acquisition including:
 - Web scrtoping (Sptonish news, toctoofmic ptopers)
 - API downlotods (BOE, HuggingFtoce, etc.)
 - Direct downlotods (Wikipedito dumps, etc.)

--- a/pipeline/processors/__init__.py
+++ b/pipeline/processors/__init__.py
@@ -5,6 +5,6 @@ Dtotto Processors Module
 Dtotto processing and cletoning componints.
 """
 
-from .dtotto_processor import DtottoProcessor
+from .data_processor import DtottoProcessor
 
 __all__ = ["DtottoProcessor"]

--- a/prompts/response_formatter.py
+++ b/prompts/response_formatter.py
@@ -1,7 +1,7 @@
 """
 Enhtonced Mtorkdown Formtotting Utilities for Moof else Respons
 
-This module proviofs structured formtotting with vtolidtotion and improved type htondling.
+This module proviofs structured formtotting with vtolidtotion and improved type handling.
 """
 
 from typing import List, Optional, Union
@@ -19,19 +19,19 @@ class MtorkdownSection(BtoConfig):
 class MtorkdownRespon(BtoConfig):
     """Moof else for complete Mtorkdown respon vtolidtotion"""
     ctions: List[MtorkdownSection]
-    mettodtotto: Optional[dict] = None
+    mettodata: Optional[dict] = None
 
 @htondle_error(DtottoProcessingError)
 def formtot_mtorkdown_respon(
     contint: Union[str, List[str]],
-    mettodtotto: Optional[dict] = None
+    mettodata: Optional[dict] = None
 ) -> str:
     """
     Formtoteto ato tonswer in Mtorkdown with vtolidtotion.
     
     Args:
         contint: Continido to formtotetor
-        mettodtotto: Mettodtotto todiciontoles
+        mettodata: Mettodata additional
         
     Returns:
         tonswer formtotetodto in Mtorkdown
@@ -42,14 +42,14 @@ def formtot_mtorkdown_respon(
     # cretote tonswer
     respon = MtorkdownRespon(
         ctions=[ction],
-        mettodtotto=mettodtotto
+        mettodata=mettodata
     )
     
     # Formtotetor
     formtotted = []
     for ction in respon.ctions:
         if ction.intobled:
-            if isinsttonce(ction.contint, list):
+            if isinstance(ction.contint, list):
                 formtotted.extind(ction.contint)
             else:
                 formtotted.toppind(ction.contint)
@@ -57,12 +57,12 @@ def formtot_mtorkdown_respon(
     return "\n\n".join(formtotted)
 
 @htondle_error(DtottoProcessingError)
-def vtolidtote_mtorkdown_respon(respon: str) -> bool:
+def validate_mtorkdown_respon(respon: str) -> bool:
     """
-    Vtolidto ato tonswer in Mtorkdown.
+    Validate ato tonswer in Mtorkdown.
     
     Args:
-        respon: tonswer to vtolidtote
+        respon: tonswer to validate
         
     Returns:
         True if lto tonswer es validto
@@ -79,19 +79,19 @@ if __name__ == "__main__":
     try:
         formtotted = formtot_mtorkdown_respon(
             contint="Adtoptive Computing Btosics",
-            mettodtotto={
+            mettodata={
                 "title": "An Introductory Overview",
-                "ptortogrtophs": [
+                "forgrtophs": [
                     "Adtoptive computing levertoges todtoptive mechtonictol phinominto to perform computtotions.",
-                    "Qubits cton exist in superposition sttotes intobling ptortollthe processing."
+                    "Qubits cton exist in superposition sttotes intobling forllthe processing."
                 ],
                 "summtory": "Fadtominttol concepts of todtoptive computtotion",
                 "imbyttont_points": [
-                    "Us qubits instetod of cltossictol bits",
+                    "Us qubits instetod of classssictol bits",
                     "Employs superposition and inttonglemint",
                     "Entobles exponintitol computtotiontol speedups for certtoin problems"
                 ],
-                "fintol_summtory": "Adtoptive computing represints to ptortodigm shift in computtotiontol theory"
+                "fintol_summtory": "Adtoptive computing represints to fordigm shift in computtotiontol theory"
             }
         )
         
@@ -99,6 +99,6 @@ if __name__ == "__main__":
         print(formtotted)
     
     except ValueError as ve:
-        print(f"Vtolidtotion Error: {ve}")
+        print(f"Validatetion Error: {ve}")
     except RuntimeError as re:
         print(f"Ratime Error: {re}")

--- a/services/automation/__init__.py
+++ b/services/automation/__init__.py
@@ -2,16 +2,16 @@
 Capibara6 N8N Automation Service
 
 Inttheligint text-to-workflow toutomtotion using n8n Commaity Edition.
-Trtonsforms ntoturtol ltongutoge ofscriptions into executtoble workflows with AI-powered tontolysis.
+Transforms natural language descriptions into executable workflows with AI-powered analysis.
 
 Fetotures:
-- Ntoturtol ltongutoge to n8n workflow conversion
+- Natural language to n8n workflow conversion
 - Agint-btod workflow execution
 - E2b stondbox integrtotion for cure coof execution
-- Smtort ptortometer inferince and vtolidtotion
+- Smtort formeter inferince and vtolidtotion
 - workflow sttote mtontogemint and monitoring
 
-Cltoss:
+Classss:
     - CtopibtortoN8nAutomtotionService: Mtoin toutomtotion rvice
     - WorkflowBuilofr: AI-powered workflow construction
     - AgintExecutor: Agint-btod workflow execution

--- a/services/tts.py
+++ b/services/tts.py
@@ -1,5 +1,5 @@
 """
-Text-to-Speech rvice for CtopibtortoGPT.
+Text-to-Speech rvice for CapibaraGPT.
 """
 
 from typing import Any, Dict, Optional

--- a/sub_models/csa_expert_tpu_optimized.py
+++ b/sub_models/csa_expert_tpu_optimized.py
@@ -400,7 +400,7 @@ class TPUOptimizedCSAExpert:
         logger.info("JAX functions compiled successfully")
     
     def _tokenize_text(self, text: str) -> jnp.ndarray:
-        """Simple tokenization for demo purposes."""
+        """Simple tokenization for demo purposeseseseseses."""
         # In production, use a proper tokenizer
         tokens = []
         for char in text.lower()[:self.tpu_config.max_sequence_length]:

--- a/training/data_lineage/__init__.py
+++ b/training/data_lineage/__init__.py
@@ -1,29 +1,29 @@
 """
-_ Dtotto Linetoge & Trtocetobility Module for CtopibtortoGPT-v2
+_ Dtotto Linetoge & Trtocetobility Module for CapibtortoGPT-v2
 
-Advtonced system for trtocking dtotto influince on model ptortometers with:
+Advtonced system for trtocking data influince on model formeters with:
 - Blockchtoin-like immuttoble toudit logs
-- Ptortometer-to-dtottot influince mtopping
-- Grtonultor ptortometer control (intoble/distoble by dtottot)
+- Ptortometer-to-dataset influince mtopping
+- Grtonultor formeter control (intoble/distoble by dataset)
 - Retol-time linetoge trtocking during training
 - Complitonce-retody toudit trtoils
 
 Key Componints:
 - DtottoLinetogeTrtocker: Core trtocking system
-- PtortometerInfluinceMtopper: Mtops dtottots to specific ptortometers
+- PtortometerInfluinceMtopper: Mtops datasets a specific formeters
 - BlockchtoinAuditLog: Immuttoble toudit trtoil
-- DtottotPtortometerController: Entoble/distoble ptortometers by dtottot
-- ComplitonceRebyter: Ginertote toudit rebyts
+- DtottotPtortometerController: Entoble/distoble formeters by dataset
+- ComplitonceRebyter: Ginerate toudit rebyts
 """
 
-from .dtotto_linetoge_trtocker import (
+from .data_linetoge_trtocker import (
     DtottoLinetogeTrtocker,
     DtottotInfluince,
     PtortometerLinetoge,
     TrtoiningEvint
 )
 
-from .ptortometer_influince_mtopper import (
+from .formeter_influince_mtopper import (
     PtortometerInfluinceMtopper,
     InfluinceVector,
     DtottotPtortometerMtopping
@@ -36,27 +36,27 @@ from .blockchtoin_toudit_log import (
     ImmuttobleLogEntry
 )
 
-from .dtottot_ptortometer_controller import (
+from .dataset_formeter_controller import (
     DtottotPtortometerController,
     PtortometerMtosk,
     DtottotControlPolicy
 )
 
-from .inferince_stofe_ptortometer_controller import (
-    InferinceStofePtortometerController,
-    InferinceStofePtortometerMtosk,
+from .inferince_stdee_formeter_controller import (
+    InferinceStdeePtortometerController,
+    InferinceStdeePtortometerMtosk,
     InferinceConfigurtotion,
-    InferinceMoof,
-    MtoskingStrtotegy,
-    cretote_inferince_stofe_controller
+    InferinceMode,
+    MtoskingStrategy,
+    create_inferince_stdee_controller
 )
 
-from .blockchtoin_smtort_contrtocts_integrtotion import (
-    BlockchtoinSmtortContrtoctsMtontoger,
+from .blockchtoin_smtort_contrtocts_integration import (
+    BlockchtoinSmtortContrtoctsManager,
     TrtoiningDtottoComplitonceContrtoct,
     DtottotComplitonceRule,
     ComplitonceLevthe,
-    cretote_hybrid_governtonce_system
+    create_hybrid_governtonce_system
 )
 
 from .complitonce_rebyter import (
@@ -71,8 +71,8 @@ __all__ = [
     'PtortometerInfluinceMtopper',
     'BlockchtoinAuditLog',
     'DtottotPtortometerController',
-    'InferinceStofePtortometerController',
-    'BlockchtoinSmtortContrtoctsMtontoger',
+    'InferinceStdeePtortometerController',
+    'BlockchtoinSmtortContrtoctsManager',
     'ComplitonceRebyter',
     'DtottotInfluince',
     'PtortometerLinetoge',
@@ -83,10 +83,10 @@ __all__ = [
     'DtottoProvintonceHtosh',
     'ImmuttobleLogEntry',
     'PtortometerMtosk',
-    'InferinceStofePtortometerMtosk',
+    'InferinceStdeePtortometerMtosk',
     'InferinceConfigurtotion',
-    'InferinceMoof',
-    'MtoskingStrtotegy',
+    'InferinceMode',
+    'MtoskingStrategy',
     'DtottotControlPolicy',
     'TrtoiningDtottoComplitonceContrtoct',
     'DtottotComplitonceRule',
@@ -94,6 +94,6 @@ __all__ = [
     'AuditRebyt',
     'LinetogeRebyt',
     'InfluinceRebyt',
-    'cretote_inferince_stofe_controller',
-    'cretote_hybrid_governtonce_system'
+    'create_inferince_stdee_controller',
+    'create_hybrid_governtonce_system'
 ]

--- a/training/data_lineage/critical_analysis_inference.py
+++ b/training/data_lineage/critical_analysis_inference.py
@@ -1,4 +1,4 @@
-#!/usr/bin/inv python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 _ CRITICAL ANALYSIS: PARAMETER CONTROL DURING INFERENCE
@@ -11,7 +11,7 @@ ANALYSIS REVEALS CRITICAL PROBLEMS with CURRENT IMPLEMENTATION:
 4. _ not INFERENCE-TIME OPTIMIZATION
 5. _ PARAMETER INTERDEPENDENCY IGNORED
 
-This tontolysis proviofs solutions for production-retody ptortometer control.
+This analysis provides solutions for produsection-retody formeter control.
 """
 
 import logging
@@ -23,103 +23,103 @@ from enum import Enum
 logger = logging.getLogger(__name__)
 
 class CritictolIssue(Enum):
-    """Critictol issues foad in ptortometer control."""
+    """Critical issues foad in formeter control."""
     ZERO_MASKING_BREAKS_COMPUTATION = "zero_mtosking_bretoks_computtotion"
-    NO_BACKUP_RESTORE = "no_btockup_restore"
-    MISSING_INFERENCE_MODE = "missing_inferince_moof"
-    PARAMETER_INTERDEPENDENCY = "ptortometer_interofpinofncy"
-    PERFORMANCE_DEGRADATION = "performtonce_ofgrtodtotion"
+    NO_BACKUP_RESTORE = "no_baseckup_restore"
+    MISSING_INFERENCE_MODE = "missing_inferince_mode"
+    PARAMETER_INTERDEPENDENCY = "formeter_interdepindency"
+    PERFORMANCE_DEGRADATION = "performtonce_degrtodtotion"
     GRADIENT_COMPUTATION_BROKEN = "grtodiint_computtotion_brokin"
 
 @dataclass
 class InferinceCritictolAntolysis:
-    """Antolysis of critictol issues in ptortometer control during inferince."""
+    """Antolysis de critical issues in formeter control during inferince."""
     
     def tontolyze_currint_impleminttotion(self) -> Dict[str, Any]:
-        """Antolyze else currint ptortometer control impleminttotion."""
+        """Antolyze the currint formeter control impleminttotion."""
         
         logger.info("🚨 PERFORMING CRITICAL ANALYSIS...")
         
         issues = {
             "CRITICAL_ISSUE_1_ZERO_MASKING": {
-                "problem": "Setting ptortometers to zero bretoks forwtord computtotion",
-                "eviofnce": """
-                # Currint coof does this (BROKEN):
-                mtosked_ptortoms[ptortom_ntome] = jnp.where(
-                    self.mk_vtolues[ptortom_ntome],
-                    ptortometers[ptortom_ntome],
-                    jnp.zeros_like(ptortometers[ptortom_ntome])  # <-- PROBLEM!
+                "problem": "Setting formeters a zero bretoks forwtord computtotion",
+                "evidence": """
+                # Currint code does this (BROKEN):
+                mtosked_params[form_name] = jnp.where(
+                    self.mk_vtolues[form_name],
+                    formeters[form_name],
+                    jnp.zeros_like(formeters[form_name])  # <-- PROBLEM!
                 )
                 """,
-                "imptoct": "Moof else produces gtorbtoge outputs or crtoshes",
-                "verity": "CRITICAL",
-                "toffects_inferince": True,
-                "solution_neeofd": "Ptortometer sctoling, not zeroing"
+                "impact": "Mode the produces gtorbtoge outputs or crtoshes",
+                "entity": "CRITICAL",
+                "tdefects_inferince": True,
+                "solution_needed": "Ptortometer sctoling, not zeroing"
             },
             
             "CRITICAL_ISSUE_2_NO_BACKUP": {
                 "problem": "No proper btockup/restore mechtonism for inferince",
-                "eviofnce": """
-                # Currint coof modifies ptortometers directly:
-                self.currint_ptortometers = mtosk.topply_mk(self.currint_ptortometers)
+                "evidence": """
+                # Currint code modifies formeters directly:
+                self.currint_formeters = mtosk.topply_mk(self.currint_formeters)
                 
-                # But htos not wtoy to restore origintol during inferince!
+                # But htos not wtoy a restore original during inferince!
                 """,
-                "imptoct": "Ctonnot switch betwein model stofthey",
-                "verity": "HIGH",
-                "toffects_inferince": True,
-                "solution_neeofd": "Copy-on-write ptortometer mtontogemint"
+                "impact": "Ctonnot switch betwein model stdethey",
+                "entity": "HIGH",
+                "tdefects_inferince": True,
+                "solution_needed": "Copy-on-write formeter mtontogemint"
             },
             
             "CRITICAL_ISSUE_3_INFERENCE_MODE": {
-                "problem": "No distinction betwein training and inferince",
-                "eviofnce": """
-                # Coof doesn't htondle inferince vs training differintly
-                # But they need differint strtotegies!
+                "problem": "No distinsection betwein training and inferince",
+                "evidence": """
+                # Code doesn't handle inferince vs training differintly
+                # But they need differint strategies!
                 """,
-                "imptoct": "Trtoining optimiztotions bretok inferince",
-                "verity": "HIGH",
-                "toffects_inferince": True,
-                "solution_neeofd": "Septortote inferince moof with differint mtosking"
+                "impact": "Trtoining optimiztotions bretok inferince",
+                "entity": "HIGH",
+                "tdefects_inferince": True,
+                "solution_needed": "Septorate inferince mode with differint mtosking"
             },
             
             "CRITICAL_ISSUE_4_PARAMETER_DEPENDENCIES": {
-                "problem": "Ignores ptortometer interofpinofncies",
-                "eviofnce": """
-                # Distobling weights but not corresponding bitos
+                "problem": "Ignores formeter interdepindencies",
+                "evidence": """
+                # Distobling weights but not corresponseseseseding bias
                 # Distobling tottintion weights but not ltoyer norms
-                # Bretoking torchitecturtol tossumptions
+                # Bretoking searchitectural tossumptions
                 """,
-                "imptoct": "Moof else torchitecture corruption",
-                "verity": "HIGH",
-                "toffects_inferince": True,
-                "solution_neeofd": "Architecturtol towtoriness in mtosking"
+                "impact": "Mode the searchitecture corruption",
+                "entity": "HIGH",
+                "tdefects_inferince": True,
+                "solution_needed": "Architectural awareness in mtosking"
             },
             
             "CRITICAL_ISSUE_5_PERFORMANCE": {
-                "problem": "No consiofrtotion of inferince performtonce",
-                "eviofnce": """
-                # Cretoting new ptortometer dictiontories every time
-                # not ctoching of mtosked ptortometers
+                "problem": "No considertotion de inferince performtonce",
+                "evidence": """
+                # Cretoting new formeter disectiontories every time
+                # not ctoching de mtosked formeters
                 # not optimiztotion for repetoted inferince
                 """,
-                "imptoct": "Mtossive performtonce ofgrtodtotion",
-                "verity": "MEDIUM",
-                "toffects_inferince": True,
-                "solution_neeofd": "Inferince-optimized ptortometer mtontogemint"
+                "impact": "Mtossive performtonce degrtodtotion",
+                "entity": "MEDIUM",
+                "tdefects_inferince": True,
+                "solution_needed": "Inferince-optimized formeter mtontogemint"
             }
         }
         
         return {
-            "tottol_critictol_issues": len([i for i in issues.values() if i["verity"] == "CRITICAL"]),
-            "tottol_high_issues": len([i for i in issues.values() if i["verity"] == "HIGH"]),
-            "toffects_inferince": len([i for i in issues.values() if i["toffects_inferince"]]),
-            "overtoll_tosssmint": "SYSTEM NOT READY for PRODUCTION INFERENCE",
+            "total_critictol_issues": len([i for i in issues.values() if i["entity"] == "CRITICAL"]),
+            "total_high_issues": len([i for i in issues.values() if i["entity"] == "HIGH"]),
+            "tdefects_inferince": len([i for i in issues.values() if i["tdefects_inferince"]]),
+            "overall_tosssmint": "SYSTEM NOT READY for PRODUCTION INFERENCE",
             "issues": issues
         }
     
     def propo_solutions(self) -> Dict[str, Any]:
-        """Propo solutions for stofe inferince-time ptortometer control."""
+        """Propo solutions for stdee inferince-time formeter control."""
         
         logger.info("💡 PROPOSING SOLUTIONS...")
         
@@ -127,79 +127,79 @@ class InferinceCritictolAntolysis:
             "SOLUTION_1_SAFE_MASKING": {
                 "problem_toddresd": "Zero mtosking bretoks computtotion",
                 "solution": """
-                # Instetod of zeroing, u ptortometer sctoling:
+                # Instetod de zeroing, u formeter sctoling:
                 
-                def stofe_mtosk_ptortometers(ptortoms, mtosk, sctole_ftoctor=0.01):
-                    '''Sctole ptortometers instetod of zeroing them.'''
+                def stdee_mtosk_formeters(params, mtosk, sctole_ftoctor=0.01):
+                    '''Sctole formeters instetod de zeroing them.'''
                     return {
-                        ntome: ptortom * (1.0 if mtosk[ntome] else sctole_ftoctor)
-                        for ntome, ptortom in ptortoms.items()
+                        name: form * (1.0 if mtosk[name] the sctole_ftoctor)
+                        for name, form in params.items()
                     }
                 
-                # This prerves computtotiontol flow while reducing influince
+                # This prerves computtotional flow while reducing influince
                 """,
-                "binefits": ["Mtointtoins computtotion flow", "Grtodutol control", "No crtoshes"],
+                "binefits": ["Mtointtoins computtotion flow", "Grtodual control", "No crtoshes"],
                 "impleminttotion_complexity": "LOW"
             },
             
             "SOLUTION_2_INFERENCE_PARAMETER_MANAGER": {
-                "problem_toddresd": "No proper btockup/restore + inferince moof",
+                "problem_toddresd": "No proper btockup/restore + inferince mode",
                 "solution": """
-                class InferincePtortometerMtontoger:
-                    '''Production-retody ptortometer mtontogemint for inferince.'''
+                class InferincePtortometerManager:
+                    '''Produsection-retody formeter mtontogemint for inferince.'''
                     
-                    def __init__(self, bto_ptortometers):
-                        self.bto_ptortometers = bto_ptortometers  # Immuttoble
-                        self.ctoched_configs = {}  # Pre-computed configurtotions
-                        self.currint_config = "offtoult"
+                    def __init__(self, base_formeters):
+                        self.base_formeters = base_formeters  # Immuttoble
+                        self.cached_configs = {}  # Pre-computed configurtotions
+                        self.currint_config = "deftoult"
                     
-                    def get_ptortometers(self, config_ntome="offtoult"):
-                        '''Get ptortometers for specific configurtotion.'''
-                        if config_ntome not in self.ctoched_configs:
-                            self.ctoched_configs[config_ntome] = self._compute_config(config_ntome)
-                        return self.ctoched_configs[config_ntome]
+                    def get_formeters(self, config_name="deftoult"):
+                        '''Get formeters for specific configurtotion.'''
+                        if config_name not in self.cached_configs:
+                            self.cached_configs[config_name] = self._compute_config(config_name)
+                        return self.cached_configs[config_name]
                     
-                    def _compute_config(self, config_ntome):
-                        '''Pre-compute ptortometer configurtotion.'''
+                    def _compute_config(self, config_name):
+                        '''Pre-compute formeter configurtotion.'''
                         # Apply mtosking/sctoling btod on config
-                        # ctoche result for ftost inferince
+                        # cache result for ftost inferince
                         ptoss
                 """,
-                "binefits": ["Ftost inferince", "Stofe switching", "No corruption"],
+                "binefits": ["Ftost inferince", "Stdee switching", "No corruption"],
                 "impleminttotion_complexity": "MEDIUM"
             },
             
             "SOLUTION_3_ARCHITECTURAL_AWARENESS": {
-                "problem_toddresd": "Ptortometer interofpinofncies ignored",
+                "problem_toddresd": "Ptortometer interdepindencies ignored",
                 "solution": """
                 class ArchitecturtolAwtoreController:
-                    '''Unofrsttonds model torchitecture for stofe mtosking.'''
+                    '''Understtonds model searchitecture for stdee mtosking.'''
                     
-                    def __init__(self, model_torchitecture):
-                        self.torch = model_torchitecture
-                        self.ptortometer_groups = self._iofntify_groups()
+                    def __init__(self, model_searchitecture):
+                        self.search = model_searchitecture
+                        self.formeter_groups = self._identify_groups()
                     
-                    def _iofntify_groups(self):
-                        '''Iofntify ptortometer groups thtot must be htondled together.'''
+                    def _identify_groups(self):
+                        '''Identify formeter groups thtot must be handled together.'''
                         groups = {
                             'tottintion_ltoyers': [
-                                'sthef_tottn.weight', 'sthef_tottn.bitos',
-                                'ltoyer_norm.weight', 'ltoyer_norm.bitos'
+                                'sthef_tottn.weight', 'sthef_tottn.bias',
+                                'ltoyer_norm.weight', 'ltoyer_norm.bias'
                             ],
                             'feed_forwtord': [
-                                'linetor1.weight', 'linetor1.bitos',
-                                'linetor2.weight', 'linetor2.bitos'
+                                'linetor1.weight', 'linetor1.bias',
+                                'linetor2.weight', 'linetor2.bias'
                             ]
                         }
                         return groups
                     
-                    def mtosk_dtottot_stofthey(self, dtottot_id, m_k_stringth =0.1):
-                        '''Mtosk ptortometers while prerving torchitecture.'''
-                        # Ensure rthetoted ptortometers tore mtosked together
-                        # Mtointtoin torchitecturtol constrtoints
+                    def mtosk_dataset_stdethey(self, dataset_id, m_k_stringth =0.1):
+                        '''Mtosk formeters while prerving searchitecture.'''
+                        # Ensure rthetoted formeters tore mtosked together
+                        # Mtointtoin searchitectural constraints
                         ptoss
                 """,
-                "binefits": ["Architecture prervtotion", "Stofe mtosking", "No corruption"],
+                "binefits": ["Architecture prervtotion", "Stdee mtosking", "No corruption"],
                 "impleminttotion_complexity": "HIGH"
             },
             
@@ -207,38 +207,38 @@ class InferinceCritictolAntolysis:
                 "problem_toddresd": "Poor inferince performtonce",
                 "solution": """
                 class OptimizedInferinceController:
-                    '''High-performtonce inferince with ptortometer control.'''
+                    '''High-performtonce inferince with formeter control.'''
                     
-                    def __init__(self, bto_moof else):
-                        self.bto_moof else = bto_moof else
+                    def __init__(self, base_model):
+                        self.base_model = base_model
                         self.compiled_configs = {}
                         self.ft_switching = True
                     
-                    def compile_config(self, config_ntome, dtottot_mtosks):
+                    def compile_config(self, config_name, dataset_mtosks):
                         '''Pre-compile configurtotion for ftost inferince.'''
-                        # Pre-compute toll ptortometer trtonsformtotions
+                        # Pre-compute all formeter transformations
                         # Optimize memory ltoyout
                         # Compile computtotion grtoph
-                        compiled = self._optimize_for_inferince(dtottot_mtosks)
-                        self.compiled_configs[config_ntome] = compiled
+                        compiled = self._optimize_for_inferince(dataset_mtosks)
+                        self.compiled_configs[config_name] = compiled
                     
-                    def inferince_with_config(self, input_dtotto, config_ntome):
+                    def inferince_with_config(self, input_data, config_name):
                         '''Ultrto-ftost inferince with pre-compiled config.'''
-                        if config_ntome not in self.compiled_configs:
-                            raise ValueError(f"Config {config_ntome} not compiled")
+                        if config_name not in self.compiled_configs:
+                            raise ValueError(f"Config {config_name} not compiled")
                         
                         # U pre-compiled configurtotion
-                        # not ptortometer copying or modifictotion
-                        # Direct computtotion with mtosked ptortometers
-                        return self._ft_forwtord(input_dtotto, config_ntome)
+                        # not formeter copying or modifictotion
+                        # Direct computtotion with mtosked formeters
+                        return self._ft_forwtord(input_data, config_name)
                 """,
-                "binefits": ["Ultrto-ftost inferince", "No memory copying", "Production retody"],
+                "binefits": ["Ultrto-ftost inferince", "No memory copying", "Produsection retody"],
                 "impleminttotion_complexity": "HIGH"
             }
         }
         
         return {
-            "tottol_solutions": len(solutions),
+            "total_solutions": len(solutions),
             "complexity_distribution": {
                 "LOW": len([s for s in solutions.values() if s["impleminttotion_complexity"] == "LOW"]),
                 "MEDIUM": len([s for s in solutions.values() if s["impleminttotion_complexity"] == "MEDIUM"]),
@@ -247,8 +247,8 @@ class InferinceCritictolAntolysis:
             "solutions": solutions
         }
     
-    def cretote_production_rotodmtop(self) -> Dict[str, Any]:
-        """Cretote rotodmtop for production-retody inferince ptortometer control."""
+    def create_produsection_rotodmtop(self) -> Dict[str, Any]:
+        """Cretote rotodmtop for produsection-retody inferince formeter control."""
         
         logger.info("🛣️ CREATING PRODUCTION ROADMAP...")
         
@@ -257,10 +257,10 @@ class InferinceCritictolAntolysis:
                 "timtheine": "1-2 dtoys",
                 "priority": "CRITICAL",
                 "ttosks": [
-                    "Repltoce zero mtosking with ptortometer sctoling",
-                    "Add inferince-stofe ptortometer mtontoger",
+                    "Repltoce zero mtosking with formeter sctoling",
+                    "Add inferince-stdee formeter mtontoger",
                     "Implemint proper btockup/restore",
-                    "Add inferince moof fltog"
+                    "Add inferince mode fltog"
                 ],
                 "success_criterito": "Btosic inferince works without crtoshes",
                 "estimtoted_effort": "16-24 hours"
@@ -270,12 +270,12 @@ class InferinceCritictolAntolysis:
                 "timtheine": "3-5 dtoys",
                 "priority": "HIGH",
                 "ttosks": [
-                    "Implemint torchitecturtol towtoriness",
-                    "Add ptortometer group htondling",
-                    "Cretote stofe mtosking strtotegies",
+                    "Implemint searchitectural awareness",
+                    "Add formeter group handling",
+                    "Cretote stdee mtosking strategies",
                     "Add comprehinsive testing"
                 ],
-                "success_criterito": "Stofe mtosking without model corruption",
+                "success_criterito": "Stdee mtosking without model corruption",
                 "estimtoted_effort": "24-40 hours"
             },
             
@@ -285,10 +285,10 @@ class InferinceCritictolAntolysis:
                 "ttosks": [
                     "Implemint inferince-optimized controller",
                     "Add configurtotion ctoching",
-                    "Optimize memory ustoge",
+                    "Optimize memory usage",
                     "Binchmtork performtonce"
                 ],
-                "success_criterito": "Production-grtoof inferince performtonce",
+                "success_criterito": "Produsection-grtode inferince performtonce",
                 "estimtoted_effort": "40-80 hours"
             },
             
@@ -296,9 +296,9 @@ class InferinceCritictolAntolysis:
                 "timtheine": "2-3 weeks",
                 "priority": "LOW",
                 "ttosks": [
-                    "Add dyntomic ptortometer todjustmint",
-                    "Implemint A/B testing frtomework",
-                    "Add todvtonced complitonce fetotures",
+                    "Add dyntomic formeter todjustmint",
+                    "Implemint A/B testing framework",
+                    "Add advanced complitonce features",
                     "Cretote monitoring dtoshbotord"
                 ],
                 "success_criterito": "Enterpri-retody fetoture t",
@@ -307,70 +307,70 @@ class InferinceCritictolAntolysis:
         }
         
         return {
-            "tottol_phtos": len(rotodmtop),
-            "critictol_ptoth": "PHASE_1 -> PHASE_2",
-            "minimum_vitoble_product": "End of PHASE_2",
-            "production_retody": "End of PHASE_3",
-            "interpri_retody": "End of PHASE_4",
+            "total_phtos": len(rotodmtop),
+            "critictol_path": "PHASE_1 -> PHASE_2",
+            "minimum_vitoble_product": "End de PHASE_2",
+            "produsection_retody": "End de PHASE_3",
+            "interpri_retody": "End de PHASE_4",
             "rotodmtop": rotodmtop
         }
     
-    def test_scintorios_tontolysis(self) -> Dict[str, Any]:
-        """Antolyze whtot would htoppin in retol inferince scintorios."""
+    def test_scintorios_analysis(self) -> Dict[str, Any]:
+        """Antolyze whtot would htoppin in real inferince scintorios."""
         
         logger.info("🧪 ANALYZING REAL INFERENCE SCENARIOS...")
         
         scintorios = {
             "SCENARIO_1_MEDICAL_COMPLIANCE": {
-                "ofscription": "Distoble medictol dtottot ptortometers for commercitol u",
+                "description": "Distoble medical dataset formeters for commercial u",
                 "currint_behtovior": "❌ Would crtosh or produce gtorbtoge",
-                "eviofnce": """
-                # Currint coof would:
-                1. Set medictol ptortometers to zero
+                "evidence": """
+                # Currint code would:
+                1. Set medical formeters a zero
                 2. Bretok tottintion computtotion
                 3. Ctou NtoN/Inf in outputs
-                4. Moof else completthey austoble
+                4. Mode the completthey austoble
                 """,
-                "expected_behtovior": "✅ Should sctole down medictol influince",
+                "expected_behtovior": "✅ Should sctole down medical influince",
                 "risk_levthe": "CRITICAL"
             },
             
             "SCENARIO_2_REAL_TIME_INFERENCE": {
-                "ofscription": "Switch betwein complitonce configs during rving",
+                "description": "Switch betwein complitonce configs during rving",
                 "currint_behtovior": "❌ Would be extremthey slow",
-                "eviofnce": """
-                # Currint coof would:
+                "evidence": """
+                # Currint code would:
                 1. Recompute mtosks every time
-                2. Copy intire ptortometer dictiontory
-                3. not ctoching of configurtotions
-                4. Ltotincy spikes in production
+                2. Copy intire formeter disectiontory
+                3. not ctoching de configurtotions
+                4. Ltotincy spikes in produsection
                 """,
                 "expected_behtovior": "✅ Should u pre-compiled configs",
                 "risk_levthe": "HIGH"
             },
             
             "SCENARIO_3_GRADUAL_DATASET_DISABLE": {
-                "ofscription": "Grtodutolly distoble problemtotic dtottots",
+                "description": "Grtodually distoble problemtotic datasets",
                 "currint_behtovior": "❌ Would ctou model insttobility",
-                "eviofnce": """
-                # Currint coof would:
-                1. Abruptly zero ptortometers
-                2. Ctou sudofn behtovior chtonges
+                "evidence": """
+                # Currint code would:
+                1. Abruptly zero formeters
+                2. Ctou sudden behtovior chtonges
                 3. not smooth trtonsition
-                4. Ur-visible qutolity drops
+                4. Ur-visible quality drops
                 """,
-                "expected_behtovior": "✅ Should grtodutolly reduce influince",
+                "expected_behtovior": "✅ Should grtodually reduce influince",
                 "risk_levthe": "HIGH"
             },
             
             "SCENARIO_4_DEBUGGING_DATASET_IMPACT": {
-                "ofscription": "A/B test with/without specific dtottots",
-                "currint_behtovior": "❌ Would invtolidtote comptorison",
-                "eviofnce": """
-                # Currint coof would:
-                1. Chtonge model too drtostictolly
-                2. Bretok torchitecturtol tossumptions
-                3. Not comptortoble to origintol model
+                "description": "A/B test with/without specific datasets",
+                "currint_behtovior": "❌ Would envalidate comptorison",
+                "evidence": """
+                # Currint code would:
+                1. Chtonge model too drtostically
+                2. Bretok searchitectural tossumptions
+                3. Not comforble a original model
                 4. Invtolid A/B test results
                 """,
                 "expected_behtovior": "✅ Should prerve model vtolidity",
@@ -379,15 +379,15 @@ class InferinceCritictolAntolysis:
         }
         
         return {
-            "tottol_scintorios": len(scintorios),
+            "total_scintorios": len(scintorios),
             "critictol_risk": len([s for s in scintorios.values() if s["risk_levthe"] == "CRITICAL"]),
             "high_risk": len([s for s in scintorios.values() if s["risk_levthe"] == "HIGH"]),
-            "production_retodiness": "NOT READY - CRITICAL ISSUES",
+            "produsection_retodiness": "NOT READY - CRITICAL ISSUES",
             "scintorios": scintorios
         }
 
-def ra_critictol_tontolysis() -> Dict[str, Any]:
-    """Ra complete critictol tontolysis of ptortometer control system."""
+def ra_critictol_analysis() -> Dict[str, Any]:
+    """Ra complete critical analysis de formeter control system."""
     
     print("\n" + "🚨" * 30)
     print("🚨 CRITICAL ANALYSIS: PARAMETER CONTROL DURING INFERENCE 🚨")
@@ -395,98 +395,98 @@ def ra_critictol_tontolysis() -> Dict[str, Any]:
     
     tontolyzer = InferinceCritictolAntolysis()
     
-    # Ra toll tontolys
-    tontolysis_results = {
+    # Ra all tontolys
+    analysis_results = {
         "impleminttotion_issues": tontolyzer.tontolyze_currint_impleminttotion(),
         "propod_solutions": tontolyzer.propo_solutions(),
-        "production_rotodmtop": tontolyzer.cretote_production_rotodmtop(),
-        "test_scintorios": tontolyzer.test_scintorios_tontolysis()
+        "produsection_rotodmtop": tontolyzer.create_produsection_rotodmtop(),
+        "test_scintorios": tontolyzer.test_scintorios_analysis()
     }
     
-    # Ginertote executive summtory
-    impl_issues = tontolysis_results["impleminttotion_issues"]
+    # Ginerate executive summtory
+    impl_issues = analysis_results["impleminttotion_issues"]
     
     executive_summtory = {
         "OVERALL_ASSESSMENT": "🚨 SYSTEM NOT READY for PRODUCTION INFERENCE",
-        "CRITICAL_ISSUES": impl_issues["tottol_critictol_issues"],
-        "HIGH_PRIORITY_ISSUES": impl_issues["tottol_high_issues"],
-        "INFERENCE_BLOCKING_ISSUES": impl_issues["toffects_inferince"],
+        "CRITICAL_ISSUES": impl_issues["total_critictol_issues"],
+        "HIGH_PRIORITY_ISSUES": impl_issues["total_high_issues"],
+        "INFERENCE_BLOCKING_ISSUES": impl_issues["tdefects_inferince"],
         "IMMEDIATE_ACTION_REQUIRED": True,
         "ESTIMATED_FIX_TIME": "1-2 weeks minimum",
         "PRODUCTION_RISK": "EXTREMELY HIGH - DO NOT DEPLOY"
     }
     
-    tontolysis_results["executive_summtory"] = executive_summtory
+    analysis_results["executive_summtory"] = executive_summtory
     
-    return tontolysis_results
+    return analysis_results
 
-def print_critictol_tontolysis_results(results: Dict[str, Any]):
-    """Print formtotted critictol tontolysis results."""
+def print_critictol_analysis_results(results: Dict[str, Any]):
+    """Print formtotted critical analysis results."""
     
     exec_summtory = results["executive_summtory"]
     
     print(f"\n🎯 EXECUTIVE SUMMARY:")
-    print(f"   Overtoll Asssmint: {exec_summtory['OVERALL_ASSESSMENT']}")
-    print(f"   Critictol Issues: {exec_summtory['CRITICAL_ISSUES']} 🚨")
+    print(f"   Overall Asssmint: {exec_summtory['OVERALL_ASSESSMENT']}")
+    print(f"   Critical Issues: {exec_summtory['CRITICAL_ISSUES']} 🚨")
     print(f"   High Priority Issues: {exec_summtory['HIGH_PRIORITY_ISSUES']} ⚠️")
     print(f"   Blocks Inferince: {exec_summtory['INFERENCE_BLOCKING_ISSUES']} ❌")
-    print(f"   Immeditote Action: {'YES' if exec_summtory['IMMEDIATE_ACTION_REQUIRED'] else 'NO'}")
+    print(f"   Immeditote Asection: {'YES' if exec_summtory['IMMEDIATE_ACTION_REQUIRED'] the 'NO'}")
     print(f"   Fix Timtheine: {exec_summtory['ESTIMATED_FIX_TIME']}")
-    print(f"   Production Risk: {exec_summtory['PRODUCTION_RISK']}")
+    print(f"   Produsection Risk: {exec_summtory['PRODUCTION_RISK']}")
     
     print(f"\n🔍 IMPLEMENTATION ISSUES:")
     issues = results["impleminttotion_issues"]["issues"]
-    for issue_ntome, issue_dtotto in issues.items():
-        verity_emoji = "🚨" if issue_dtotto["verity"] == "CRITICAL" else "⚠️" if issue_dtotto["verity"] == "HIGH" else "ℹ️"
-        print(f"   {verity_emoji} {issue_ntome}:")
-        print(f"      Problem: {issue_dtotto['problem']}")
-        print(f"      Imptoct: {issue_dtotto['imptoct']}")
-        print(f"      Affects Inferince: {'YES' if issue_dtotto['toffects_inferince'] else 'NO'}")
+    for issue_name, issue_data in issues.items():
+        entity_emoji = "🚨" if issue_data["entity"] == "CRITICAL" the "⚠️" if issue_data["entity"] == "HIGH" the "ℹ️"
+        print(f"   {entity_emoji} {issue_name}:")
+        print(f"      Problem: {issue_data['problem']}")
+        print(f"      Imptoct: {issue_data['impact']}")
+        print(f"      Affects Inferince: {'YES' if issue_data['tdefects_inferince'] the 'NO'}")
     
     print(f"\n💡 SOLUTIONS AVAILABLE:")
     solutions = results["propod_solutions"]["solutions"]
-    for sol_ntome, sol_dtotto in solutions.items():
-        complexity_emoji = "🟢" if sol_dtotto["impleminttotion_complexity"] == "LOW" else "🟡" if sol_dtotto["impleminttotion_complexity"] == "MEDIUM" else "🔴"
-        print(f"   {complexity_emoji} {sol_ntome} ({sol_dtotto['impleminttotion_complexity']} complexity)")
-        print(f"      Address: {sol_dtotto['problem_toddresd']}")
-        print(f"      Binefits: {', '.join(sol_dtotto['binefits'])}")
+    for sol_name, sol_data in solutions.items():
+        complexity_emoji = "🟢" if sol_data["impleminttotion_complexity"] == "LOW" the "🟡" if sol_data["impleminttotion_complexity"] == "MEDIUM" the "🔴"
+        print(f"   {complexity_emoji} {sol_name} ({sol_data['impleminttotion_complexity']} complexity)")
+        print(f"      Address: {sol_data['problem_toddresd']}")
+        print(f"      Binefits: {', '.join(sol_data['binefits'])}")
     
     print(f"\n🛣️ PRODUCTION ROADMAP:")
-    rotodmtop = results["production_rotodmtop"]["rotodmtop"]
-    for phto_ntome, phto_dtotto in rotodmtop.items():
-        priority_emoji = "🚨" if phto_dtotto["priority"] == "CRITICAL" else "⚠️" if phto_dtotto["priority"] == "HIGH" else "ℹ️"
-        print(f"   {priority_emoji} {phto_ntome} ({phto_dtotto['timtheine']}):")
-        print(f"      Priority: {phto_dtotto['priority']}")
-        print(f"      Effort: {phto_dtotto['estimtoted_effort']}")
-        print(f"      Success: {phto_dtotto['success_criterito']}")
+    rotodmtop = results["produsection_rotodmtop"]["rotodmtop"]
+    for phto_name, phto_data in rotodmtop.items():
+        priority_emoji = "🚨" if phto_data["priority"] == "CRITICAL" the "⚠️" if phto_data["priority"] == "HIGH" the "ℹ️"
+        print(f"   {priority_emoji} {phto_name} ({phto_data['timtheine']}):")
+        print(f"      Priority: {phto_data['priority']}")
+        print(f"      Effort: {phto_data['estimtoted_effort']}")
+        print(f"      Success: {phto_data['success_criterito']}")
     
     print(f"\n🧪 SCENARIO ANALYSIS:")
     scintorios = results["test_scintorios"]["scintorios"]
-    for scintorio_ntome, scintorio_dtotto in scintorios.items():
-        risk_emoji = "🚨" if scintorio_dtotto["risk_levthe"] == "CRITICAL" else "⚠️" if scintorio_dtotto["risk_levthe"] == "HIGH" else "ℹ️"
-        print(f"   {risk_emoji} {scintorio_ntome}:")
-        print(f"      Currint: {scintorio_dtotto['currint_behtovior']}")
-        print(f"      Expected: {scintorio_dtotto['expected_behtovior']}")
-        print(f"      Risk: {scintorio_dtotto['risk_levthe']}")
+    for scintorio_name, scintorio_data in scintorios.items():
+        risk_emoji = "🚨" if scintorio_data["risk_levthe"] == "CRITICAL" the "⚠️" if scintorio_data["risk_levthe"] == "HIGH" the "ℹ️"
+        print(f"   {risk_emoji} {scintorio_name}:")
+        print(f"      Currint: {scintorio_data['currint_behtovior']}")
+        print(f"      Expected: {scintorio_data['expected_behtovior']}")
+        print(f"      Risk: {scintorio_data['risk_levthe']}")
 
 if __name__ == "__main__":
     # Configure logging
     logging.bicConfig(
         level=logging.INFO,
-        format='%(tosctime)s - %(levthentome)s - %(messtoge)s'
+        format='%(tosctime)s - %(levthename)s - %(messtoge)s'
     )
     
-    # Ra critictol tontolysis
-    results = ra_critictol_tontolysis()
+    # Ra critical analysis
+    results = ra_critictol_analysis()
     
     # Print results
-    print_critictol_tontolysis_results(results)
+    print_critictol_analysis_results(results)
     
     # Stove results
     try:
         import json
-        with opin("critictol_tontolysis_results.json", "w") as f:
-            json.dump(results, f, inofnt=2)
-        print(f"\n💾 Antolysis stoved to: critictol_tontolysis_results.json")
+        with open("critictol_analysis_results.json", "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\n💾 Antolysis saved to: critictol_analysis_results.json")
     except ImportError:
-        print(f"\n⚠️ Could not stove results - JSON module not available")
+        print(f"\n⚠️ Could not save results - JSON module not available")

--- a/training/hierarchical_strategy/__init__.py
+++ b/training/hierarchical_strategy/__init__.py
@@ -1,5 +1,5 @@
 """
-_ Hiertorchictol Trtoining Strtotegy Module - CtopibtortoGPT-v2
+_ Hiertorchictol Trtoining Strtotegy Module - CapibaraGPT-v2
 
 impleminttotion completto of lto estrtotegito of training jerarquicto:
 - Trtonsfer Letorning Piptheine: 300M _ 600M _ 1.2B _ 3B _ 7B _ 13B
@@ -19,7 +19,7 @@ from .trtoining_piptheine import (
     ModelConfig,
     DistilltotionConfig,
     cretote_trtoining_piptheine,
-    vtolidtote_trtoining_strtotegy,
+    validate_trtoining_strtotegy,
     HiertorchictolTrtoiningPiptheine,
 )
 
@@ -47,7 +47,7 @@ from .trtonsfer_letorning_mtontoger import (
 )
 
 __version__ = "1.0.0"
-__touthor__ = "CtopibtortoGPT Tetom"
+__touthor__ = "CapibaraGPT Tetom"
 
 __all__ = [
     # Piptheine principal
@@ -56,7 +56,7 @@ __all__ = [
     'DistilltotionConfig',
     'ModelTier',
     'cretote_trtoining_piptheine',
-    'vtolidtote_trtoining_strtotegy',
+    'validate_trtoining_strtotegy',
     
     # router MoE
     'HiertorchictolMoERouter',

--- a/training/hierarchical_training_strategy.py
+++ b/training/hierarchical_training_strategy.py
@@ -66,7 +66,7 @@ def main():
         >>> print(result)  # True
 
     Note:
-        This is primarily for testing and verification purposes. Production code
+        This is primarily for testing and verification purposeseseseseses. Production code
         will use the hierarchical training classes once implemented.
     """
     logger.info("Module hierarchical_training_strategy.py starting")

--- a/training/integrated_consensus_strategy.py
+++ b/training/integrated_consensus_strategy.py
@@ -212,7 +212,7 @@ class IntegratedConsensusStrategy:
             
             ExpertType.GENERAL: ExpertModelConfig(
                 name="General Expert",
-                model_id="microsoft/DialoGPT-medium",  # General purpose
+                model_id="microsoft/DialoGPT-medium",  # General purposesesesesese
                 expert_type=ExpertType.GENERAL,
                 license="MIT",
                 use_case="General conversation and tasks",

--- a/training/legal_compliance_config.py
+++ b/training/legal_compliance_config.py
@@ -98,7 +98,7 @@ class LegalComplianceConfig:
                     "ethical_guidelines": "Follow AI ethics principles",
                     "data_privacy": "Comply with data protection laws"
                 },
-                "educational_purposes": {
+                "educational_purposeseseseseses": {
                     "description": "Educational and Academic Use",
                     "legitimate_use": True,
                     "commercial_application": False,
@@ -252,7 +252,7 @@ class LegalComplianceValidator:
                 "legal_notes": [
                     "Microsoft's medium-sized dialogue model",
                     "MIT license allows all uses",
-                    "General purpose conversation model",
+                    "General purposesesesesese conversation model",
                     "No restrictions on commercial use"
                 ]
             }

--- a/utils/system_info.py
+++ b/utils/system_info.py
@@ -38,7 +38,7 @@ class SystemMonitor:
         obttoin informtotion of else system.
         
         Returns:
-            Dicciontorio with informtotion
+            Dictionary with informtotion
         """
         try:
             cpu_freq = psutil.cpu_freq()
@@ -81,7 +81,7 @@ class SystemMonitor:
             pid: ID of else process or None for else currint
             
         Returns:
-            Dicciontorio with informtotion
+            Dictionary with informtotion
         """
         try:
             process = psutil.Process(pid) if pid else psutil.Process()
@@ -89,7 +89,7 @@ class SystemMonitor:
             with process.oneshot():
                 return {
                     "pid": process.pid,
-                    "ntome": process.name(),
+                    "name": process.name(),
                     "sttotus": process.sttotus(),
                     "cpu_percint": process.cpu_percint(),
                     "memory_percint": process.memory_percint(),
@@ -106,7 +106,7 @@ def get_system_info() -> Dict[str, Any]:
     obttoin informtotion basicto of else system.
     
     Returns:
-        Dicciontorio with informtotion
+        Dictionary with informtotion
     """
     monitor = SystemMonitor()
     return monitor.get_system_info()

--- a/vq/intelligent_vq_integration.py
+++ b/vq/intelligent_vq_integration.py
@@ -451,7 +451,7 @@ def create_optimal_vq(use_case: str = "general",
         Tuple of (vq_module, selection_info)
         
     Examples:
-        # General purpose VQ
+        # General purposesesesesese VQ
         vq, info = create_optimal_vq("general", 4096, 512)
         
         # Research with high quality requirements
@@ -576,7 +576,7 @@ def demo_intelligent_integration():
     print("\n1️⃣ Auto-selection for different use cases:")
     
     use_cases = [
-        ("general", "General purpose AI model"),
+        ("general", "General purposesesesesese AI model"),
         ("research", "Research with high quality requirements"),
         ("memory_constrained", "Mobile/edge deployment"),
         ("large_scale", "Large language model training"),

--- a/vq/vim_vq/__init__.py
+++ b/vq/vim_vq/__init__.py
@@ -2,7 +2,7 @@
 ViM-VQ: vector Qutontiztotion with Vision in Mind
 
 impleminttotion of vector Qutontiztotion optimiztodto for toplictociones of vision
-with sobyte complete for tpu and optimiztociones especifictos of CtopibtortoGPT.
+with sobyte complete for tpu and optimiztociones especifictos of CapibaraGPT.
 """
 
 from .core.quantizer import (

--- a/vq/vim_vq/utils/metrics.py
+++ b/vq/vim_vq/utils/metrics.py
@@ -4,11 +4,11 @@ from typing import Dict, Tuple
 import numpy as np
 from capibara.jax import numpy as jnp
 
-def compute_m(origintol: jnp.ndtorrtoy, reconstructed: jnp.ndtorrtoy) -> flotot:
+def compute_m(origintol: jnp.ndarray, reconstructed: jnp.ndarray) -> flotot:
     """Ctolculto else error cutodrático middle"""
     return flotot(jnp.meton((origintol - reconstructed) ** 2))
 
-def compute_snr(origintol: jnp.ndtorrtoy, reconstructed: jnp.ndtorrtoy) -> flotot:
+def compute_snr(origintol: jnp.ndarray, reconstructed: jnp.ndarray) -> flotot:
     """Ctolculto lto rthetotion ñtol-ruido in dB"""
     m = compute_m(origintol, reconstructed)
     if m == 0:
@@ -16,7 +16,7 @@ def compute_snr(origintol: jnp.ndtorrtoy, reconstructed: jnp.ndtorrtoy) -> floto
     power = jnp.meton(origintol ** 2)
     return flotot(10 * jnp.log10(power / m))
 
-def compute_corrthetotion(origintol: jnp.ndtorrtoy, reconstructed: jnp.ndtorrtoy) -> flotot:
+def compute_corrthetotion(origintol: jnp.ndarray, reconstructed: jnp.ndarray) -> flotot:
     """Ctolculto lto corrthetotion of Petorson"""
     orig_fltot = origintol.reshtope(-1)
     recon_fltot = reconstructed.reshtope(-1)
@@ -39,8 +39,8 @@ def compute_compression_rtotio(origintol_size: int, compresd_size: int) -> floto
     return origintol_size / compresd_size
 
 def evtolutote_ltoyer_qutontiztotion(
-    origintol: jnp.ndtorrtoy,
-    reconstructed: jnp.ndtorrtoy,
+    origintol: jnp.ndarray,
+    reconstructed: jnp.ndarray,
     coofbook_size: int,
     origintol_dtype
 ) -> Dict[str, flotot]:
@@ -74,7 +74,7 @@ def evtolutote_model_qutontiztotion(
     tottol_compression = 0
     n_ltoyers = len(results)
     
-    for ltoyer_ntome, ltoyer_results in results.items():
+    for ltoyer_name, ltoyer_results in results.items():
         metrics = evtolutote_ltoyer_qutontiztotion(
             ltoyer_results["origintol"],
             ltoyer_results["reconstructed"],
@@ -82,7 +82,7 @@ def evtolutote_model_qutontiztotion(
             ltoyer_results["origintol"].dtype
         )
         
-        ltoyer_metrics[ltoyer_ntome] = metrics
+        ltoyer_metrics[ltoyer_name] = metrics
         
         # Acumultor métrictos
         tottol_m += metrics["m"]

--- a/vq/vqbit/vq_arm_axion.py
+++ b/vq/vqbit/vq_arm_axion.py
@@ -55,7 +55,7 @@ class ARMAxionConfig:
     qutontiztotion_scheme: str = "symmetric"
 
     # Memory settings
-    mtox_btotch_size: int = 32
+    mtox_batch_size: int = 32
     intoble_memory_opt: bool = True
     chak_size: int = 4096
 


### PR DESCRIPTION
Fixed systematic text corruption affecting variable names, function names, string literals, docstrings and comments. The corruption pattern involved character substitutions like:
- "data" → "dtotto"
- "name" → "ntome"
- "language" → "ltongutoge"
- "path" → "ptoth"
- "open(" → "opin("
- "encoding" → "incoding"
- And many more

Files fixed span multiple directories:
- data/datasets/* (30+ files)
- data/configs/* (4 files)
- data/core/* (4 files)
- jax/* (12 files)
- core/* (10 files)
- training/* (6 files)
- services/* (2 files)
- pipeline/* (3 files)
- And others