### PR TITLE
fix: Add graceful handling for missing JAX/Flax/PyTorch dependencies

### DIFF
--- a/core/cot/enhanced_cot_module.py
+++ b/core/cot/enhanced_cot_module.py
@@ -3,8 +3,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-import flax.linen as nn
-import jax.numpy as jnp
+# Lazy imports for JAX/Flax (TPU backend)
+nn = None
+jnp = None
+
+def _ensure_jax():
+    """Lazy import JAX/Flax modules."""
+    global nn, jnp
+    if jnp is None:
+        try:
+            import flax.linen as _nn
+            import jax.numpy as _jnp
+            nn = _nn
+            jnp = _jnp
+        except ImportError as e:
+            raise ImportError(
+                "JAX/Flax not installed. Install with: pip install jax flax"
+            ) from e
 
 try:
     from capibara.core.kernels.tpu_v4_wrappers import tpu_kernthe

--- a/layers/__init__.py
+++ b/layers/__init__.py
@@ -7,13 +7,16 @@ Neural network layer implementations:
 - abstract_reasoning: Platonic, Quineana, GameTheory
 - sparsity: BitNet, sparse layers, quantization
 - ultra_layer_integration: Ecosystem orchestration
+
+Note: Most layers require JAX/Flax or PyTorch. Check availability flags
+before using specific layers.
 """
 
 import logging
 
 logger = logging.getLogger(__name__)
 
-# SSM hybrid layers
+# SSM hybrid layers (requires JAX/Flax)
 try:
     from .ssm_hybrid_layers import (
         UltraSSMLayer,
@@ -27,7 +30,8 @@ try:
         SSM_COMPONENTS_AVAILABLE,
     )
     SSM_LAYERS_AVAILABLE = True
-except ImportError:
+except Exception as e:
+    logger.debug(f"SSM hybrid layers not available: {e}")
     SSM_LAYERS_AVAILABLE = False
     SSM_COMPONENTS_AVAILABLE = False
     UltraSSMLayer = None
@@ -39,36 +43,40 @@ except ImportError:
     create_ssm_config = None
     validate_ssm_system = None
 
-# Passive learning layers
+# Passive learning layers (requires JAX/Flax)
 try:
     from .pasive.synthetic_embedding import SyntheticEmbedding
     from .pasive.attention import DistributedAttention
     PASSIVE_LAYERS_AVAILABLE = True
-except ImportError:
+except Exception as e:
+    logger.debug(f"Passive layers not available: {e}")
     PASSIVE_LAYERS_AVAILABLE = False
     SyntheticEmbedding = None
     DistributedAttention = None
 
-# Abstract reasoning layers
+# Abstract reasoning layers (requires JAX/Flax)
 try:
     from .abstract_reasoning.platonic import Platonic
     from .abstract_reasoning.quineana import Quineana
-    from .abstract_reasoning.game_theory import GameTheory
+    from .abstract_reasoning.game_theory import GameTheory, BasicGameTheory
     ABSTRACT_REASONING_AVAILABLE = True
-except ImportError:
+except Exception as e:
+    logger.debug(f"Abstract reasoning layers not available: {e}")
     ABSTRACT_REASONING_AVAILABLE = False
     Platonic = None
     Quineana = None
     GameTheory = None
+    BasicGameTheory = None
 
-# Sparsity and quantization layers
+# Sparsity and quantization layers (requires JAX/Flax)
 try:
     from .sparsity.bitnet import Conv1DBlock, BitNet158
     from .sparsity.sparse_capibara import SparseCapibara
     from .sparsity.affine_quantizer import AffineQuantizer
     from .sparsity.mixture_of_rookies import MixtureOfRookies
     SPARSITY_LAYERS_AVAILABLE = True
-except ImportError:
+except Exception as e:
+    logger.debug(f"Sparsity layers not available: {e}")
     SPARSITY_LAYERS_AVAILABLE = False
     Conv1DBlock = None
     BitNet158 = None
@@ -82,7 +90,8 @@ try:
     from .meta_la import MetaLA, MetaLAConfig
     from .smb_layer import SMBLayer
     ADDITIONAL_LAYERS_AVAILABLE = True
-except ImportError:
+except Exception as e:
+    logger.debug(f"Additional layers not available: {e}")
     ADDITIONAL_LAYERS_AVAILABLE = False
     Conv1DBlockLayer = None
     MetaLA = None
@@ -102,7 +111,8 @@ try:
         ULTRA_TRAINING_INTEGRATION,
     )
     ULTRA_LAYER_INTEGRATION_AVAILABLE = True
-except ImportError:
+except Exception as e:
+    logger.debug(f"Ultra layer integration not available: {e}")
     ULTRA_LAYER_INTEGRATION_AVAILABLE = False
     ULTRA_CORE_AVAILABLE = False
     ULTRA_TRAINING_INTEGRATION = False
@@ -131,6 +141,7 @@ __all__ = [
     "Platonic",
     "Quineana",
     "GameTheory",
+    "BasicGameTheory",
     # Sparsity
     "Conv1DBlock",
     "BitNet158",

--- a/layers/abstract_reasoning/game_theory.py
+++ b/layers/abstract_reasoning/game_theory.py
@@ -1,44 +1,71 @@
 """
 abstract_reasoning game_theory module.
 
-# This module provides functionality for game_theory.
+This module provides functionality for game_theory using JAX/Flax.
+Requires: pip install jax flax
 """
 
 import logging
 from typing import Any, Dict, List, Optional
 import numpy as np
-import flax.linen as nn
-import jax.numpy as jnp
 
 logger = logging.getLogger(__name__)
 
-class GameTheory(nn.Module):
-    """Game theory layer for strategic decision making in neural networks."""
-    
-    features: int = 768
-    num_agents: int = 2
-    
-    @nn.compact
-    def __call__(self, x):
-        """Apply game theory principles to input."""
-        batch_size, seq_len, features = x.shape
-        
-        # Simple implementation - can be expanded
-        # Multi-agent decision making
-        agent_weights = self.param('agent_weights', 
-                                   nn.initializers.normal(0.02), 
-                                   (self.num_agents, features))
-        
-        # Compute payoff matrix
-        payoffs = jnp.dot(x, agent_weights.T)  # (batch, seq, agents)
-        
-        # Nash equilibrium approximation (simplified)
-        equilibrium = nn.softmax(payoffs, axis=-1)
-        
-        # Weighted combination based on equilibrium
-        output = jnp.sum(equilibrium[:, :, :, None] * x[:, :, None, :], axis=2)
-        
-        return output
+# JAX/Flax imports (TPU backend)
+try:
+    import flax.linen as nn
+    import jax.numpy as jnp
+    JAX_AVAILABLE = True
+except ImportError:
+    nn = None  # type: ignore
+    jnp = None  # type: ignore
+    JAX_AVAILABLE = False
+    logger.warning("JAX/Flax not available. Install with: pip install jax flax")
+
+
+def _check_jax():
+    """Check if JAX is available, raise if not."""
+    if not JAX_AVAILABLE:
+        raise ImportError(
+            "JAX/Flax required for this module. Install with: pip install jax flax"
+        )
+
+
+# Only define Flax-based class if JAX is available
+if JAX_AVAILABLE:
+    class GameTheory(nn.Module):
+        """Game theory layer for strategic decision making in neural networks."""
+
+        features: int = 768
+        num_agents: int = 2
+
+        @nn.compact
+        def __call__(self, x):
+            """Apply game theory principles to input."""
+            batch_size, seq_len, features = x.shape
+
+            # Simple implementation - can be expanded
+            # Multi-agent decision making
+            agent_weights = self.param('agent_weights',
+                                       nn.initializers.normal(0.02),
+                                       (self.num_agents, features))
+
+            # Compute payoff matrix
+            payoffs = jnp.dot(x, agent_weights.T)  # (batch, seq, agents)
+
+            # Nash equilibrium approximation (simplified)
+            equilibrium = nn.softmax(payoffs, axis=-1)
+
+            # Weighted combination based on equilibrium
+            output = jnp.sum(equilibrium[:, :, :, None] * x[:, :, None, :], axis=2)
+
+            return output
+else:
+    # Stub class when JAX not available
+    class GameTheory:  # type: ignore
+        """Stub: JAX/Flax required for full functionality."""
+        def __init__(self, *args, **kwargs):
+            raise ImportError("JAX/Flax required. Install with: pip install jax flax")
 
 class BasicGameTheory:
     """Basic Game Theory implementation for abstract reasoning."""

--- a/layers/ssm_hybrid_layers.py
+++ b/layers/ssm_hybrid_layers.py
@@ -4,7 +4,7 @@ SSM Hybrid Layers - CapibaraGPT v2024 Ultra Advanced
 
 Capas híbridas SSM que combinan Mamba and S4 with todas las optimizaciones tpu v4-32 existentes:
 - Integration with tpu-optimized caching systems
-- Mixed precision BF16/FP32 support  
+- Mixed precision BF16/FP32 support
 - Fused operations for systolic arrays
 - Memory layout optimization
 - Performance benchmarking integration
@@ -12,6 +12,7 @@ Capas híbridas SSM que combinan Mamba and S4 with todas las optimizaciones tpu 
 
 Esta es la evolución de las capas for arquitecturas or(n) de vanguardia.
 """
+from __future__ import annotations  # Enable string annotations for type hints
 
 import os
 import sys
@@ -26,15 +27,33 @@ from abc import ABC, abstractmethod
 script_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.dirname(script_dir)
 if project_root not in sys.path:
-    # Fixed: Using proper imports instead of sys.path manipulation
+    sys.path.insert(0, project_root)
 
-from capibara.jax import jax
-from flax import linen as nn
 from functools import partial
-from capibara.jax import numpy as jnp
+
+# JAX/Flax imports (TPU backend)
+try:
+    from capibara.jax import jax
+    from flax import linen as nn
+    from capibara.jax import numpy as jnp
+    JAX_AVAILABLE = True
+except ImportError:
+    jax = None  # type: ignore
+    nn = None  # type: ignore
+    jnp = None  # type: ignore
+    JAX_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+if not JAX_AVAILABLE:
+    logger.warning("JAX/Flax not available. SSM Hybrid Layers will have limited functionality.")
 
 # Import existing optimized components
-from .base import BaseLayer, LayerConfig
+try:
+    from .base import BaseLayer, LayerConfig
+except ImportError:
+    BaseLayer = object
+    LayerConfig = None
 
 # Placeholder caches for removed modules
 class TpuAttentionCache:

--- a/training/hierarchical_training_strategy.py
+++ b/training/hierarchical_training_strategy.py
@@ -16,10 +16,26 @@ Características:
 """
 
 import os
-import torch
 import logging
-import torch.nn as nn
 from enum import Enum
+
+# Lazy imports for PyTorch (GPU backend)
+torch = None
+nn = None
+
+def _ensure_torch():
+    """Lazy import PyTorch modules."""
+    global torch, nn
+    if torch is None:
+        try:
+            import torch as _torch
+            import torch.nn as _nn
+            torch = _torch
+            nn = _nn
+        except ImportError as e:
+            raise ImportError(
+                "PyTorch not installed. Install with: pip install torch"
+            ) from e
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass, field


### PR DESCRIPTION
- layers/__init__.py: Use try/except Exception for all layer imports with availability flags (SSM_LAYERS_AVAILABLE, etc.)
- layers/ssm_hybrid_layers.py: Add from __future__ import annotations and proper JAX availability checks
- layers/abstract_reasoning/game_theory.py: Guard class definitions with JAX_AVAILABLE check, provide stub when unavailable
- core/cot/enhanced_cot_module.py: Add lazy loading pattern for JAX/Flax
- training/hierarchical_training_strategy.py: Add lazy loading for PyTorch

This allows the codebase to be imported even without JAX/Flax/PyTorch, with functionality gracefully degraded based on available backends.