### PR TITLE
Align metadata with LICENSE file and update README repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Modules for structured reasoning:
 
 ```bash
 # Clone the repository
-git clone https://github.com/anacronic-io/capibaraGPT_v3.git
+git clone https://github.com/anachroni-co/capibaraGPT_v3.git
 cd capibaraGPT_v3
 
 # Create virtual environment
@@ -260,10 +260,10 @@ Copyright (c) 2024-2026 Anacroni S.Coop.Gal. All rights reserved.
 
 ## Contact
 
-- **Repository**: [github.com/anacronic-io/capibaraGPT_v3](https://github.com/anacronic-io/capibaraGPT_v3)
+- **Repository**: [github.com/anachroni-co/capibaraGPT_v3](https://github.com/anachroni-co/capibaraGPT_v3)
 - **Organization**: [Anacroni S.Coop.Gal.](https://www.anachroni.co)
 - **Email**: info@anachroni.co
-- **Issues**: [GitHub Issues](https://github.com/anacronic-io/capibaraGPT_v3/issues)
+- **Issues**: [GitHub Issues](https://github.com/anachroni-co/capibaraGPT_v3/issues)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "capibaragpt"
 dynamic = ["version"]
 description = "CapibaraGPT - Advanced Modular AI System with TPU/GPU Support"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = {file = "LICENSE"}
 requires-python = ">=3.9"
 authors = [
     {name = "CapibaraGPT Team", email = "team@capibaragpt.io"}
@@ -19,7 +19,7 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
### Motivation
- Ensure project metadata and documentation consistently reference the repository license file and the canonical repository URLs to avoid mismatched links and license attribution.

### Description
- Update `pyproject.toml` to use `license = {file = "LICENSE"}` and change the license classifier to `"License :: Other/Proprietary License"`, and update `README.md` to use `https://github.com/anachroni-co/capibaraGPT_v3` for the clone, repository, and issues links.

### Testing
- No automated tests were run because these are metadata and documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697948086a4c8321b0dff7a2f9eb1aa0)