### PR TITLE
fix: Critical bugs for A100 GPU training support

### DIFF
--- a/core/backends/gpu_backend.py
+++ b/core/backends/gpu_backend.py
@@ -291,11 +291,22 @@ class GPUBackend(ComputeBackend):
         self,
         parameters: Sequence[TensorLike],
         max_norm: float,
+        optimizer: Optional[Any] = None,
     ) -> TensorLike:
-        """Clip gradients with AMP support."""
+        """Clip gradients with AMP support.
+
+        Args:
+            parameters: Model parameters to clip gradients for
+            max_norm: Maximum gradient norm
+            optimizer: Optimizer for AMP unscaling (required when using GradScaler)
+
+        Note:
+            When using mixed precision training with GradScaler, pass the
+            optimizer to properly unscale gradients before clipping.
+        """
         _ensure_torch()
-        if self._scaler:
-            self._scaler.unscale_(parameters)
+        if self._scaler and optimizer is not None:
+            self._scaler.unscale_(optimizer)
         return torch.nn.utils.clip_grad_norm_(parameters, max_norm)
 
     # ==================== JIT Compilation ====================

--- a/training/unified_consensus.py
+++ b/training/unified_consensus.py
@@ -1056,10 +1056,11 @@ async def run_integrated_training_example():
     # show resultados finales
     logger.info("🎉 Entrenamiento integrado completado!")
     logger.info(f"📊 Análisis final: {results['final_analysis']['summary']}")
-    logger.info(f"🎯 Evaluación promedio: {np.mean([
+    avg_eval = np.mean([
         np.mean([model['average_score'] for model in phase.values()])
         for phase in evaluation_results.values()
-    ]):.3f}")
+    ])
+    logger.info(f"🎯 Evaluación promedio: {avg_eval:.3f}")
     logger.info(f"📈 Dataset combinado: {len(combined_dataset['input_ids']):,} samples")
     
     return results, evaluation_results, combined_dataset

--- a/training/unified_trainer.py
+++ b/training/unified_trainer.py
@@ -9,13 +9,20 @@ Merges: trainer.py + train_unified.py + train_TPU.py + parts of train_300M_scale
 """
 
 import os
+import time
+import logging
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
 import optax
 import wandb
-import asyncio
-import numpy as np
-from pathlib import Path
 from flax.training import train_state
-from typing import Dict, Any, Optional, Tuple, Union, Listuple, Union, Listuple, Union, Listuple, Union, List
+
+from capibara.jax import jax
+from capibara.jax import numpy as jnp
 
 # Import optimized modules
 from .training_config import ModelScale, TrainingConfigFactory, get_config_for_scale


### PR DESCRIPTION
- Fix GradScaler.unscale_() bug in gpu_backend.py - was passing parameters instead of optimizer, added optional optimizer parameter to clip_grad_norm
- Fix corrupted imports in unified_trainer.py - replaced "Listuple" with proper List, Tuple imports, added missing time/logging/dataclass imports
- Fix f-string syntax error in unified_consensus.py - multi-line expression was causing unterminated string literal error in Python < 3.12