### PR TITLE
Add quick-start examples to README files; robustness fixes for quality filter and test gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ capibaraGPT_v3/
 ├── training/                # Training loops and utilities
 ├── inference/               # Inference pipelines
 ├── tests/                   # Unit and integration tests
-└── configs/                 # Model and training configurations
+└── config/                  # Model and training configurations
 ```
 
 ### Key Components
@@ -87,7 +87,7 @@ Modules for structured reasoning:
 
 ```bash
 # Clone the repository
-git clone https://github.com/anacronic-io/capibaraGPT_v3.git
+git clone https://github.com/anachroni-co/capibaraGPT_v3.git
 cd capibaraGPT_v3
 
 # Create virtual environment
@@ -260,10 +260,10 @@ Copyright (c) 2024-2026 Anacroni S.Coop.Gal. All rights reserved.
 
 ## Contact
 
-- **Repository**: [github.com/anacronic-io/capibaraGPT_v3](https://github.com/anacronic-io/capibaraGPT_v3)
+- **Repository**: [github.com/anachroni-co/capibaraGPT_v3](https://github.com/anachroni-co/capibaraGPT_v3)
 - **Organization**: [Anacroni S.Coop.Gal.](https://www.anachroni.co)
 - **Email**: info@anachroni.co
-- **Issues**: [GitHub Issues](https://github.com/anacronic-io/capibaraGPT_v3/issues)
+- **Issues**: [GitHub Issues](https://github.com/anachroni-co/capibaraGPT_v3/issues)
 
 ---
 
@@ -274,3 +274,15 @@ Copyright (c) 2024-2026 Anacroni S.Coop.Gal. All rights reserved.
 *Free for science, education, and research. Commercial use requires license.*
 
 </div>
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) de uso básico del backend:
+
+```python
+from core.backends import get_backend
+
+backend = get_backend()
+x = backend.randn((2, 4))
+print(backend.gelu(x))
+```

--- a/agents/README.md
+++ b/agents/README.md
@@ -362,3 +362,11 @@ This project is licensed under the MIT License - see the [LICENSE.md](../../LICE
 **CapibaraGPT v3.3 - Advanced Multi-Agent System**
 
 *Ultra Agent Orchestrator • 8 Agent Types • Multi-Step Reasoning • Strategic Planning • Premium Dataset Integration*
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-comando) para inspeccionar el orquestador de agentes:
+
+```bash
+python agents/ultra_agent_orchestrator.py --help
+```

--- a/capibara/README.md
+++ b/capibara/README.md
@@ -135,3 +135,14 @@ quantized, indices = vq_opt.optimize_vq_forward(x, codebook)
 ## License
 
 MIT License - See main repository for details.
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) de uso del paquete principal:
+
+```python
+from capibara.cli import main
+
+# Simula el arranque del CLI principal
+main()
+```

--- a/config/README.md
+++ b/config/README.md
@@ -219,3 +219,14 @@ valid_paths = check_data_paths(config.training)
 ## 📖 Configuration Examples
 
 See the `configs_toml/` directory for complete configuration examples in TOML format.
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para cargar una configuración TOML:
+
+```python
+import toml
+
+config = toml.load("config/configs_toml/default.toml")
+print(config["model"]["hidden_size"])
+```

--- a/core/README.md
+++ b/core/README.md
@@ -585,3 +585,17 @@ if not ULTRA_CORE_AVAILABLE:
 
 **Last updated**: 2025-11-16
 **System version**: v2.0.0
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para usar el backend y una atención básica:
+
+```python
+from core.backends import get_backend
+
+backend = get_backend()
+q = backend.randn((2, 8, 128, 64))
+k = backend.randn((2, 8, 128, 64))
+v = backend.randn((2, 8, 128, 64))
+output = backend.scaled_dot_product_attention(q, k, v)
+```

--- a/data/README.md
+++ b/data/README.md
@@ -676,3 +676,13 @@ print(f"Available datasets: {available}")
 
 **Last updated**: 2025-11-16
 **System version**: v2.0.0
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-flujo) para preparar datos:
+
+```text
+1) Coloca archivos .jsonl en data/raw/
+2) Referencia esos archivos en tu config de entrenamiento
+3) Ejecuta el pipeline de preprocesamiento
+```

--- a/inference/README.md
+++ b/inference/README.md
@@ -685,3 +685,11 @@ config.use_gradient_checkpointing = True
 
 **Last updated**: 2025-11-16
 **System version**: v2.0.0
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-comando) para ejecutar inferencia:
+
+```bash
+capibara-inference --config config/configs_toml/inference.toml
+```

--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -411,3 +411,15 @@ class IProcessor(ABC):
 - [Sub-Models](../sub_models/README.md)
 - [Core Backends](../core/backends/README.md)
 - [Utils Cache](../utils/README.md#cache-manager)
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para implementar una interfaz:
+
+```python
+from interfaces.base import BaseInterface
+
+class MiInterface(BaseInterface):
+    def run(self, payload):
+        return {"result": payload}
+```

--- a/jax/README.md
+++ b/jax/README.md
@@ -586,3 +586,14 @@ tpu_optimization.verify_optimizations()  # Verify they are active
 **Last updated**: 2025-11-16
 **System version**: v2.0.0
 **JAX Version**: 0.4.20+
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para seleccionar backend JAX/TPU:
+
+```python
+from core.backends import get_backend, BackendType
+
+backend = get_backend(BackendType.TPU)
+print(backend.name)
+```

--- a/layers/README.md
+++ b/layers/README.md
@@ -1189,3 +1189,12 @@ Part of the capibaraGPT-v2 project. See [LICENSE](../../LICENSE) for details.
 
 **Maintained by**: Capibara ML Team
 **Last Updated**: 2025-11-16
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) de uso de una capa:
+
+```python
+# layer = SomeLayer(config)
+# output = layer(inputs)
+```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -429,3 +429,11 @@ mcp:
 - [Core Backends](../core/backends/README.md)
 - [Inference Module](../inference/README.md)
 - [Training Module](../training/README.md)
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-comando) para iniciar un servicio MCP:
+
+```bash
+python -m mcp.server --config config/configs_toml/mcp.toml
+```

--- a/modules/README.md
+++ b/modules/README.md
@@ -365,3 +365,12 @@ modules:
 - [Core Module](../core/README.md)
 - [MoE System](../core/moe/README.md)
 - [Chain-of-Thought](../core/cot/README.md)
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para activar un módulo:
+
+```python
+# module = SomeModule(config)
+# result = module.run(payload)
+```

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -977,3 +977,13 @@ Part of the capibaraGPT-v2 project. See [LICENSE](../../LICENSE) for details.
 
 **Maintained by**: Capibara ML Team
 **Last Updated**: 2025-11-16
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-flujo) de un pipeline:
+
+```text
+1) Preparar entrada
+2) Ejecutar pipeline multimodal/RAG
+3) Obtener respuesta estructurada
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "capibaragpt"
 dynamic = ["version"]
 description = "CapibaraGPT - Advanced Modular AI System with TPU/GPU Support"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = {file = "LICENSE"}
 requires-python = ">=3.9"
 authors = [
     {name = "CapibaraGPT Team", email = "team@capibaragpt.io"}
@@ -19,7 +19,7 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -140,6 +140,7 @@ addopts = [
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "benchmark: performance benchmarks (requires pytest-benchmark)",
     "tpu: marks tests that require TPU",
     "gpu: marks tests that require GPU",
     "integration: marks integration tests",

--- a/safety/README.md
+++ b/safety/README.md
@@ -482,3 +482,13 @@ MINIMAL_CONFIG = {
 - [Content Filtering Documentation](./content_filter.py)
 - [Intervention System Details](./intervention_system.py)
 - [Mental Health Resources](https://988lifeline.org/)
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) de validación de seguridad:
+
+```python
+# result = safety_pipeline.evaluate(text)
+# if result.blocked:
+#     handle_block()
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -317,3 +317,11 @@ CAPIBARA_LOG_LEVEL=DEBUG python scripts/train_synthetic.py
 - [Training Module](../training/README.md)
 - [Tests](../tests/README.md)
 - [Configuration](../config/README.md)
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-comando) para ejecutar un script utilitario:
+
+```bash
+python scripts/inspect_model.py --config config/configs_toml/model.toml
+```

--- a/services/README.md
+++ b/services/README.md
@@ -1059,3 +1059,11 @@ Part of the capibaraGPT-v2 project. See [LICENSE](../../LICENSE) for details.
 
 **Maintained by**: Capibara ML Team
 **Last Updated**: 2025-11-16
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-comando) para levantar un servicio:
+
+```bash
+python services/api_server.py --config config/configs_toml/service.toml
+```

--- a/sub_models/README.md
+++ b/sub_models/README.md
@@ -621,3 +621,12 @@ config = ModularConfig(
 
 **Last updated**: 2025-11-16
 **System version**: v2.0.0
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para cargar un sub-modelo:
+
+```python
+# sub_model = load_sub_model("mamba")
+# output = sub_model.forward(tokens)
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -519,3 +519,11 @@ pytest tests/benchmarks/ --benchmark-disable-gc
 - [pytest documentation](https://docs.pytest.org/)
 - [pytest-benchmark](https://pytest-benchmark.readthedocs.io/)
 - [Core Backends README](../core/backends/README.md)
+
+## Ejemplo rápido
+
+Ejemplo para ejecutar la suite completa:
+
+```bash
+pytest -v
+```

--- a/tests/benchmarks/test_attention_benchmark.py
+++ b/tests/benchmarks/test_attention_benchmark.py
@@ -11,6 +11,17 @@ import pytest
 import numpy as np
 from typing import Tuple
 
+try:
+    import pytest_benchmark  # noqa: F401
+    BENCHMARK_AVAILABLE = True
+except ImportError:
+    BENCHMARK_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not BENCHMARK_AVAILABLE,
+    reason="pytest-benchmark not installed",
+)
+
 
 class TestAttentionBenchmarks:
     """Benchmark attention implementations."""

--- a/tests/unit/test_quality_filter.py
+++ b/tests/unit/test_quality_filter.py
@@ -1,0 +1,65 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_quality_filter_module():
+    module_path = Path(__file__).resolve().parents[2] / "training" / "data_preprocessing" / "quality_filter.py"
+    spec = importlib.util.spec_from_file_location("quality_filter", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyClassifier:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def __call__(self, text):
+        return self.responses(text)
+
+
+def test_toxicity_filter_handles_case_insensitive_labels():
+    quality_filter = load_quality_filter_module()
+    config = quality_filter.QualityConfig(use_toxicity_filter=False, toxicity_threshold=0.5)
+    advanced_filter = quality_filter.AdvancedFilter(config)
+    advanced_filter.config.use_toxicity_filter = True
+    advanced_filter.toxicity_classifier = DummyClassifier(
+        lambda text: [{"label": "toxic", "score": 0.9}] if "bad" in text else [{"label": "safe", "score": 0.1}]
+    )
+
+    docs = [{"text": "bad text"}, {"text": "ok text"}]
+    filtered = advanced_filter.filter_by_toxicity(docs)
+
+    assert len(filtered) == 1
+    assert filtered[0]["text"] == "ok text"
+
+
+def test_toxicity_filter_ignores_non_toxic_labels():
+    quality_filter = load_quality_filter_module()
+    config = quality_filter.QualityConfig(use_toxicity_filter=False, toxicity_threshold=0.5)
+    advanced_filter = quality_filter.AdvancedFilter(config)
+    advanced_filter.config.use_toxicity_filter = True
+    advanced_filter.toxicity_classifier = DummyClassifier(
+        lambda text: [{"label": "non-toxic", "score": 0.99}]
+    )
+
+    docs = [{"text": "safe text"}]
+    filtered = advanced_filter.filter_by_toxicity(docs)
+
+    assert len(filtered) == 1
+    assert filtered[0]["text"] == "safe text"
+
+
+def test_toxicity_filter_accepts_dict_payload():
+    quality_filter = load_quality_filter_module()
+    config = quality_filter.QualityConfig(use_toxicity_filter=False, toxicity_threshold=0.5)
+    advanced_filter = quality_filter.AdvancedFilter(config)
+    advanced_filter.config.use_toxicity_filter = True
+    advanced_filter.toxicity_classifier = DummyClassifier(
+        lambda text: {"label": "TOXIC", "score": 0.9}
+    )
+
+    docs = [{"text": "bad text"}]
+    filtered = advanced_filter.filter_by_toxicity(docs)
+
+    assert filtered == []

--- a/training/README.md
+++ b/training/README.md
@@ -639,3 +639,11 @@ For training issues:
 
 **Last updated**: 2025-11-16
 **System version**: v2.0.0
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-comando) para entrenar:
+
+```bash
+capibara-train --config config/configs_toml/training.toml
+```

--- a/training/data_preprocessing/quality_filter.py
+++ b/training/data_preprocessing/quality_filter.py
@@ -348,7 +348,13 @@ class AdvancedFilter:
         """Initialize advanced filtering models."""
         
         # Initialize perplexity model
-        if self.config.use_perplexity_filter and TRANSFORMERS_AVAILABLE:
+        if self.config.use_perplexity_filter:
+            if not TRANSFORMERS_AVAILABLE:
+                logger.warning("Perplexity filtering requested but transformers not available")
+                return
+            if not self.config.perplexity_model:
+                logger.warning("Perplexity filtering requested but no model configured")
+                return
             try:
                 # TODO: Initialize perplexity model (GPT-2 or similar for scoring)
                 logger.info("Perplexity filtering would be initialized here")
@@ -377,6 +383,17 @@ class AdvancedFilter:
         logger.info("Perplexity filtering would be applied here")
         return docs
     
+    def _is_toxic_prediction(self, prediction: Dict[str, Any]) -> bool:
+        label = str(prediction.get('label', '')).strip().lower()
+        score = float(prediction.get('score', 0.0))
+        normalized_label = label.replace(" ", "").replace("_", "-")
+
+        if "non-toxic" in normalized_label or "nontoxic" in normalized_label:
+            return False
+        if "toxic" in normalized_label:
+            return score > self.config.toxicity_threshold
+        return False
+
     def filter_by_toxicity(self, docs: List[Dict]) -> List[Dict]:
         """Filter documents by toxicity score."""
         if not self.config.use_toxicity_filter or not self.toxicity_classifier:
@@ -388,12 +405,10 @@ class AdvancedFilter:
             try:
                 text = doc.get('text_norm', doc.get('text', ''))[:512]  # Limit length
                 result = self.toxicity_classifier(text)
+                if isinstance(result, dict):
+                    result = [result]
                 
-                # Assuming the model returns toxicity score
-                is_toxic = any(
-                    pred['label'] == 'TOXIC' and pred['score'] > self.config.toxicity_threshold
-                    for pred in result
-                )
+                is_toxic = any(self._is_toxic_prediction(pred) for pred in result)
                 
                 if not is_toxic:
                     filtered_docs.append(doc)

--- a/utils/README.md
+++ b/utils/README.md
@@ -686,3 +686,13 @@ class Trainer:
 - [Core Module](../core/README.md)
 - [Configuration](../config/README.md)
 - [Training Module](../training/README.md)
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para usar utilidades:
+
+```python
+# from utils.logging_utils import setup_logging
+# logger = setup_logging()
+# logger.info("utils listo")
+```

--- a/vq/README.md
+++ b/vq/README.md
@@ -920,3 +920,13 @@ Part of the capibaraGPT-v2 project. See [LICENSE](../../LICENSE) for details.
 **Last Updated**: 2025-11-16
 **Version**: 2024.1.0
 **Status**: Production-Ready Ultra
+
+## Ejemplo rápido
+
+Ejemplo (pseudo-código) para vector quantization:
+
+```python
+# vq = VectorQuantizer(config)
+# codes = vq.encode(inputs)
+# reconstructed = vq.decode(codes)
+```


### PR DESCRIPTION
### Motivation

- Provide short, consistent "Ejemplo rápido" sections across the repository READMEs so users have runnable/pseudo examples of how to use each component.  
- Prevent benchmark failures on systems without `pytest-benchmark` and make benchmark use explicit in configuration.  
- Make the quality/filtering pipeline more robust to varying toxicity classifier outputs and missing optional dependencies.

### Description

- Added concise `Ejemplo rápido` (quick-start) sections to many module `README.md` files (core, agents, capibara, config, data, inference, interfaces, jax, layers, mcp, modules, pipeline, services, sub_models, tests, training, utils, vq, scripts, etc.), providing short pseudo-commands/snippets for each component.  
- Updated `pyproject.toml` to use a `license` file, normalized dev extras formatting, adjusted classifiers/URLs, and registered a `benchmark` pytest marker in `tool.pytest.ini_options`.  
- Changed `tests/benchmarks/test_attention_benchmark.py` to detect `pytest-benchmark` safely (try/except import) and apply `pytest.mark.skipif` to skip the module when the plugin is unavailable.  
- Added `tests/unit/test_quality_filter.py` and made robustness fixes to `training/data_preprocessing/quality_filter.py`, including safer perplexity initialization checks and a `_is_toxic_prediction` helper that normalizes label formats, accepts dict payloads, and compares scores against `toxicity_threshold`.

### Testing

- No automated test suite was executed as part of this rollout.  
- New unit tests were added at `tests/unit/test_quality_filter.py` but were not run in CI during this change.  
- Benchmark gating was implemented so benchmark tests will be skipped if `pytest-benchmark` is not installed (this avoids failures when the plugin is absent).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697948086a4c8321b0dff7a2f9eb1aa0)