### PR TITLE
Add JSON-LD normalization and TOON serialization utilities; optional TOON output in RAG pipeline

### DIFF
--- a/core/pipelines/rag_pipeline.py
+++ b/core/pipelines/rag_pipeline.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from capibara.utils.logging import get_logger
+from capibara.utils.jsonld_toon import JsonLdConfig, build_rag_jsonld_context, jsonld_to_toon
 
 from capibara.prompts import format_markdown_response
 
@@ -28,9 +29,17 @@ class RAGIntegrator:
     Optionally can have `generate_context(query, max_tokens)`.
     """
 
-    def __init__(self, rag_system: Any, context_template: str = "Context: {context}\n\nQuestion: {query}\n\nAnswer:"):
+    def __init__(
+        self,
+        rag_system: Any,
+        context_template: str = "Context: {context}\n\nQuestion: {query}\n\nAnswer:",
+        use_toon: bool = False,
+        jsonld_context: Optional[Dict[str, Any]] = None,
+    ):
         self.rag_system = rag_system
         self.context_template = context_template
+        self.use_toon = use_toon
+        self.jsonld_context = jsonld_context or {}
 
     def prepare_prompt(self, query: str, k: int = 3, max_tokens: Optional[int] = None) -> Dict[str, Any]:
         """Prepare a prompt with RAG-retrieved context."""
@@ -50,6 +59,11 @@ class RAGIntegrator:
                 context_text = "\n\n".join(doc.get("text", "") for doc in docs)
         else:
             context_text = "\n\n".join(doc.get("text", "") for doc in docs)
+
+        if self.use_toon:
+            jsonld_config = JsonLdConfig(base_context=self.jsonld_context)
+            jsonld_payload = build_rag_jsonld_context(query, context_text, docs, jsonld_config)
+            context_text = jsonld_to_toon(jsonld_payload)
 
         prompt = self.context_template.format(context=context_text, query=query)
         return {

--- a/docs/jsonld_toon/README.md
+++ b/docs/jsonld_toon/README.md
@@ -1,0 +1,34 @@
+# JSON-LD + TOON en capibaraGPT_v3
+
+## Objetivo
+
+Establecer JSON-LD como formato canónico para datos persistentes/estructurados y TOON como vista compacta para consumo por LLMs. Esto permite trazabilidad semántica (JSON-LD) y eficiencia de tokens (TOON) sin perder información.
+
+## Características clave
+
+- **JSON-LD como fuente de verdad**
+  - Usa `@context`, `@id`, `@type` para entidades y relaciones.
+  - Apto para auditoría, versionado y razonamiento por grafo.
+- **TOON como vista para modelos**
+  - Representación determinista, compacta y lossless.
+  - Reduce tokens y mejora el parsing al exponer estructuras con indentación.
+- **Separación de capas**
+  - Persistencia y RAG interno mantienen JSON-LD.
+  - Entrada a modelos usa TOON derivado.
+
+## Flujo recomendado (alto nivel)
+
+1. **Ingesta** → Normalización JSON-LD (`@id`, `@type`, `@context`).
+2. **RAG interno** → Fusión, filtrado y selección sobre JSON-LD.
+3. **Encoder** → JSON-LD → TOON antes del prompt.
+
+## Implementación inicial
+
+Se añadió un módulo utilitario para:
+- Normalizar documentos/chunks a JSON-LD.
+- Construir un contexto JSON-LD para RAG.
+- Serializar JSON-LD a TOON siguiendo reglas deterministas.
+
+Revisar:
+- `utils/jsonld_toon.py`
+- `core/pipelines/rag_pipeline.py` (opción `use_toon`)

--- a/docs/jsonld_toon/organization/README.md
+++ b/docs/jsonld_toon/organization/README.md
@@ -1,0 +1,33 @@
+# Organización y ahorro esperado (JSON-LD + TOON)
+
+## Organización de datos
+
+- **Documento JSON-LD (canónico)**
+  - Campos mínimos: `@context`, `@id`, `@type`.
+  - Propiedades del documento (`text`, `metadata`, `timestamp`).
+  - Chunks como entidades separadas con relación `parent`.
+- **Contexto RAG JSON-LD**
+  - Contiene `query`, `context` y colecciones de `documents` y `chunks`.
+  - IDs estables para trazabilidad entre etapas.
+- **Vista TOON para LLMs**
+  - Serialización determinista con bloques y arrays tabulares.
+  - `@id` y `@type` siempre visibles.
+
+## Ahorro y métricas sugeridas
+
+Para validar ahorro y robustez:
+
+- **Tokens del contexto**
+  - Comparar JSON-LD vs. TOON para el mismo contenido.
+- **Costo de serialización**
+  - Medir tiempo de `JSON-LD → TOON` por tamaño de contexto.
+- **Latencia total**
+  - Medir tiempo end-to-end (recuperación + serialización + inferencia).
+- **Robustez de parsing**
+  - Verificar reconstrucción lossless TOON → JSON-LD.
+
+## Recomendaciones de uso
+
+- Persistencia: almacenar siempre JSON-LD.
+- RAG interno: operar y fusionar JSON-LD.
+- LLM: enviar solo TOON.

--- a/reports/jsonld_toon_assessment.md
+++ b/reports/jsonld_toon_assessment.md
@@ -1,0 +1,108 @@
+# Informe: viabilidad de JSON-LD/"json-dl" + TOON en capibaraGPT_v3
+
+## Resumen ejecutivo
+
+El proyecto ya cuenta con pipelines RAG y mecanismos de preparación de contexto basados en texto plano y metadatos genéricos. En particular, el RAG avanzado almacena documentos y chunks como diccionarios con claves simples (`text`, `metadata`, `chunks`, `timestamp`) y recupera por relevancia sin un esquema semántico explícito. Asimismo, el integrador RAG prepara prompts concatenando texto plano. Esto implica que **hoy no existe un modelo semántico formal ni un formato canónico** para datos persistentes o de contexto, por lo que introducir JSON-LD ("json-dl") como fuente de verdad y TOON como vista para LLMs sería un cambio de arquitectura relevante. 【F:core/pipelines/advanced_rag_pipeline.py†L130-L223】【F:core/pipelines/rag_pipeline.py†L17-L73】
+
+**Conclusión rápida:**
+- **Sí es viable** adoptar JSON-LD como formato canónico y TOON como vista para LLMs, pero **requiere capas nuevas** (normalización, encoder/decoder, contratos de datos y validación). La ganancia en robustez puede ser alta (trazabilidad, auditoría, consistencia), mientras que la mejora en velocidad dependerá de la implementación del encoder y del costo de transformación en tiempo de ejecución. Hoy no hay evidencia de benchmarking en el repositorio para cuantificar esa mejora, por lo que cualquier estimación de rendimiento debe validarse con pruebas específicas. 【F:core/pipelines/advanced_rag_pipeline.py†L130-L223】【F:core/pipelines/rag_pipeline.py†L17-L73】
+
+---
+
+## Estado actual del proyecto (RAG y preparación de contexto)
+
+### RAG avanzado
+- Los documentos se almacenan en un diccionario en memoria (`document_store`) con estructura plana y campos libres (`text`, `metadata`, `chunks`, `timestamp`). No existe un modelo semántico estándar ni campos obligatorios equivalentes a `@id` o `@type`. 【F:core/pipelines/advanced_rag_pipeline.py†L130-L223】
+- La recuperación opera sobre texto y metadatos (no estructurados semánticamente) y el contexto se construye por concatenación de texto. 【F:core/pipelines/advanced_rag_pipeline.py†L190-L223】
+
+### RAG integrator (pipeline mínimo)
+- El `RAGIntegrator` espera `documents` con `text` y `score`, y genera un prompt que concatena texto plano. 【F:core/pipelines/rag_pipeline.py†L17-L73】
+- No existe en el pipeline un modelo estructurado persistente para los documentos ni un punto de serialización formal (p. ej., encoder JSON-LD → TOON). 【F:core/pipelines/rag_pipeline.py†L17-L73】
+
+---
+
+## Encaje con JSON-LD ("json-dl") + TOON
+
+### Encaje conceptual
+Tu especificación propone:
+- **JSON-LD** como fuente de verdad (persistencia, grafos, auditoría, versionado).
+- **TOON** como vista compacta para LLMs, generada por un encoder determinista y lossless.
+
+En el estado actual, el sistema **no tiene**:
+- Un esquema explícito de entidades/relaciones.
+- Un mecanismo de normalización semántica de la información recuperada.
+- Una capa formal de serialización/normalización para entrada de LLMs.
+
+Por tanto, **el encaje es arquitectónicamente coherente**, pero requiere construir una capa semántica encima del pipeline actual. 【F:core/pipelines/advanced_rag_pipeline.py†L130-L223】【F:core/pipelines/rag_pipeline.py†L17-L73】
+
+---
+
+## Impacto esperado
+
+### Robustez y trazabilidad
+**Alta mejora potencial**, porque:
+- JSON-LD fuerza un contrato semántico para entidades y relaciones (IDs estables, tipos, contexto).
+- Permite auditoría y razonamiento por grafo, útil para RAG explicable.
+- Evita ambigüedad en los datos de entrada al modelo (cada entidad anclada a `@id`).
+
+### Velocidad / tokens
+**Ganancia potencial, no garantizada**, porque:
+- TOON reduce tokens en el prompt (mejor densidad de información) → puede acelerar inferencia al reducir longitud del contexto.
+- Pero introduce costo de transformación JSON-LD → TOON en tiempo de ejecución.
+- El impacto real depende del **tamaño del contexto**, el **tiempo de serialización**, y **si el pipeline actual ya está optimizado**.
+
+No hay benchmarks en el repositorio que midan tiempo de serialización o ahorro de tokens, por lo que esto debe validarse con pruebas específicas. 【F:core/pipelines/advanced_rag_pipeline.py†L130-L223】【F:core/pipelines/rag_pipeline.py†L17-L73】
+
+---
+
+## Cambios necesarios para adoptar JSON-LD + TOON
+
+### 1) Contrato de datos y normalización
+- Definir un esquema JSON-LD mínimo para documentos, chunks, episodios y métricas (incluye `@id`, `@type`, `@context`).
+- Mapear los datos actuales (`text`, `metadata`, `chunks`) a entidades explícitas.
+
+### 2) Capa de serialización TOON
+- Implementar un encoder JSON-LD → TOON siguiendo reglas deterministas y lossless.
+- Enviar TOON solo en la etapa de entrada a modelos (no persistirlo).
+
+### 3) RAG interno en JSON-LD
+- Tras la recuperación, normalizar documentos a JSON-LD.
+- Aplicar filtrado y fusión sobre JSON-LD antes de serializar a TOON.
+
+### 4) Validación y trazabilidad
+- Añadir validadores que aseguren que todo objeto persistente tenga `@id`, `@type` y `@context`.
+- Agregar verificaciones de reversibilidad TOON → JSON-LD.
+
+---
+
+## Riesgos y mitigaciones
+
+| Riesgo | Impacto | Mitigación |
+|---|---|---|
+| Incremento de complejidad en el pipeline | Medio/Alto | Implementar por fases: primero JSON-LD en ingestión, luego encoder TOON, luego RAG completo en JSON-LD. |
+| Costo de serialización TOON | Medio | Benchmark dedicado con tamaños de contexto reales; optimizar el encoder y cachear resultados. |
+| Coste de migración de datos existentes | Medio | Introducir un “adapter layer” que traduzca los registros actuales a JSON-LD sin cambiar su origen. |
+
+---
+
+## Recomendación
+
+**Recomendado con cautela** si el objetivo principal es **robustez, trazabilidad y consistencia semántica** del RAG. Esto encaja muy bien con el enfoque actual de pipelines y monitoreo en el proyecto. Sin embargo, **no se puede afirmar mejora de velocidad sin benchmarks**. Se sugiere:
+
+1. Prototipo en un pipeline de RAG mínimo: ingesta → normalización JSON-LD → encoder TOON → prompt.
+   - **Ingesta**: mapear cada documento a JSON-LD con `@id`, `@type` y `@context` (incluyendo `text`, `metadata`, `timestamp`).
+   - **Normalización**: garantizar un JSON-LD único por documento y por chunk (si aplica), con IDs estables y referencias entre entidades.
+   - **Encoder TOON**: convertir el JSON-LD final siguiendo las reglas deterministas (bloques por indentación, arrays tabulares cuando aplique).
+   - **Prompt**: sustituir el contexto concatenado por TOON serializado para el modelo.
+2. Benchmark de tokens y latencia (antes vs. después) midiendo:
+   - Tokens del contexto (JSON-LD vs. TOON).
+   - Tiempo de serialización (JSON-LD → TOON).
+   - Latencia total de inferencia.
+3. Si el ahorro de tokens es significativo y la serialización no introduce overhead alto, avanzar a integración completa.
+
+---
+
+## Apéndice: relación con componentes actuales
+
+- **RAG avanzado:** Base viable para incorporar JSON-LD en `document_store` y en la salida de `retrieve_documents`. 【F:core/pipelines/advanced_rag_pipeline.py†L130-L223】
+- **RAG integrator:** Lugar natural para serializar a TOON antes de generar el prompt. 【F:core/pipelines/rag_pipeline.py†L17-L73】

--- a/utils/jsonld_toon.py
+++ b/utils/jsonld_toon.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha1
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class JsonLdConfig:
+    base_context: Dict[str, Any]
+    document_type: str = "Document"
+    chunk_type: str = "DocumentChunk"
+    rag_context_type: str = "RAGContext"
+    id_namespace: str = "rag"
+
+
+def normalize_document_jsonld(
+    doc: Mapping[str, Any],
+    doc_id: str,
+    config: JsonLdConfig,
+) -> Dict[str, Any]:
+    metadata = dict(doc.get("metadata", {}) or {})
+    content = {
+        "@id": doc_id,
+        "@type": config.document_type,
+        "text": doc.get("text", ""),
+        "metadata": metadata,
+    }
+    if "timestamp" in doc:
+        content["timestamp"] = doc["timestamp"]
+    return content
+
+
+def normalize_chunk_jsonld(
+    chunk: Mapping[str, Any],
+    chunk_id: str,
+    parent_id: str,
+    config: JsonLdConfig,
+) -> Dict[str, Any]:
+    metadata = dict(chunk.get("metadata", {}) or {})
+    content = {
+        "@id": chunk_id,
+        "@type": config.chunk_type,
+        "text": chunk.get("text", ""),
+        "metadata": metadata,
+        "parent": {"@id": parent_id},
+    }
+    if "timestamp" in chunk:
+        content["timestamp"] = chunk["timestamp"]
+    return content
+
+
+def build_rag_jsonld_context(
+    query: str,
+    context_text: str,
+    documents: Iterable[Mapping[str, Any]],
+    config: Optional[JsonLdConfig] = None,
+) -> Dict[str, Any]:
+    config = config or JsonLdConfig(base_context={})
+    doc_list: List[Dict[str, Any]] = []
+    chunk_list: List[Dict[str, Any]] = []
+
+    for index, doc in enumerate(documents):
+        doc_id = f"{config.id_namespace}:doc:{index}"
+        doc_jsonld = normalize_document_jsonld(doc, doc_id, config)
+        doc_list.append(doc_jsonld)
+        for chunk_index, chunk in enumerate(doc.get("chunks", []) or []):
+            chunk_id = f"{config.id_namespace}:chunk:{index}:{chunk_index}"
+            chunk_list.append(normalize_chunk_jsonld(chunk, chunk_id, doc_id, config))
+
+    fingerprint = sha1(f"{query}|{len(doc_list)}|{len(chunk_list)}".encode("utf-8")).hexdigest()[:12]
+    return {
+        "@context": config.base_context,
+        "@id": f"{config.id_namespace}:context:{fingerprint}",
+        "@type": config.rag_context_type,
+        "query": query,
+        "context": context_text,
+        "documents": doc_list,
+        "chunks": chunk_list,
+    }
+
+
+def _is_tabular_array(items: List[Any]) -> bool:
+    if not items:
+        return False
+    if not all(isinstance(item, Mapping) for item in items):
+        return False
+    keys = list(items[0].keys())
+    if any(list(item.keys()) != keys for item in items):
+        return False
+    for item in items:
+        if any(isinstance(value, (Mapping, list)) for value in item.values()):
+            return False
+    return True
+
+
+def _sorted_keys(obj: Mapping[str, Any]) -> List[str]:
+    keys = list(obj.keys())
+    pinned = [key for key in ("@id", "@type") if key in keys]
+    remainder = sorted(key for key in keys if key not in pinned)
+    return pinned + remainder
+
+
+def jsonld_to_toon(data: Any, indent: int = 0, field_name: Optional[str] = None) -> str:
+    pad = "  " * indent
+    if isinstance(data, Mapping):
+        lines: List[str] = []
+        if field_name is not None:
+            lines.append(f"{pad}{field_name}:")
+            pad = "  " * (indent + 1)
+        for key in _sorted_keys(data):
+            value = data[key]
+            if isinstance(value, Mapping):
+                lines.append(f"{pad}{key}:")
+                lines.append(jsonld_to_toon(value, indent + 1))
+            elif isinstance(value, list):
+                lines.append(_format_array(key, value, indent))
+            else:
+                lines.append(f"{pad}{key}: {value}")
+        return "\n".join(lines)
+    if isinstance(data, list):
+        return _format_array(field_name or "items", data, indent)
+    return f"{pad}{data}"
+
+
+def _format_array(field_name: str, value: List[Any], indent: int) -> str:
+    pad = "  " * indent
+    if _is_tabular_array(value):
+        fields = list(value[0].keys())
+        header = f"{pad}{field_name}[{len(value)}]{{{','.join(fields)}}}:"
+        rows = [
+            f"{pad}  {','.join(str(item.get(field, '')) for field in fields)}" for item in value
+        ]
+        return "\n".join([header] + rows)
+    inline_items = ", ".join(str(item) for item in value)
+    return f"{pad}{field_name}: [{inline_items}]"


### PR DESCRIPTION
### Motivation
- Introduce JSON-LD as a canonical representation for persisted RAG artifacts and TOON as a compact, deterministic view for LLM consumption to improve traceability and token efficiency.
- Provide a small, testable utility layer to normalize existing flat document/chunk structures into JSON-LD and to serialize those structures into a compact TOON format for prompts.
- Add documentation and an assessment report to describe organization, expected savings, and recommended benchmarking steps before full integration.

### Description
- Add `utils/jsonld_toon.py` implementing `JsonLdConfig`, `normalize_document_jsonld`, `normalize_chunk_jsonld`, `build_rag_jsonld_context`, and `jsonld_to_toon` with deterministic key ordering and tabular-array handling. 
- Extend the RAG integrator in `core/pipelines/rag_pipeline.py` with constructor options `use_toon` and `jsonld_context` and wire `build_rag_jsonld_context` + `jsonld_to_toon` in `prepare_prompt` when `use_toon=True`.
- Add documentation files `docs/jsonld_toon/README.md` and `docs/jsonld_toon/organization/README.md` that describe the approach, data organization, metrics to measure, and usage recommendations.
- Add a detailed assessment `reports/jsonld_toon_assessment.md` that explains integration steps, risks, and a recommended prototyping/benchmark plan.

### Testing
- No automated tests were executed as part of this change.
- Basic repository sanity actions (file creation, import wiring, and a git commit) were performed successfully during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a49ccf28483219e72f72663cfc910)