### PR TITLE
revert: restore capibara/ directory (undo e164e01)

### DIFF
--- a/capibara/README.md
+++ b/capibara/README.md
@@ -1,0 +1,148 @@
+# CapibaraGPT v3 - Core Modules Export
+
+This directory contains the recovered and documented core modules for CapibaraGPT v3.
+All code is documented in English with comprehensive docstrings and type hints.
+
+## Directory Structure
+
+```
+v3_export/
+├── core/
+│   ├── ssm/                    # State Space Models
+│   │   ├── ssm_tpu.py          # Classic SSM optimized for TPU
+│   │   ├── spike_ssm.py        # Bio-inspired Spiking SSM
+│   │   └── __init__.py
+│   │
+│   ├── routers/                # Routing Mechanisms
+│   │   ├── self_modifying_router.py  # Nested Learning Router
+│   │   └── __init__.py
+│   │
+│   ├── optimizations/          # Hardware Optimizations
+│   │   ├── tpu_v6e.py          # TPU v6e-64 specific optimizations
+│   │   └── __init__.py
+│   │
+│   ├── vq/                     # Vector Quantization
+│   │   ├── vq_arm_axion.py     # ARM Axion VQ optimizer
+│   │   └── __init__.py
+│   │
+│   └── __init__.py
+│
+├── layers/                     # Neural Network Layers (future)
+├── training/                   # Training Systems (future)
+├── inference/                  # Inference Engines (future)
+├── utils/                      # Utilities (future)
+└── README.md
+```
+
+## Module Descriptions
+
+### SSM (State Space Models)
+
+- **SSMBlock**: Classic state space model with O(n) complexity
+  - TPU-optimized using `jax.lax.scan`
+  - Stable initialization for state transition matrix
+  - Support for bidirectional processing
+
+- **SpikeSSM**: Bio-inspired spiking neural network SSM
+  - Surrogate gradient learning for spike discontinuities
+  - Leaky integrate-and-fire neuron dynamics
+  - Energy-efficient sparse activations
+
+- **AdaptiveSpikeSSM**: Advanced spiking SSM with:
+  - Adaptive thresholds based on activity
+  - Multiple decay timescales
+  - Lateral inhibition for competition
+
+### Routers
+
+- **SelfModifyingRouter**: Nested Learning router (NeurIPS 2025 inspired)
+  - Two-level optimization:
+    - Level 1: Routing decisions (fast, every step)
+    - Level 2: Meta-routing policy (slow, every 100 steps)
+  - Self-modification of temperature, top-k, exploration rate
+  - Automatic adaptation to changing conditions
+
+### Optimizations
+
+- **TPUv6eOptimizer**: Google Cloud TPU v6e-64 optimizations
+  - Optimized attention with einsum operations
+  - Mamba SSM optimized for TPU scan operations
+  - Mixed precision (bfloat16) support
+  - Distributed training with PMAP
+
+### Vector Quantization
+
+- **ARMAxionOptimizer**: ARM processor optimizations
+  - SVE2 vectorization support (512-bit)
+  - Memory-efficient chunked attention
+  - Efficient VQ codebook lookups
+  - Portable fallback for non-ARM systems
+
+## Installation
+
+Copy these modules to your CapibaraGPT v3 project:
+
+```bash
+# From v2 repository root
+cp -r v3_export/* /path/to/capibaraGPT_v3/capibara/
+```
+
+## Dependencies
+
+```
+jax>=0.4.0
+flax>=0.7.0
+optax>=0.1.5
+torch>=2.0.0  # Optional, for ARM optimizations
+numpy>=1.24.0
+```
+
+## Usage Example
+
+```python
+# SSM usage
+from core.ssm import SSMBlock, SpikeSSM
+
+ssm = SSMBlock(hidden_size=256, state_dim=64)
+spike_ssm = SpikeSSM(hidden_size=256, threshold=0.5)
+
+# Router usage
+from core.routers import create_self_modifying_router
+
+router = create_self_modifying_router()
+routes, metadata = router.route(inputs)
+router.update_with_feedback(routes, performance=0.85, step=100)
+
+# TPU optimization
+from core.optimizations import TPUv6eOptimizer
+
+optimizer = TPUv6eOptimizer()
+attention = optimizer.create_optimized_attention(1024, 16, 2048)
+
+# ARM VQ optimization
+from core.vq import create_arm_axion_optimizer
+
+vq_opt = create_arm_axion_optimizer()
+quantized, indices = vq_opt.optimize_vq_forward(x, codebook)
+```
+
+## References
+
+- Gu, A., Goel, K., & Re, C. (2021). Efficiently Modeling Long Sequences with Structured State Spaces. arXiv:2111.00396
+- Neftci, E. O., Mostafa, H., & Zenke, F. (2019). Surrogate gradient learning in spiking neural networks. IEEE Signal Processing Magazine.
+- Behrouz, A.; Razaviyayn, M.; Mirrokni, V.; Zhong, P. (2025). Nested Learning: The Illusion of Deep Learning Architectures. NeurIPS 2025.
+
+## License
+
+MIT License - See main repository for details.
+
+## Example quick
+
+Example (pseudo-code) de uso del paquete principal:
+
+```python
+from capibara.cli import main
+
+# Simula el arranque del CLI principal
+main()
+```

--- a/capibara/__init__.py
+++ b/capibara/__init__.py
@@ -1,0 +1,58 @@
+"""
+Core Module for CapibaraGPT v3.
+
+This package contains the core components of CapibaraGPT:
+
+Submodules:
+    - ssm: State Space Models (SSM, SpikeSSM, AdaptiveSpikeSSM)
+    - routers: Routing mechanisms (SelfModifyingRouter with Nested Learning)
+    - optimizations: Hardware optimizations (TPU v6e-64)
+    - vq: Vector Quantization (ARM Axion optimizations)
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from . import ssm
+    SSM_AVAILABLE = True
+except Exception as e:
+    ssm = None
+    SSM_AVAILABLE = False
+    logger.debug("capibara.ssm unavailable: %s", e)
+
+try:
+    from . import routers
+    ROUTERS_AVAILABLE = True
+except Exception as e:
+    routers = None
+    ROUTERS_AVAILABLE = False
+    logger.debug("capibara.routers unavailable: %s", e)
+
+try:
+    from . import optimizations
+    OPTIMIZATIONS_AVAILABLE = True
+except Exception as e:
+    optimizations = None
+    OPTIMIZATIONS_AVAILABLE = False
+    logger.debug("capibara.optimizations unavailable: %s", e)
+
+try:
+    from . import vq
+    VQ_AVAILABLE = True
+except Exception as e:
+    vq = None
+    VQ_AVAILABLE = False
+    logger.debug("capibara.vq unavailable: %s", e)
+
+__all__ = [
+    "ssm",
+    "routers",
+    "optimizations",
+    "vq",
+    "SSM_AVAILABLE",
+    "ROUTERS_AVAILABLE",
+    "OPTIMIZATIONS_AVAILABLE",
+    "VQ_AVAILABLE",
+]

--- a/capibara/cli.py
+++ b/capibara/cli.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+CapibaraGPT v3 - Minimal CLI
+
+Provides --info, --health, and --demo entrypoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from main import CapibaraGPT, SystemConfig, run_demo, __version__
+
+logger = logging.getLogger("capibaragpt")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="CapibaraGPT v3 - CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["cpu", "gpu", "tpu", "auto"],
+        default="cpu",
+        help="Compute backend (default: cpu)",
+    )
+    parser.add_argument(
+        "--model",
+        choices=["transformer", "mamba", "hybrid"],
+        default="hybrid",
+        help="Model architecture (default: hybrid)",
+    )
+    parser.add_argument("--health", action="store_true", help="Run health check and exit")
+    parser.add_argument("--demo", action="store_true", help="Run demonstration mode")
+    parser.add_argument("--info", action="store_true", help="Show system information")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    config = SystemConfig(
+        backend=args.backend,
+        model_type=args.model,
+    )
+
+    app = CapibaraGPT(config)
+
+    if not await app.initialize():
+        logger.error("Failed to initialize CapibaraGPT")
+        return 1
+
+    if args.health:
+        health = await app.health_check()
+        logger.info("Health Status: %s", health.overall)
+        for name, status in health.components.items():
+            logger.info("  %s: %s", name, status)
+        return 0 if health.overall in ("healthy", "partial") else 1
+
+    if args.demo:
+        await run_demo(app)
+        return 0
+
+    if args.info:
+        info = app.get_system_info()
+        logger.info("System Information:")
+        for key, value in info.items():
+            logger.info("  %s: %s", key, value)
+        return 0
+
+    logger.info("CapibaraGPT v%s", __version__)
+    logger.info("Backend: %s", app.get_system_info()["backend"])
+    logger.info("Model: %s", config.model_type)
+    logger.info("Ready. Use --help for options.")
+    return 0
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    parser = _build_parser()
+    args = parser.parse_args()
+    sys.exit(asyncio.run(_run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/capibara/core/__init__.py
+++ b/capibara/core/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 core package shim.
+
+This module aliases the top-level `core` package so that both
+`core.*` and `capibara.core.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_core = importlib.import_module("core")
+
+# Expose as capibara.core
+sys.modules[__name__] = _core

--- a/capibara/interfaces/__init__.py
+++ b/capibara/interfaces/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 interfaces package shim.
+
+This module aliases the top-level `interfaces` package so that both
+`interfaces.*` and `capibara.interfaces.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_interfaces = importlib.import_module("interfaces")
+
+# Expose as capibara.interfaces
+sys.modules[__name__] = _interfaces

--- a/capibara/jax/__init__.py
+++ b/capibara/jax/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 JAX package shim.
+
+This module aliases the top-level `jax` package so that both
+`jax.*` and `capibara.jax.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_jax = importlib.import_module("jax")
+
+# Expose as capibara.jax
+sys.modules[__name__] = _jax

--- a/capibara/layers/__init__.py
+++ b/capibara/layers/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 layers package shim.
+
+This module aliases the top-level `layers` package so that both
+`layers.*` and `capibara.layers.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_layers = importlib.import_module("layers")
+
+# Expose as capibara.layers
+sys.modules[__name__] = _layers

--- a/capibara/modules/__init__.py
+++ b/capibara/modules/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 modules package shim.
+
+This module aliases the top-level `modules` package so that both
+`modules.*` and `capibara.modules.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_modules = importlib.import_module("modules")
+
+# Expose as capibara.modules
+sys.modules[__name__] = _modules

--- a/capibara/mvp_api.py
+++ b/capibara/mvp_api.py
@@ -1,0 +1,379 @@
+"""
+MVP production API for CapibaraGPT v3.
+
+Frozen P0 surface:
+- POST /v1/generate
+- GET /health/live
+- GET /health/ready
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+try:
+    from fastapi import FastAPI, HTTPException, Request
+    from fastapi.responses import JSONResponse
+except Exception as exc:  # pragma: no cover
+    raise RuntimeError(
+        "FastAPI is required for MVP API. Install with: pip install fastapi uvicorn"
+    ) from exc
+
+
+def _load_hybrid_inference_symbols():
+    """Load hybrid inference symbols without importing inference.__init__ side effects."""
+    root = Path(__file__).resolve().parents[1]
+    engine_path = root / "inference" / "hybrid_inference_engine.py"
+    spec = importlib.util.spec_from_file_location("capibara_hybrid_engine", engine_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load hybrid inference module from {engine_path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.HybridInferenceEngine, mod.InferenceBackend, mod.InferenceConfig
+
+
+HybridInferenceEngine, InferenceBackend, InferenceConfig = _load_hybrid_inference_symbols()
+
+logger = logging.getLogger("capibara.mvp_api")
+SERVICE_NAME = os.getenv("CAPIBARA_SERVICE_NAME", "capibara-api")
+SERVICE_ENV = os.getenv("CAPIBARA_ENV", "dev")
+SERVICE_VERSION = os.getenv("CAPIBARA_SERVICE_VERSION", "1.0.0")
+
+MAX_PROMPT_CHARS = int(os.getenv("CAPIBARA_MAX_PROMPT_CHARS", "12000"))
+MAX_NEW_TOKENS = int(os.getenv("CAPIBARA_MAX_NEW_TOKENS", "1024"))
+REQUEST_TIMEOUT_S = float(os.getenv("CAPIBARA_REQUEST_TIMEOUT_S", "30"))
+STRICT_RUNTIME = os.getenv("CAPIBARA_STRICT_RUNTIME", "1").strip().lower() not in {
+    "0",
+    "false",
+    "no",
+    "off",
+}
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, max_length=MAX_PROMPT_CHARS)
+    max_new_tokens: int = Field(128, ge=1, le=MAX_NEW_TOKENS)
+    temperature: float = Field(0.7, ge=0.0, le=2.0)
+
+
+class Usage(BaseModel):
+    input_tokens: int
+    output_tokens: int
+
+
+class GenerateResponse(BaseModel):
+    text: str
+    usage: Usage
+    latency_ms: float
+    model_version: str
+    request_id: str
+
+
+class _FakeResult:
+    def __init__(self, text: str, prompt_tokens: int, tokens_generated: int) -> None:
+        self.text = text
+        self.prompt_tokens = prompt_tokens
+        self.tokens_generated = tokens_generated
+
+
+class _FakeInferenceEngine:
+    """Deterministic lightweight engine for containerized smoke tests."""
+
+    async def generate(self, prompt: str, **kwargs):
+        max_tokens = int(kwargs.get("max_tokens", 32))
+        token_count = max(1, min(max_tokens, 32))
+        text = f"fake-response:{prompt[:64]}"
+        return _FakeResult(text=text, prompt_tokens=max(1, len(prompt.split())), tokens_generated=token_count)
+
+
+class MVPService:
+    """Thin service wrapper around HybridInferenceEngine for API use."""
+
+    def __init__(self) -> None:
+        backend = os.getenv("CAPIBARA_BACKEND", "cpu").strip().lower()
+        backend_map = {
+            "cpu": InferenceBackend.CPU,
+            "gpu": InferenceBackend.GPU_CUDA,
+            "tpu": InferenceBackend.TPU_V6E,
+            "auto": InferenceBackend.AUTO,
+        }
+        model_path = os.getenv("CAPIBARA_MODEL_PATH", "").strip()
+        use_fake_backend = os.getenv("CAPIBARA_FAKE_BACKEND", "0").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+        self.model_version = os.getenv("CAPIBARA_MODEL_VERSION", "mvp-v1")
+        if use_fake_backend:
+            self.engine = _FakeInferenceEngine()
+            self._ready = True
+            self._ready_reason = "ready"
+            self.model_version = os.getenv("CAPIBARA_MODEL_VERSION", "mvp-fake-v1")
+            return
+
+        self.engine = HybridInferenceEngine(
+            InferenceConfig(
+                backend=backend_map.get(backend, InferenceBackend.CPU),
+                model_path=model_path,
+            )
+        )
+        self._ready = False
+        self._ready_reason = "model_not_loaded"
+
+        if model_path:
+            self.load_model(model_path)
+
+    def load_model(self, model_path: str) -> None:
+        self.engine.load_model(model_path)
+        self._ready = True
+        self._ready_reason = "ready"
+
+    @property
+    def ready(self) -> bool:
+        return self._ready and self.engine is not None
+
+    @property
+    def ready_reason(self) -> str:
+        return self._ready_reason
+
+
+def _log_event(event: str, **payload: object) -> None:
+    """Emit structured JSON logs for API events."""
+    record = {
+        "event": event,
+        "service": SERVICE_NAME,
+        "env": SERVICE_ENV,
+        "version": SERVICE_VERSION,
+        **payload,
+    }
+    logger.info(json.dumps(record, ensure_ascii=True, sort_keys=True))
+
+
+def create_app(service: Optional[MVPService] = None) -> FastAPI:
+    service = service or MVPService()
+    app = FastAPI(title="CapibaraGPT MVP API", version="1.0.0")
+
+    @app.middleware("http")
+    async def request_id_middleware(request: Request, call_next):
+        incoming = request.headers.get("X-Request-Id", "").strip()
+        incoming_trace = request.headers.get("X-Trace-Id", "").strip()
+        request_id = incoming or str(uuid.uuid4())
+        trace_id = incoming_trace or request_id
+        request.state.request_id = request_id
+        request.state.trace_id = trace_id
+        start = time.time()
+        try:
+            response = await call_next(request)
+        except HTTPException as exc:
+            detail = exc.detail
+            if isinstance(detail, dict):
+                detail.setdefault("request_id", request_id)
+            else:
+                detail = {"error": "http_exception", "message": str(detail), "request_id": request_id}
+            latency_ms = (time.time() - start) * 1000.0
+            _log_event(
+                "request_http_exception",
+                request_id=request_id,
+                trace_id=trace_id,
+                path=request.url.path,
+                method=request.method,
+                status_code=exc.status_code,
+                latency_ms=round(latency_ms, 3),
+            )
+            response = JSONResponse(status_code=exc.status_code, content={"detail": detail})
+            response.headers["X-Request-Id"] = request_id
+            response.headers["X-Trace-Id"] = trace_id
+            return response
+        except Exception as exc:
+            latency_ms = (time.time() - start) * 1000.0
+            _log_event(
+                "request_unhandled_exception",
+                request_id=request_id,
+                trace_id=trace_id,
+                path=request.url.path,
+                method=request.method,
+                latency_ms=round(latency_ms, 3),
+                error=str(exc),
+            )
+            response = JSONResponse(
+                status_code=500,
+                content={
+                    "detail": {
+                        "error": "internal_server_error",
+                        "message": str(exc),
+                        "request_id": request_id,
+                    }
+                },
+            )
+            response.headers["X-Request-Id"] = request_id
+            response.headers["X-Trace-Id"] = trace_id
+            return response
+
+        response.headers["X-Request-Id"] = request_id
+        response.headers["X-Trace-Id"] = trace_id
+        latency_ms = (time.time() - start) * 1000.0
+        _log_event(
+            "request_complete",
+            request_id=request_id,
+            trace_id=trace_id,
+            path=request.url.path,
+            method=request.method,
+            status_code=response.status_code,
+            latency_ms=round(latency_ms, 3),
+        )
+        return response
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(request: Request, exc: HTTPException):
+        request_id = getattr(request.state, "request_id", str(uuid.uuid4()))
+        trace_id = getattr(request.state, "trace_id", request_id)
+        detail = exc.detail
+        if isinstance(detail, dict):
+            detail.setdefault("request_id", request_id)
+        else:
+            detail = {"error": "http_exception", "message": str(detail), "request_id": request_id}
+        response = JSONResponse(status_code=exc.status_code, content={"detail": detail})
+        response.headers["X-Request-Id"] = request_id
+        response.headers["X-Trace-Id"] = trace_id
+        return response
+
+    @app.get("/health/live")
+    async def health_live(request: Request) -> dict:
+        return {
+            "status": "alive",
+            "strict_runtime": STRICT_RUNTIME,
+            "timestamp": int(time.time()),
+            "request_id": request.state.request_id,
+        }
+
+    @app.get("/health/ready")
+    async def health_ready(request: Request) -> dict:
+        if not service.ready:
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "reason": service.ready_reason,
+                    "strict_runtime": STRICT_RUNTIME,
+                    "request_id": request.state.request_id,
+                },
+            )
+        return {
+            "status": "ready",
+            "strict_runtime": STRICT_RUNTIME,
+            "request_id": request.state.request_id,
+        }
+
+    @app.post("/v1/generate", response_model=GenerateResponse)
+    async def generate(req: GenerateRequest, request: Request) -> GenerateResponse:
+        request_id = request.state.request_id
+        trace_id = request.state.trace_id
+
+        if not service.ready:
+            _log_event(
+                "generate_not_ready",
+                request_id=request_id,
+                trace_id=trace_id,
+                reason=service.ready_reason,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": "service_not_ready",
+                    "reason": service.ready_reason,
+                    "request_id": request_id,
+                },
+            )
+
+        start = time.time()
+        try:
+            result = await asyncio.wait_for(
+                service.engine.generate(
+                    req.prompt,
+                    max_tokens=req.max_new_tokens,
+                    temperature=req.temperature,
+                ),
+                timeout=REQUEST_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as exc:
+            latency_ms = (time.time() - start) * 1000.0
+            _log_event(
+                "generate_timeout",
+                request_id=request_id,
+                trace_id=trace_id,
+                latency_ms=round(latency_ms, 3),
+                timeout_s=REQUEST_TIMEOUT_S,
+            )
+            raise HTTPException(
+                status_code=504,
+                detail={
+                    "error": "generation_timeout",
+                    "message": f"Request exceeded timeout of {REQUEST_TIMEOUT_S}s",
+                    "request_id": request_id,
+                },
+            ) from exc
+        except Exception as exc:
+            latency_ms = (time.time() - start) * 1000.0
+            _log_event(
+                "generate_error",
+                request_id=request_id,
+                trace_id=trace_id,
+                latency_ms=round(latency_ms, 3),
+                error=str(exc),
+            )
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": "generation_failed",
+                    "message": str(exc),
+                    "request_id": request_id,
+                },
+            ) from exc
+
+        latency_ms = (time.time() - start) * 1000.0
+        _log_event(
+            "generate_ok",
+            request_id=request_id,
+            trace_id=trace_id,
+            latency_ms=round(latency_ms, 3),
+            input_tokens=result.prompt_tokens,
+            output_tokens=result.tokens_generated,
+            model_version=service.model_version,
+        )
+        return GenerateResponse(
+            text=result.text,
+            usage=Usage(
+                input_tokens=result.prompt_tokens,
+                output_tokens=result.tokens_generated,
+            ),
+            latency_ms=latency_ms,
+            model_version=service.model_version,
+            request_id=request_id,
+        )
+
+    return app
+
+
+app = create_app()
+
+
+def run() -> None:
+    """Run MVP API with uvicorn."""
+    import uvicorn
+
+    host = os.getenv("CAPIBARA_API_HOST", "0.0.0.0")
+    port = int(os.getenv("CAPIBARA_API_PORT", "8000"))
+    uvicorn.run("capibara.mvp_api:app", host=host, port=port, reload=False)
+

--- a/capibara/optimizations/__init__.py
+++ b/capibara/optimizations/__init__.py
@@ -1,0 +1,23 @@
+"""
+Optimizations Module for CapibaraGPT.
+
+This package contains hardware-specific optimizations:
+- TPU v6e-64 optimizations for Google Cloud TPU
+- ARM Axion optimizations for ARM-based processors
+"""
+
+from .tpu_v6e import (
+    TPUv6eConfig,
+    TPUv6eOptimizer,
+    TPUv6eTrainingPipeline,
+    get_tpu_optimizer,
+    initialize_tpu_training,
+)
+
+__all__ = [
+    "TPUv6eConfig",
+    "TPUv6eOptimizer",
+    "TPUv6eTrainingPipeline",
+    "get_tpu_optimizer",
+    "initialize_tpu_training",
+]

--- a/capibara/optimizations/tpu_v6e.py
+++ b/capibara/optimizations/tpu_v6e.py
@@ -1,0 +1,565 @@
+"""
+TPU v6e-64 Optimizations for CapibaraGPT.
+
+This module provides specific optimizations for training and inference on
+Google Cloud TPU v6e-64 pods. It includes optimized attention, Mamba SSM,
+and hybrid model implementations designed for maximum TPU utilization.
+
+Key Features:
+    - Optimized attention using einsum operations
+    - TPU-specific Mamba SSM implementation
+    - Hybrid model combining attention and SSM layers
+    - Distributed training support with PMAP
+    - Mixed precision (bfloat16) computation
+    - Performance benchmarking utilities
+
+Hardware Specifications (TPU v6e-64):
+    - 64 TPU cores
+    - 16GB HBM per core (1024GB total)
+    - Optimized for bfloat16 precision
+    - Support for ring attention and sequence parallelism
+
+Usage:
+    >>> config = TPUv6eConfig()
+    >>> optimizer = TPUv6eOptimizer(config)
+    >>> attention = optimizer.create_optimized_attention(
+    ...     hidden_size=1024, num_heads=16, max_seq_length=2048
+    ... )
+"""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# TPU/JAX imports with graceful fallback
+try:
+    import jax
+    import jax.numpy as jnp
+    from flax import linen as nn
+    from flax.training import train_state
+    import optax
+    TPU_AVAILABLE = True
+except ImportError as e:
+    logger.debug(f"TPU/JAX dependencies not available: {e}")
+    TPU_AVAILABLE = False
+    jax = None
+    jnp = None
+    nn = None
+    optax = None
+
+# Numpy fallback
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+
+@dataclass
+class TPUv6eConfig:
+    """Configuration for TPU v6e-64 optimization.
+
+    Attributes:
+        num_cores: Number of TPU cores (64 for v6e-64).
+        memory_per_core_gb: Memory per core in GB.
+        total_memory_gb: Total HBM memory in GB.
+        precision: Default precision ('bfloat16' recommended for TPU).
+        enable_v4_embedding: Enable v4-style embedding optimization.
+        enable_sliced_attention: Enable sliced attention for memory efficiency.
+        enable_ring_attention: Enable ring attention for sequence parallelism.
+        enable_sequence_parallel: Enable sequence parallelism.
+        gradient_accumulation_steps: Steps to accumulate gradients.
+        micro_batch_size: Batch size per core.
+        global_batch_size: Total batch size across all cores.
+        learning_rate: Base learning rate.
+        weight_decay: AdamW weight decay.
+        warmup_steps: Learning rate warmup steps.
+        max_steps: Maximum training steps.
+    """
+    num_cores: int = 64
+    memory_per_core_gb: int = 16
+    total_memory_gb: int = 1024
+    precision: str = "bfloat16"
+    enable_v4_embedding: bool = True
+    enable_sliced_attention: bool = True
+    enable_ring_attention: bool = True
+    enable_sequence_parallel: bool = True
+    gradient_accumulation_steps: int = 8
+    micro_batch_size: int = 4
+    global_batch_size: int = 2048
+    learning_rate: float = 1e-4
+    weight_decay: float = 0.01
+    warmup_steps: int = 1000
+    max_steps: int = 100000
+
+
+class TPUv6eOptimizer:
+    """
+    Optimizer for TPU v6e-64 specific operations.
+
+    This class provides factory methods for creating TPU-optimized modules
+    and utilities for benchmarking and memory management.
+
+    Attributes:
+        config: TPUv6eConfig instance.
+        device_count: Detected number of TPU cores.
+        optimizer: Optax optimizer for training.
+        scheduler: Learning rate scheduler.
+        performance_metrics: Collected performance metrics.
+
+    Example:
+        >>> optimizer = TPUv6eOptimizer()
+        >>> attention = optimizer.create_optimized_attention(1024, 16, 2048)
+        >>> metrics = optimizer.benchmark_tpu_performance(model, (32, 512))
+    """
+
+    def __init__(self, config: Optional[TPUv6eConfig] = None):
+        """
+        Initialize TPU v6e optimizer.
+
+        Args:
+            config: Optional configuration. Uses defaults if not provided.
+        """
+        self.config = config or TPUv6eConfig()
+        self.device_count = self._detect_tpu_cores()
+        self.performance_metrics = {}
+        self.optimizer = None
+        self.scheduler = None
+
+        if TPU_AVAILABLE:
+            self._setup_jax_config()
+            self._initialize_optimizer()
+
+    def _detect_tpu_cores(self) -> int:
+        """Detect the number of available TPU cores."""
+        if not TPU_AVAILABLE:
+            return 0
+
+        try:
+            device_count = jax.device_count()
+            logger.info(f"Detected {device_count} TPU cores")
+            return device_count
+        except Exception as e:
+            logger.warning(f"Failed to detect TPU cores: {e}")
+            return 0
+
+    def _setup_jax_config(self):
+        """Configure JAX for TPU v6e-64 optimization."""
+        # TPU v6e specific configuration
+        jax.config.update('jax_enable_x64', False)
+        jax.config.update('jax_default_prng_impl', 'rbg')
+
+        logger.info("JAX configured for TPU v6e-64 optimization")
+
+    def _initialize_optimizer(self):
+        """Initialize optimizer and learning rate scheduler."""
+        # AdamW optimizer optimized for TPU
+        self.optimizer = optax.adamw(
+            learning_rate=self.config.learning_rate,
+            weight_decay=self.config.weight_decay,
+            b1=0.9,
+            b2=0.95,
+            eps=1e-8
+        )
+
+        # Cosine decay with warmup
+        self.scheduler = optax.warmup_cosine_decay_schedule(
+            init_value=0.0,
+            peak_value=self.config.learning_rate,
+            warmup_steps=self.config.warmup_steps,
+            decay_steps=self.config.max_steps
+        )
+
+        logger.info("TPU v6e optimizer initialized with AdamW and cosine schedule")
+
+    def create_optimized_attention(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        max_seq_length: int
+    ) -> "nn.Module":
+        """
+        Create attention module optimized for TPU v6e.
+
+        Uses einsum operations for efficient TPU computation and
+        supports bfloat16 precision.
+
+        Args:
+            hidden_size: Model hidden dimension.
+            num_heads: Number of attention heads.
+            max_seq_length: Maximum sequence length.
+
+        Returns:
+            Flax Module for optimized attention.
+
+        Raises:
+            RuntimeError: If JAX/Flax is not available.
+        """
+        if not TPU_AVAILABLE:
+            raise RuntimeError("JAX/Flax not available for TPU optimization")
+
+        class TPUv6eOptimizedAttention(nn.Module):
+            """Attention optimized for TPU v6e-64."""
+            hidden_size: int
+            num_heads: int
+            max_seq_length: int
+
+            def setup(self):
+                self.head_dim = self.hidden_size // self.num_heads
+                self.scale = 1.0 / (self.head_dim ** 0.5)
+
+                self.q_proj = nn.Dense(self.hidden_size, dtype=jnp.bfloat16)
+                self.k_proj = nn.Dense(self.hidden_size, dtype=jnp.bfloat16)
+                self.v_proj = nn.Dense(self.hidden_size, dtype=jnp.bfloat16)
+                self.out_proj = nn.Dense(self.hidden_size, dtype=jnp.bfloat16)
+
+            def __call__(self, x: jnp.ndarray, training: bool = False) -> jnp.ndarray:
+                batch_size, seq_len, _ = x.shape
+
+                # Q, K, V projections
+                q = self.q_proj(x)
+                k = self.k_proj(x)
+                v = self.v_proj(x)
+
+                # Reshape for multi-head attention
+                q = q.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+                k = k.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+                v = v.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
+
+                # Efficient einsum for TPU
+                # b=batch, s=seq_q, t=seq_k, h=heads, d=head_dim
+                scores = jnp.einsum('bshd,bthd->bhst', q, k) * self.scale
+
+                # Causal mask
+                causal_mask = jnp.triu(jnp.ones((seq_len, seq_len)), k=1)
+                scores = scores + causal_mask * -1e9
+
+                # Softmax
+                attn_weights = jax.nn.softmax(scores, axis=-1)
+
+                # Apply attention
+                out = jnp.einsum('bhst,bthd->bshd', attn_weights, v)
+                out = out.reshape(batch_size, seq_len, self.hidden_size)
+
+                return self.out_proj(out)
+
+        return TPUv6eOptimizedAttention(hidden_size, num_heads, max_seq_length)
+
+    def create_optimized_mamba_ssm(
+        self,
+        hidden_size: int,
+        state_size: int = 16
+    ) -> "nn.Module":
+        """
+        Create Mamba SSM module optimized for TPU v6e.
+
+        Implements selective state space model with efficient TPU operations.
+
+        Args:
+            hidden_size: Model hidden dimension.
+            state_size: SSM state dimension.
+
+        Returns:
+            Flax Module for optimized Mamba SSM.
+
+        Raises:
+            RuntimeError: If JAX/Flax is not available.
+        """
+        if not TPU_AVAILABLE:
+            raise RuntimeError("JAX/Flax not available for TPU optimization")
+
+        class TPUv6eOptimizedMambaSSM(nn.Module):
+            """Mamba SSM optimized for TPU v6e-64."""
+            hidden_size: int
+            state_size: int
+
+            def setup(self):
+                # Projections optimized for TPU
+                self.input_proj = nn.Dense(self.hidden_size * 2, dtype=jnp.bfloat16)
+                self.gate_proj = nn.Dense(self.hidden_size, dtype=jnp.bfloat16)
+                self.output_proj = nn.Dense(self.hidden_size, dtype=jnp.bfloat16)
+
+                # SSM parameters
+                self.A = self.param(
+                    'A',
+                    nn.initializers.normal(0.02),
+                    (self.state_size, self.hidden_size)
+                )
+                self.B = self.param(
+                    'B',
+                    nn.initializers.normal(0.02),
+                    (self.hidden_size, self.state_size)
+                )
+                self.C = self.param(
+                    'C',
+                    nn.initializers.normal(0.02),
+                    (self.hidden_size, self.state_size)
+                )
+
+            def __call__(self, x: jnp.ndarray, training: bool = False) -> jnp.ndarray:
+                batch_size, seq_len, _ = x.shape
+
+                # Input projection and gating
+                proj = self.input_proj(x)
+                gate, input_proj = jnp.split(proj, 2, axis=-1)
+                gate = jax.nn.silu(gate)
+
+                # SSM computation with scan
+                def ssm_step(carry, inputs):
+                    h = carry
+                    x_t, B_t, C_t = inputs
+
+                    # State update with exponential discretization
+                    h = jnp.exp(self.A) * h + jnp.einsum('bh,hs->bs', x_t, self.B)
+                    y_t = jnp.einsum('bs,hs->bh', h, self.C)
+
+                    return h, y_t
+
+                # Initialize state
+                h_init = jnp.zeros((batch_size, self.state_size))
+
+                # Prepare inputs for scan
+                B_expanded = jnp.einsum('bsh,hs->bss', input_proj, self.B)
+                C_expanded = jnp.einsum('bsh,hs->bss', input_proj, self.C)
+
+                # Run SSM scan
+                inputs_transposed = jnp.transpose(input_proj, (1, 0, 2))
+                _, y_sequence = jax.lax.scan(
+                    ssm_step,
+                    h_init,
+                    (inputs_transposed, B_expanded, C_expanded)
+                )
+
+                # Apply gate and output projection
+                y_sequence = jnp.transpose(y_sequence, (1, 0, 2))
+                output = gate * y_sequence
+                return self.output_proj(output)
+
+        return TPUv6eOptimizedMambaSSM(hidden_size, state_size)
+
+    def benchmark_tpu_performance(
+        self,
+        model: "nn.Module",
+        input_shape: Tuple[int, int]
+    ) -> Dict[str, float]:
+        """
+        Benchmark model performance on TPU v6e-64.
+
+        Args:
+            model: Flax model to benchmark.
+            input_shape: Tuple of (batch_size, seq_length).
+
+        Returns:
+            Dictionary with performance metrics.
+        """
+        if not TPU_AVAILABLE:
+            return {"error": "TPU not available"}
+
+        batch_size, seq_len = input_shape
+
+        # Create test data
+        rng = jax.random.PRNGKey(42)
+        input_ids = jax.random.randint(rng, (batch_size, seq_len), 0, 1000)
+
+        # Compile model
+        def forward_fn(params, inputs):
+            return model.apply(params, inputs, training=False)
+
+        compiled_fn = jax.jit(forward_fn)
+
+        # Initialize parameters
+        params = model.init(rng, input_ids)
+
+        # Warmup
+        for _ in range(5):
+            _ = compiled_fn(params, input_ids)
+
+        # Benchmark
+        num_iterations = 20
+        start_time = time.time()
+        for _ in range(num_iterations):
+            _ = compiled_fn(params, input_ids)
+        end_time = time.time()
+
+        avg_time_ms = (end_time - start_time) * 1000 / num_iterations
+        tokens_per_second = (batch_size * seq_len) / (avg_time_ms / 1000)
+
+        return {
+            "avg_time_ms": avg_time_ms,
+            "tokens_per_second": tokens_per_second,
+            "batch_size": batch_size,
+            "sequence_length": seq_len,
+            "tpu_cores": self.device_count
+        }
+
+    def get_tpu_memory_usage(self) -> Dict[str, float]:
+        """Get TPU memory usage information."""
+        if not TPU_AVAILABLE:
+            return {"error": "TPU not available"}
+
+        return {
+            "total_memory_gb": self.config.total_memory_gb,
+            "memory_per_core_gb": self.config.memory_per_core_gb,
+            "num_cores": self.device_count,
+            "estimated_utilization": 0.8
+        }
+
+
+class TPUv6eTrainingPipeline:
+    """
+    Training pipeline optimized for TPU v6e-64.
+
+    Provides distributed training setup with PMAP, gradient accumulation,
+    and mixed precision support.
+
+    Attributes:
+        config: TPUv6eConfig instance.
+        optimizer: TPUv6eOptimizer instance.
+        training_metrics: Collected training metrics.
+        pmap_devices: Devices for PMAP parallelism.
+
+    Example:
+        >>> pipeline = TPUv6eTrainingPipeline()
+        >>> pipeline.setup_distributed_training()
+        >>> train_step = pipeline.create_training_step(model)
+    """
+
+    def __init__(self, config: Optional[TPUv6eConfig] = None):
+        """
+        Initialize training pipeline.
+
+        Args:
+            config: Optional configuration.
+        """
+        self.config = config or TPUv6eConfig()
+        self.optimizer = TPUv6eOptimizer(self.config)
+        self.training_metrics = {}
+        self.pmap_devices = None
+
+    def setup_distributed_training(self) -> bool:
+        """
+        Set up distributed training on TPU v6e-64.
+
+        Returns:
+            True if setup successful.
+
+        Raises:
+            RuntimeError: If TPU is not available.
+        """
+        if not TPU_AVAILABLE:
+            raise RuntimeError("TPU not available for distributed training")
+
+        devices = jax.devices()
+        logger.info(f"Setting up distributed training on {len(devices)} TPU cores")
+
+        self.pmap_devices = devices
+        return True
+
+    def create_training_step(self, model: "nn.Module"):
+        """
+        Create optimized training step function.
+
+        Args:
+            model: Flax model to train.
+
+        Returns:
+            JIT-compiled training step function.
+
+        Raises:
+            RuntimeError: If TPU is not available.
+        """
+        if not TPU_AVAILABLE:
+            raise RuntimeError("TPU not available for training")
+
+        def train_step(state, batch):
+            """Optimized training step."""
+            def loss_fn(params):
+                logits = model.apply(params, batch['input_ids'], training=True)
+                loss = optax.softmax_cross_entropy_with_integer_labels(
+                    logits[:, :-1], batch['input_ids'][:, 1:]
+                ).mean()
+                return loss, logits
+
+            grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+            (loss, logits), grads = grad_fn(state.params)
+
+            # Apply gradients
+            updates, new_opt_state = self.optimizer.optimizer.update(
+                grads, state.opt_state, state.params
+            )
+            new_params = optax.apply_updates(state.params, updates)
+
+            return state.replace(
+                params=new_params,
+                opt_state=new_opt_state
+            ), loss
+
+        return jax.jit(train_step)
+
+    def get_training_config(self) -> Dict[str, Any]:
+        """Get training configuration summary."""
+        return {
+            "device_type": "tpu_v6e_64",
+            "num_cores": self.config.num_cores,
+            "global_batch_size": self.config.global_batch_size,
+            "micro_batch_size": self.config.micro_batch_size,
+            "gradient_accumulation_steps": self.config.gradient_accumulation_steps,
+            "precision": self.config.precision,
+            "optimizer": "adamw",
+            "learning_rate": self.config.learning_rate,
+            "weight_decay": self.config.weight_decay,
+            "warmup_steps": self.config.warmup_steps,
+            "max_steps": self.config.max_steps,
+            "enable_mixed_precision": True,
+            "enable_gradient_checkpointing": True
+        }
+
+
+# Global optimizer instance
+_tpu_optimizer: Optional[TPUv6eOptimizer] = None
+
+
+def get_tpu_optimizer(config: Optional[TPUv6eConfig] = None) -> TPUv6eOptimizer:
+    """Get global TPU v6e optimizer instance."""
+    global _tpu_optimizer
+
+    if _tpu_optimizer is None:
+        _tpu_optimizer = TPUv6eOptimizer(config)
+
+    return _tpu_optimizer
+
+
+def initialize_tpu_training(
+    config: Optional[TPUv6eConfig] = None
+) -> TPUv6eTrainingPipeline:
+    """
+    Initialize TPU v6e-64 training pipeline.
+
+    Args:
+        config: Optional configuration.
+
+    Returns:
+        Configured TPUv6eTrainingPipeline.
+    """
+    logger.info("Initializing TPU v6e-64 training pipeline...")
+
+    pipeline = TPUv6eTrainingPipeline(config)
+    pipeline.setup_distributed_training()
+
+    training_config = pipeline.get_training_config()
+    logger.info(f"TPU training configuration: {training_config}")
+
+    return pipeline
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    if TPU_AVAILABLE:
+        optimizer = TPUv6eOptimizer()
+        logger.info(f"TPU cores detected: {optimizer.device_count}")
+        logger.info(f"Memory info: {optimizer.get_tpu_memory_usage()}")
+    else:
+        logger.warning("TPU not available - running in CPU mode")

--- a/capibara/pipeline/__init__.py
+++ b/capibara/pipeline/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 pipeline package shim.
+
+This module aliases the top-level `pipeline` package so that both
+`pipeline.*` and `capibara.pipeline.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_pipeline = importlib.import_module("pipeline")
+
+# Expose as capibara.pipeline
+sys.modules[__name__] = _pipeline

--- a/capibara/routers/__init__.py
+++ b/capibara/routers/__init__.py
@@ -1,0 +1,29 @@
+"""
+Routers Module for CapibaraGPT.
+
+This package contains experimental routing mechanisms for expert selection and
+token routing (e.g., SelfModifyingRouter). The primary router for the project
+is `capibara.core.router.EnhancedRouter`.
+"""
+
+from .self_modifying_router import (
+    SelfModifyingRouter,
+    SelfModifyingRouterConfig,
+    RoutingPolicy,
+    RoutingPolicyConfig,
+    MetaRoutingPolicy,
+    MetaRoutingPolicyConfig,
+    create_self_modifying_router,
+    get_global_self_modifying_router,
+)
+
+__all__ = [
+    "SelfModifyingRouter",
+    "SelfModifyingRouterConfig",
+    "RoutingPolicy",
+    "RoutingPolicyConfig",
+    "MetaRoutingPolicy",
+    "MetaRoutingPolicyConfig",
+    "create_self_modifying_router",
+    "get_global_self_modifying_router",
+]

--- a/capibara/routers/self_modifying_router.py
+++ b/capibara/routers/self_modifying_router.py
@@ -1,0 +1,837 @@
+"""
+Self-Modifying Router for CapibaraGPT.
+
+This module implements a self-modifying router inspired by Nested Learning
+(Behrouz et al., NeurIPS 2025). The router learns not only routing decisions
+but also learns to modify its own routing logic based on observed performance.
+
+Key Features:
+    - Two-level nested optimization (routing policy + meta-routing policy)
+    - Different update frequencies (every step vs every N steps)
+    - Self-modification of routing parameters and strategies
+    - Performance trend analysis
+    - Automatic adaptation to changing conditions
+
+Architecture:
+    Level 1 - Routing Policy (updates every step):
+        - Makes routing decisions for input tokens
+        - Learns from immediate feedback
+        - Maintains route performance statistics
+
+    Level 2 - Meta-Routing Policy (updates every 100 steps):
+        - Analyzes routing trends over time
+        - Modifies Level 1 policy structure and parameters
+        - Optimizes temperature, top-k, exploration rate
+        - Triggers structural changes when needed
+
+This implements the key Nested Learning principle of learning at multiple
+time scales, where the router learns both WHAT to route AND HOW to route.
+
+Reference:
+    Behrouz, A.; Razaviyayn, M.; Mirrokni, V.; Zhong, P. (2025).
+    "Nested Learning: The Illusion of Deep Learning Architectures"
+    NeurIPS 2025
+"""
+
+import logging
+from typing import Dict, List, Optional, Any, Tuple
+from dataclasses import dataclass, field
+from collections import defaultdict, deque
+from datetime import datetime
+import random
+
+try:
+    import numpy as np
+    NUMPY_AVAILABLE = True
+except ImportError:
+    NUMPY_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+# Numpy fallback for environments without numpy
+class NumpyFallback:
+    """Minimal numpy-like operations for systems without numpy."""
+
+    @staticmethod
+    def mean(x):
+        return sum(x) / len(x) if x else 0
+
+    @staticmethod
+    def std(x):
+        if not x:
+            return 0
+        mean = sum(x) / len(x)
+        variance = sum((val - mean) ** 2 for val in x) / len(x)
+        return variance ** 0.5
+
+    @staticmethod
+    def polyfit(x, y, deg):
+        """Simple linear regression for deg=1."""
+        if deg == 1 and len(x) == len(y) and len(x) >= 2:
+            n = len(x)
+            sum_x = sum(x)
+            sum_y = sum(y)
+            sum_xy = sum(x[i] * y[i] for i in range(n))
+            sum_xx = sum(x[i] ** 2 for i in range(n))
+            denom = n * sum_xx - sum_x ** 2
+            if denom == 0:
+                return [0, 0]
+            slope = (n * sum_xy - sum_x * sum_y) / denom
+            intercept = (sum_y - slope * sum_x) / n
+            return [slope, intercept]
+        return [0, 0]
+
+    @staticmethod
+    def clip(x, min_val, max_val):
+        return max(min_val, min(max_val, x))
+
+
+# Use numpy if available, otherwise use fallback
+if not NUMPY_AVAILABLE:
+    np = NumpyFallback()
+
+
+@dataclass
+class RoutingPolicyConfig:
+    """Configuration for a routing policy.
+
+    Attributes:
+        policy_id: Unique identifier for this policy.
+        num_routes: Number of possible routes (e.g., number of experts).
+        hidden_dim: Internal representation size for routing decisions.
+        temperature: Softmax temperature for route selection.
+        top_k: Number of routes to select per input.
+        exploration_rate: Probability of random exploration.
+        learning_rate: Learning rate for weight updates.
+        update_freq: Frequency of policy updates (every N steps).
+        track_performance: Whether to track per-route performance.
+        performance_window: Number of recent samples for performance tracking.
+    """
+    policy_id: str = "default"
+    num_routes: int = 32
+    hidden_dim: int = 256
+    temperature: float = 1.0
+    top_k: int = 4
+    exploration_rate: float = 0.1
+    learning_rate: float = 1e-3
+    update_freq: int = 1
+    track_performance: bool = True
+    performance_window: int = 100
+
+
+@dataclass
+class MetaRoutingPolicyConfig:
+    """Configuration for meta-routing policy.
+
+    Attributes:
+        meta_learning_rate: Learning rate for meta-level updates.
+        meta_update_freq: Frequency of meta updates (every N steps).
+        trend_analysis_window: Window size for trend analysis.
+        performance_comparison_window: Window for performance comparison.
+        poor_performance_threshold: Threshold below which triggers changes.
+        excellent_performance_threshold: Threshold above which stabilizes.
+        enable_temperature_adaptation: Allow temperature modification.
+        enable_top_k_adaptation: Allow top-k modification.
+        enable_exploration_adaptation: Allow exploration rate modification.
+        enable_structural_changes: Allow structural policy changes.
+        temperature_range: Valid range for temperature.
+        top_k_range: Valid range for top-k.
+        exploration_range: Valid range for exploration rate.
+    """
+    meta_learning_rate: float = 1e-4
+    meta_update_freq: int = 100
+    trend_analysis_window: int = 100
+    performance_comparison_window: int = 50
+    poor_performance_threshold: float = 0.5
+    excellent_performance_threshold: float = 0.9
+    enable_temperature_adaptation: bool = True
+    enable_top_k_adaptation: bool = True
+    enable_exploration_adaptation: bool = True
+    enable_structural_changes: bool = True
+    temperature_range: Tuple[float, float] = (0.1, 2.0)
+    top_k_range: Tuple[int, int] = (1, 8)
+    exploration_range: Tuple[float, float] = (0.0, 0.3)
+
+
+class RoutingPolicy:
+    """
+    Level 1: Routing policy that makes routing decisions.
+
+    This component learns to route inputs based on content and feedback.
+    It maintains performance statistics for each route and adjusts
+    routing weights based on observed outcomes.
+
+    Attributes:
+        config: RoutingPolicyConfig instance.
+        route_weights: Current routing weights per route.
+        route_biases: Bias terms per route.
+        route_performance: Performance history per route.
+        route_usage_count: Usage count per route.
+        recent_decisions: Recent routing decisions for analysis.
+    """
+
+    def __init__(self, config: RoutingPolicyConfig):
+        """
+        Initialize routing policy.
+
+        Args:
+            config: Configuration for the routing policy.
+        """
+        self.config = config
+
+        # Initialize routing weights uniformly
+        self.route_weights = [1.0 / config.num_routes] * config.num_routes
+        self.route_biases = [0.0] * config.num_routes
+
+        # Performance tracking
+        self.route_performance = defaultdict(list)
+        self.route_usage_count = defaultdict(int)
+        self.recent_decisions = deque(maxlen=config.performance_window)
+
+        logger.debug(
+            f"RoutingPolicy '{config.policy_id}' initialized with "
+            f"{config.num_routes} routes"
+        )
+
+    def select_routes(
+        self,
+        inputs: Any,
+        context: Optional[Dict[str, Any]] = None
+    ) -> Tuple[List[int], Dict[str, Any]]:
+        """
+        Select routes for the given input.
+
+        Args:
+            inputs: Input data to route.
+            context: Optional context information.
+
+        Returns:
+            Tuple of (selected_route_ids, routing_metadata).
+        """
+        # Calculate routing scores
+        scores = self._calculate_routing_scores(inputs, context)
+
+        # Apply temperature scaling
+        scaled_scores = [s / self.config.temperature for s in scores]
+
+        # Softmax computation
+        max_score = max(scaled_scores)
+        exp_scores = [2.71828 ** (s - max_score) for s in scaled_scores]
+        sum_exp = sum(exp_scores)
+        probabilities = [e / sum_exp for e in exp_scores]
+
+        # Select top-k routes with exploration
+        is_exploring = random.SystemRandom().random() < self.config.exploration_rate
+
+        if is_exploring:
+            # Exploration: random selection
+            selected_routes = random.sample(
+                range(self.config.num_routes),
+                min(self.config.top_k, self.config.num_routes)
+            )
+        else:
+            # Exploitation: top-k selection
+            route_prob_pairs = list(enumerate(probabilities))
+            route_prob_pairs.sort(key=lambda x: x[1], reverse=True)
+            selected_routes = [idx for idx, _ in route_prob_pairs[:self.config.top_k]]
+
+        # Update usage counts
+        for route_id in selected_routes:
+            self.route_usage_count[route_id] += 1
+
+        # Build metadata
+        metadata = {
+            'probabilities': probabilities,
+            'selected_routes': selected_routes,
+            'exploration': is_exploring,
+            'temperature': self.config.temperature,
+            'top_k': self.config.top_k,
+        }
+
+        # Record decision
+        self.recent_decisions.append({
+            'routes': selected_routes,
+            'scores': scores,
+            'timestamp': datetime.now().isoformat()
+        })
+
+        return selected_routes, metadata
+
+    def _calculate_routing_scores(
+        self,
+        inputs: Any,
+        context: Optional[Dict[str, Any]]
+    ) -> List[float]:
+        """Calculate routing scores for each route."""
+        scores = []
+        for i in range(self.config.num_routes):
+            # Base score from weights and biases
+            score = self.route_weights[i] + self.route_biases[i]
+
+            # Adjust based on recent performance
+            if i in self.route_performance and self.route_performance[i]:
+                recent_perf = self.route_performance[i][-10:]
+                avg_perf = sum(recent_perf) / len(recent_perf)
+                score += avg_perf * 0.5  # Performance bonus
+
+            scores.append(score)
+
+        return scores
+
+    def update(
+        self,
+        selected_routes: List[int],
+        performance_feedback: float,
+        step: int
+    ):
+        """
+        Update routing policy based on feedback.
+
+        Args:
+            selected_routes: Routes that were selected.
+            performance_feedback: Performance score in [0, 1].
+            step: Current training step.
+        """
+        if step % self.config.update_freq != 0:
+            return
+
+        # Update performance history
+        for route_id in selected_routes:
+            self.route_performance[route_id].append(performance_feedback)
+
+            # Keep history bounded
+            if len(self.route_performance[route_id]) > self.config.performance_window:
+                self.route_performance[route_id].pop(0)
+
+        # Update weights with simple gradient-like update
+        lr = self.config.learning_rate
+        for route_id in selected_routes:
+            # Positive adjustment for good performance, negative for poor
+            adjustment = lr * (performance_feedback - 0.5)
+            self.route_weights[route_id] += adjustment
+            self.route_weights[route_id] = max(0.01, self.route_weights[route_id])
+
+        # Normalize weights to sum to 1
+        total_weight = sum(self.route_weights)
+        if total_weight > 0:
+            self.route_weights = [w / total_weight for w in self.route_weights]
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """Get routing policy statistics."""
+        avg_performance = {}
+        for route_id, perfs in self.route_performance.items():
+            if perfs:
+                if NUMPY_AVAILABLE:
+                    avg_performance[route_id] = float(np.mean(perfs))
+                else:
+                    avg_performance[route_id] = sum(perfs) / len(perfs)
+
+        return {
+            'policy_id': self.config.policy_id,
+            'num_routes': self.config.num_routes,
+            'temperature': self.config.temperature,
+            'top_k': self.config.top_k,
+            'exploration_rate': self.config.exploration_rate,
+            'total_decisions': len(self.recent_decisions),
+            'route_usage': dict(self.route_usage_count),
+            'avg_route_performance': avg_performance,
+        }
+
+
+class MetaRoutingPolicy:
+    """
+    Level 2: Meta-routing policy that modifies the routing policy.
+
+    This component learns HOW to optimize the routing policy by analyzing
+    long-term trends and making structural changes to the Level 1 policy.
+
+    It operates at a slower timescale (every 100 steps by default) and
+    can modify temperature, top-k, exploration rate, and even trigger
+    structural resets of poorly performing routes.
+
+    Attributes:
+        config: MetaRoutingPolicyConfig instance.
+        meta_performance_history: History of meta-level performance.
+        modification_history: History of all modifications made.
+        current_strategy: Current meta-strategy being employed.
+        last_meta_update_step: Step of last meta update.
+    """
+
+    def __init__(self, config: MetaRoutingPolicyConfig):
+        """
+        Initialize meta-routing policy.
+
+        Args:
+            config: Configuration for the meta-routing policy.
+        """
+        self.config = config
+        self.meta_performance_history = []
+        self.modification_history = []
+        self.current_strategy = 'balanced'
+        self.last_meta_update_step = 0
+
+        logger.info("MetaRoutingPolicy initialized")
+
+    def analyze_routing_trends(
+        self,
+        routing_policy: RoutingPolicy,
+        current_step: int
+    ) -> Dict[str, Any]:
+        """
+        Analyze routing performance trends.
+
+        Args:
+            routing_policy: The routing policy to analyze.
+            current_step: Current training step.
+
+        Returns:
+            Analysis results with trend information.
+        """
+        stats = routing_policy.get_statistics()
+
+        analysis = {
+            'step': current_step,
+            'timestamp': datetime.now().isoformat(),
+            'trends': {},
+            'issues': [],
+            'recommendations': []
+        }
+
+        # Analyze route usage distribution
+        usage_counts = list(stats['route_usage'].values())
+        if usage_counts:
+            if NUMPY_AVAILABLE:
+                usage_variance = float(np.std(usage_counts)) if len(usage_counts) > 1 else 0
+                usage_mean = float(np.mean(usage_counts))
+            else:
+                usage_mean = sum(usage_counts) / len(usage_counts)
+                usage_variance = NumpyFallback.std(usage_counts)
+
+            analysis['trends']['usage_variance'] = usage_variance
+            analysis['trends']['usage_mean'] = usage_mean
+
+            # Check for imbalanced usage
+            if usage_variance > usage_mean * 0.5:
+                analysis['issues'].append('high_usage_imbalance')
+                analysis['recommendations'].append('increase_exploration')
+
+        # Analyze performance trends
+        all_performances = []
+        for route_id, perfs in routing_policy.route_performance.items():
+            if perfs:
+                all_performances.extend(perfs[-self.config.trend_analysis_window:])
+
+        if len(all_performances) >= 10:
+            x = list(range(len(all_performances)))
+            y = all_performances
+
+            try:
+                if NUMPY_AVAILABLE:
+                    trend_coef = float(np.polyfit(x, y, 1)[0])
+                else:
+                    trend_coef = NumpyFallback.polyfit(x, y, 1)[0]
+
+                analysis['trends']['performance_trend'] = trend_coef
+
+                if trend_coef < -0.001:
+                    analysis['issues'].append('declining_performance')
+                    analysis['recommendations'].append('increase_temperature')
+                elif trend_coef > 0.001:
+                    analysis['issues'].append('improving_performance')
+                    analysis['recommendations'].append('continue_current_strategy')
+            except Exception:
+                pass
+
+            # Overall performance level
+            if NUMPY_AVAILABLE:
+                avg_performance = float(np.mean(all_performances))
+            else:
+                avg_performance = sum(all_performances) / len(all_performances)
+
+            analysis['trends']['avg_performance'] = avg_performance
+
+            if avg_performance < self.config.poor_performance_threshold:
+                analysis['issues'].append('poor_overall_performance')
+                analysis['recommendations'].append('major_restructure')
+            elif avg_performance > self.config.excellent_performance_threshold:
+                analysis['issues'].append('excellent_performance')
+                analysis['recommendations'].append('reduce_exploration')
+
+        return analysis
+
+    def suggest_modifications(
+        self,
+        analysis: Dict[str, Any],
+        routing_policy: RoutingPolicy
+    ) -> Dict[str, Any]:
+        """
+        Suggest modifications based on analysis.
+
+        Args:
+            analysis: Analysis results from analyze_routing_trends.
+            routing_policy: Current routing policy.
+
+        Returns:
+            Dictionary of suggested modifications.
+        """
+        modifications = {
+            'temperature': None,
+            'top_k': None,
+            'exploration_rate': None,
+            'structural_changes': [],
+        }
+
+        recommendations = analysis.get('recommendations', [])
+
+        # Temperature adaptation
+        if self.config.enable_temperature_adaptation:
+            if 'increase_temperature' in recommendations:
+                new_temp = min(
+                    routing_policy.config.temperature * 1.2,
+                    self.config.temperature_range[1]
+                )
+                modifications['temperature'] = new_temp
+            elif 'decrease_temperature' in recommendations:
+                new_temp = max(
+                    routing_policy.config.temperature * 0.8,
+                    self.config.temperature_range[0]
+                )
+                modifications['temperature'] = new_temp
+
+        # Top-k adaptation
+        if self.config.enable_top_k_adaptation:
+            if 'increase_diversity' in recommendations:
+                new_k = min(
+                    routing_policy.config.top_k + 1,
+                    self.config.top_k_range[1]
+                )
+                modifications['top_k'] = new_k
+            elif 'decrease_diversity' in recommendations:
+                new_k = max(
+                    routing_policy.config.top_k - 1,
+                    self.config.top_k_range[0]
+                )
+                modifications['top_k'] = new_k
+
+        # Exploration rate adaptation
+        if self.config.enable_exploration_adaptation:
+            if 'increase_exploration' in recommendations:
+                new_rate = min(
+                    routing_policy.config.exploration_rate + 0.05,
+                    self.config.exploration_range[1]
+                )
+                modifications['exploration_rate'] = new_rate
+            elif 'reduce_exploration' in recommendations:
+                new_rate = max(
+                    routing_policy.config.exploration_rate - 0.05,
+                    self.config.exploration_range[0]
+                )
+                modifications['exploration_rate'] = new_rate
+
+        # Structural changes
+        if self.config.enable_structural_changes:
+            if 'major_restructure' in recommendations:
+                modifications['structural_changes'].append('reset_poor_routes')
+
+            if 'high_usage_imbalance' in analysis.get('issues', []):
+                modifications['structural_changes'].append('rebalance_weights')
+
+        return modifications
+
+    def apply_modifications(
+        self,
+        modifications: Dict[str, Any],
+        routing_policy: RoutingPolicy,
+        step: int
+    ):
+        """
+        Apply suggested modifications to the routing policy.
+
+        Args:
+            modifications: Modifications to apply.
+            routing_policy: Routing policy to modify.
+            step: Current step.
+        """
+        applied = []
+
+        # Apply temperature change
+        if modifications['temperature'] is not None:
+            old_temp = routing_policy.config.temperature
+            routing_policy.config.temperature = modifications['temperature']
+            applied.append(f"temperature: {old_temp:.3f} -> {modifications['temperature']:.3f}")
+
+        # Apply top-k change
+        if modifications['top_k'] is not None:
+            old_k = routing_policy.config.top_k
+            routing_policy.config.top_k = modifications['top_k']
+            applied.append(f"top_k: {old_k} -> {modifications['top_k']}")
+
+        # Apply exploration rate change
+        if modifications['exploration_rate'] is not None:
+            old_rate = routing_policy.config.exploration_rate
+            routing_policy.config.exploration_rate = modifications['exploration_rate']
+            applied.append(f"exploration: {old_rate:.3f} -> {modifications['exploration_rate']:.3f}")
+
+        # Apply structural changes
+        for change in modifications['structural_changes']:
+            if change == 'reset_poor_routes':
+                for route_id, perfs in routing_policy.route_performance.items():
+                    if NUMPY_AVAILABLE:
+                        avg_perf = np.mean(perfs) if perfs else 0
+                    else:
+                        avg_perf = sum(perfs) / len(perfs) if perfs else 0
+
+                    if avg_perf < 0.3:
+                        routing_policy.route_weights[route_id] = 1.0 / routing_policy.config.num_routes
+                        routing_policy.route_biases[route_id] = 0.0
+                applied.append("reset_poor_routes")
+
+            elif change == 'rebalance_weights':
+                total = sum(routing_policy.route_weights)
+                if total > 0:
+                    routing_policy.route_weights = [
+                        w / total for w in routing_policy.route_weights
+                    ]
+                applied.append("rebalance_weights")
+
+        # Record modification
+        if applied:
+            self.modification_history.append({
+                'step': step,
+                'modifications': applied,
+                'timestamp': datetime.now().isoformat()
+            })
+            logger.info(f"Step {step}: Applied meta-modifications: {', '.join(applied)}")
+
+
+@dataclass
+class SelfModifyingRouterConfig:
+    """Configuration for self-modifying router.
+
+    Attributes:
+        routing_policy_config: Configuration for Level 1 routing policy.
+        meta_routing_policy_config: Configuration for Level 2 meta policy.
+        enable_self_modification: Whether to enable meta-level modifications.
+        track_detailed_stats: Whether to track detailed statistics.
+    """
+    routing_policy_config: RoutingPolicyConfig = field(
+        default_factory=RoutingPolicyConfig
+    )
+    meta_routing_policy_config: MetaRoutingPolicyConfig = field(
+        default_factory=MetaRoutingPolicyConfig
+    )
+    enable_self_modification: bool = True
+    track_detailed_stats: bool = True
+
+
+class SelfModifyingRouter:
+    """
+    Self-Modifying Router implementing Nested Learning.
+
+    This router learns at two levels:
+    - Level 1: Routing decisions (fast, every step)
+    - Level 2: Routing policy optimization (slow, every N steps)
+
+    The meta-routing policy learns to modify the routing policy's structure
+    and parameters based on observed performance trends.
+
+    Example:
+        >>> config = SelfModifyingRouterConfig()
+        >>> router = SelfModifyingRouter(config)
+        >>> routes, metadata = router.route(input_data)
+        >>> router.update_with_feedback(routes, performance=0.8, step=100)
+
+    Attributes:
+        config: SelfModifyingRouterConfig instance.
+        routing_policy: Level 1 routing policy.
+        meta_routing_policy: Level 2 meta-routing policy.
+        current_step: Current training step.
+        total_routing_decisions: Total number of routing decisions made.
+        meta_updates_performed: Number of meta-level updates performed.
+    """
+
+    def __init__(self, config: Optional[SelfModifyingRouterConfig] = None):
+        """
+        Initialize self-modifying router.
+
+        Args:
+            config: Optional configuration. Uses defaults if not provided.
+        """
+        self.config = config or SelfModifyingRouterConfig()
+
+        # Level 1: Routing policy
+        self.routing_policy = RoutingPolicy(self.config.routing_policy_config)
+
+        # Level 2: Meta-routing policy
+        self.meta_routing_policy = MetaRoutingPolicy(
+            self.config.meta_routing_policy_config
+        )
+
+        # State tracking
+        self.current_step = 0
+        self.total_routing_decisions = 0
+        self.meta_updates_performed = 0
+
+        logger.info("Self-Modifying Router initialized")
+        logger.info(
+            f"  Level 1 (Routing): Updates every "
+            f"{self.config.routing_policy_config.update_freq} steps"
+        )
+        logger.info(
+            f"  Level 2 (Meta-Routing): Updates every "
+            f"{self.config.meta_routing_policy_config.meta_update_freq} steps"
+        )
+
+    def route(
+        self,
+        inputs: Any,
+        context: Optional[Dict[str, Any]] = None
+    ) -> Tuple[List[int], Dict[str, Any]]:
+        """
+        Perform routing decision.
+
+        Args:
+            inputs: Input data to route.
+            context: Optional routing context.
+
+        Returns:
+            Tuple of (selected_routes, routing_info).
+        """
+        self.total_routing_decisions += 1
+
+        # Level 1: Make routing decision
+        selected_routes, metadata = self.routing_policy.select_routes(inputs, context)
+
+        # Add meta-information
+        metadata['step'] = self.current_step
+        metadata['meta_updates_count'] = self.meta_updates_performed
+
+        return selected_routes, metadata
+
+    def update_with_feedback(
+        self,
+        selected_routes: List[int],
+        performance_feedback: float,
+        step: int
+    ):
+        """
+        Update router with performance feedback.
+
+        Args:
+            selected_routes: Routes that were selected.
+            performance_feedback: Performance score in [0, 1].
+            step: Current training step.
+        """
+        self.current_step = step
+
+        # Level 1: Update routing policy
+        self.routing_policy.update(selected_routes, performance_feedback, step)
+
+        # Level 2: Meta-update if it's time
+        if (self.config.enable_self_modification and
+            step % self.config.meta_routing_policy_config.meta_update_freq == 0):
+            self._perform_meta_update(step)
+
+    def _perform_meta_update(self, step: int):
+        """Perform meta-level update (Level 2)."""
+        # Analyze routing trends
+        analysis = self.meta_routing_policy.analyze_routing_trends(
+            self.routing_policy,
+            step
+        )
+
+        # Get modification suggestions
+        modifications = self.meta_routing_policy.suggest_modifications(
+            analysis,
+            self.routing_policy
+        )
+
+        # Apply modifications
+        self.meta_routing_policy.apply_modifications(
+            modifications,
+            self.routing_policy,
+            step
+        )
+
+        self.meta_updates_performed += 1
+        logger.debug(f"Meta-update {self.meta_updates_performed} completed at step {step}")
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """Get comprehensive router statistics."""
+        routing_stats = self.routing_policy.get_statistics()
+
+        return {
+            'current_step': self.current_step,
+            'total_routing_decisions': self.total_routing_decisions,
+            'meta_updates_performed': self.meta_updates_performed,
+            'level1_routing_policy': routing_stats,
+            'level2_meta_policy': {
+                'modification_count': len(self.meta_routing_policy.modification_history),
+                'recent_modifications': self.meta_routing_policy.modification_history[-5:],
+                'current_strategy': self.meta_routing_policy.current_strategy,
+            },
+            'self_modification_enabled': self.config.enable_self_modification,
+        }
+
+    def get_modification_history(self) -> List[Dict[str, Any]]:
+        """Get history of meta-level modifications."""
+        return self.meta_routing_policy.modification_history.copy()
+
+
+def create_self_modifying_router(
+    config: Optional[SelfModifyingRouterConfig] = None
+) -> SelfModifyingRouter:
+    """
+    Factory function to create a self-modifying router.
+
+    Args:
+        config: Optional configuration.
+
+    Returns:
+        SelfModifyingRouter instance.
+    """
+    return SelfModifyingRouter(config)
+
+
+# Global instance management
+_global_router: Optional[SelfModifyingRouter] = None
+
+
+def get_global_self_modifying_router() -> SelfModifyingRouter:
+    """Get the global self-modifying router instance."""
+    global _global_router
+    if _global_router is None:
+        _global_router = create_self_modifying_router()
+    return _global_router
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Self-Modifying Router - Testing Mode")
+
+    router = create_self_modifying_router()
+
+    # Simulate routing with varying performance
+    for step in range(500):
+        inputs = f"input_{step}"
+        selected_routes, metadata = router.route(inputs)
+
+        # Simulate improving performance with noise
+        base_performance = 0.3 + step * 0.001
+        noise = (hash(str(step)) % 20 - 10) / 100
+        performance = max(0, min(1, base_performance + noise))
+
+        router.update_with_feedback(selected_routes, performance, step)
+
+        if step % 100 == 0:
+            stats = router.get_statistics()
+            logger.info(f"\nStep {step}:")
+            logger.info(f"  Routing decisions: {stats['total_routing_decisions']}")
+            logger.info(f"  Meta-updates: {stats['meta_updates_performed']}")
+            logger.info(f"  Temperature: {stats['level1_routing_policy']['temperature']:.3f}")
+
+    final_stats = router.get_statistics()
+    logger.info(f"\nFinal Statistics:")
+    logger.info(f"  Total routing decisions: {final_stats['total_routing_decisions']}")
+    logger.info(f"  Total meta-updates: {final_stats['meta_updates_performed']}")

--- a/capibara/ssm/__init__.py
+++ b/capibara/ssm/__init__.py
@@ -1,0 +1,21 @@
+"""
+SSM (State Space Models) Module for CapibaraGPT.
+
+This package contains various SSM implementations optimized for TPU:
+- SSMBlock: Classic state space model with O(n) complexity
+- SpikeSSM: Bio-inspired spiking variant with surrogate gradients
+- AdaptiveSpikeSSM: Multi-timescale adaptive spiking model
+"""
+
+from .ssm_tpu import SSMBlock, SSMConfig, BidirectionalSSM, create_ssm_block
+from .spike_ssm import SpikeSSM, AdaptiveSpikeSSM, create_spike_ssm
+
+__all__ = [
+    "SSMBlock",
+    "SSMConfig",
+    "BidirectionalSSM",
+    "create_ssm_block",
+    "SpikeSSM",
+    "AdaptiveSpikeSSM",
+    "create_spike_ssm",
+]

--- a/capibara/ssm/spike_ssm.py
+++ b/capibara/ssm/spike_ssm.py
@@ -1,0 +1,336 @@
+"""
+Spiking SSM Module - Bio-inspired State Space Model with surrogate gradients.
+
+This module implements a bio-inspired spiking neural network version of SSM
+that uses surrogate gradients for backpropagation through spike discontinuities.
+The model provides sparsity and energy efficiency benefits similar to biological
+neural networks.
+
+Key Features:
+    - Surrogate gradient learning for spike discontinuities
+    - Leaky integrate-and-fire neuron dynamics
+    - Adaptive thresholds based on recent activity
+    - Multiple decay timescales for rich temporal dynamics
+    - Lateral inhibition for competitive learning
+
+Applications:
+    - Energy-efficient inference on neuromorphic hardware
+    - Sparse activations for reduced computation
+    - Temporal pattern recognition
+
+Reference:
+    Neftci, E. O., Mostafa, H., & Zenke, F. (2019). Surrogate gradient learning
+    in spiking neural networks. IEEE Signal Processing Magazine.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# JIT-compiled spike computation kernels
+# =============================================================================
+
+@jax.jit
+def _surrogate_spike_kernel(
+    membrane_potential: jnp.ndarray,
+    threshold: float,
+    surrogate_scale: float
+) -> jnp.ndarray:
+    """
+    JIT-compiled surrogate gradient spike function.
+
+    Forward pass uses hard threshold (spike or no spike).
+    Backward pass uses smooth sigmoid derivative for gradient flow.
+    """
+    # Forward pass: hard threshold
+    spikes = jnp.where(membrane_potential > threshold, 1.0, 0.0)
+
+    # Surrogate gradient: sigmoid derivative approximation
+    sigmoid_val = jax.nn.sigmoid(surrogate_scale * (membrane_potential - threshold))
+    surrogate_grad = surrogate_scale * sigmoid_val * (1 - sigmoid_val)
+
+    # Straight-through estimator with surrogate gradient
+    return spikes + jax.lax.stop_gradient(spikes - surrogate_grad) + surrogate_grad - jax.lax.stop_gradient(surrogate_grad)
+
+
+class SpikeSSM(nn.Module):
+    """
+    Bio-inspired Spiking State Space Model with surrogate gradient learning.
+
+    This model combines the memory efficiency of SSMs with the sparsity benefits
+    of spiking neural networks. It uses a surrogate gradient approach to handle
+    the non-differentiable spike function during backpropagation.
+
+    Attributes:
+        hidden_size: Size of the input/output hidden dimension.
+        state_dim: Size of the internal state dimension (default: 64).
+        threshold: Spike threshold for neuron activation (default: 0.5).
+        surrogate_scale: Scale factor for surrogate gradient (default: 10.0).
+
+    Note:
+        The surrogate gradient uses a sigmoid derivative approximation,
+        which provides smooth gradients through the hard threshold function.
+        For optimal performance, JIT compile the module at the call site:
+        >>> model = SpikeSSM(hidden_size=256)
+        >>> jit_apply = jax.jit(model.apply)
+    """
+    hidden_size: int
+    state_dim: int = 64
+    threshold: float = 0.5
+    surrogate_scale: float = 10.0
+
+    def _surrogate_spike(self, membrane_potential: jnp.ndarray) -> jnp.ndarray:
+        """
+        Surrogate gradient spike function using JIT-compiled kernel.
+
+        Args:
+            membrane_potential: Membrane potential values.
+
+        Returns:
+            Binary spike outputs with surrogate gradients attached.
+        """
+        return _surrogate_spike_kernel(membrane_potential, self.threshold, self.surrogate_scale)
+
+    @nn.compact
+    def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
+        """
+        Forward pass through the SpikeSSM.
+
+        Args:
+            inputs: Input tensor of shape [batch, seq_len, hidden_size].
+
+        Returns:
+            Output tensor of shape [batch, seq_len, hidden_size].
+        """
+        batch_size, seq_len, _ = inputs.shape
+
+        # Define layers inline with @nn.compact
+        linear_in = nn.Dense(
+            self.state_dim,
+            kernel_init=nn.initializers.xavier_uniform(),
+            bias_init=nn.initializers.zeros,
+            name='linear_in'
+        )
+        linear_out = nn.Dense(
+            self.hidden_size,
+            kernel_init=nn.initializers.xavier_uniform(),
+            bias_init=nn.initializers.zeros,
+            name='linear_out'
+        )
+        decay = self.param(
+            "decay",
+            lambda rng, shape: jnp.ones(shape) * 0.9,
+            (self.state_dim,)
+        )
+
+        def step(carry: jnp.ndarray, x: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+            """Single step of the spiking SSM."""
+            membrane_potential = carry
+
+            # Update membrane potential with input and decay
+            membrane_potential = (
+                membrane_potential * decay +
+                linear_in(x)
+            )
+
+            # Generate spikes using surrogate gradient
+            spikes = self._surrogate_spike(membrane_potential)
+
+            # Reset membrane potential where spikes occurred
+            membrane_potential = membrane_potential - spikes * self.threshold
+
+            # Generate output from spikes
+            y = linear_out(spikes)
+
+            return membrane_potential, y
+
+        # Initialize membrane potential
+        membrane_0 = jnp.zeros((batch_size, self.state_dim))
+
+        # Apply scan over sequence dimension
+        _, outputs = jax.lax.scan(step, membrane_0, jnp.transpose(inputs, (1, 0, 2)))
+
+        # Transpose back to [batch, seq, hidden]
+        outputs = jnp.transpose(outputs, (1, 0, 2))
+
+        return outputs
+
+
+class AdaptiveSpikeSSM(nn.Module):
+    """
+    Advanced SpikeSSM with adaptive thresholds and multiple timescales.
+
+    This variant includes several biologically-inspired mechanisms:
+    - Adaptive spike thresholds that increase with activity
+    - Multiple decay timescales for multi-scale temporal integration
+    - Lateral inhibition for competition between neurons
+
+    Attributes:
+        hidden_size: Size of input/output hidden dimension.
+        state_dim: Size of internal state dimension.
+        base_threshold: Base spike threshold (default: 0.5).
+        surrogate_scale: Scale for surrogate gradient (default: 10.0).
+        num_timescales: Number of different decay timescales (default: 3).
+
+    Note:
+        Multiple timescales allow the model to capture both fast and slow
+        temporal dynamics simultaneously, similar to biological neurons.
+        For optimal performance, JIT compile the module at the call site:
+        >>> model = AdaptiveSpikeSSM(hidden_size=256)
+        >>> jit_apply = jax.jit(model.apply)
+    """
+    hidden_size: int
+    state_dim: int = 64
+    base_threshold: float = 0.5
+    surrogate_scale: float = 10.0
+    num_timescales: int = 3
+
+    @nn.compact
+    def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
+        """
+        Forward pass with adaptive mechanisms.
+
+        Args:
+            inputs: Input tensor of shape [batch, seq_len, hidden_size].
+
+        Returns:
+            Output tensor of shape [batch, seq_len, hidden_size].
+        """
+        batch_size, seq_len, _ = inputs.shape
+
+        # Define layers inline with @nn.compact
+        linear_in = nn.Dense(self.state_dim, name='linear_in')
+        linear_out = nn.Dense(self.hidden_size, name='linear_out')
+        threshold_adaptation = nn.Dense(self.state_dim, use_bias=False, name='threshold_adaptation')
+
+        # Multiple decay timescales (from fast to slow)
+        decays = self.param(
+            "decays",
+            lambda rng, shape: jnp.linspace(0.7, 0.95, self.num_timescales).reshape(-1, 1),
+            (self.num_timescales, 1)
+        )
+
+        # Lateral inhibition weights
+        lateral_weights = self.param(
+            "lateral_weights",
+            lambda rng, shape: jax.random.normal(rng, shape) * 0.1,
+            (self.state_dim, self.state_dim)
+        )
+
+        def adaptive_threshold(spike_history: jnp.ndarray) -> jnp.ndarray:
+            """Compute adaptive thresholds based on recent activity."""
+            adaptation = threshold_adaptation(spike_history)
+            return self.base_threshold + 0.1 * jax.nn.tanh(adaptation)
+
+        def step(carry, x):
+            membrane_potentials, spike_history = carry
+
+            # Multi-timescale integration (vectorized, no Python loops)
+            # Compute linear_in(x) once and broadcast to all timescales
+            input_contribution = linear_in(x) / self.num_timescales  # [batch, state_dim]
+
+            # membrane_potentials: [num_timescales, batch, state_dim]
+            # decays: [num_timescales, 1] - broadcasts over batch and state_dim
+            # Vectorized update for all timescales at once
+            new_potentials = membrane_potentials * decays + input_contribution[None, :, :]
+
+            # Combine multi-timescale potentials (already stacked)
+            combined_potential = jnp.mean(new_potentials, axis=0)  # [batch, state_dim]
+
+            # Apply lateral inhibition
+            inhibited_potential = combined_potential - 0.1 * jnp.dot(
+                spike_history, lateral_weights
+            )
+
+            # Adaptive threshold
+            threshold = adaptive_threshold(spike_history)
+
+            # Generate spikes
+            spikes = jnp.where(inhibited_potential > threshold, 1.0, 0.0)
+
+            # Reset potentials where spikes occurred (vectorized, no Python loop)
+            # Broadcast spikes and threshold to all timescales
+            reset_potentials = new_potentials - spikes[None, :, :] * threshold[None, :, :]
+
+            # Update spike history (exponential moving average)
+            new_spike_history = 0.9 * spike_history + 0.1 * spikes
+
+            # Output
+            y = linear_out(spikes)
+
+            return (reset_potentials, new_spike_history), y
+
+        # Initialize states
+        membrane_0 = jnp.zeros((self.num_timescales, batch_size, self.state_dim))
+        spike_history_0 = jnp.zeros((batch_size, self.state_dim))
+
+        _, outputs = jax.lax.scan(
+            step,
+            (membrane_0, spike_history_0),
+            jnp.transpose(inputs, (1, 0, 2))
+        )
+
+        return jnp.transpose(outputs, (1, 0, 2))
+
+
+def create_spike_ssm(
+    hidden_size: int,
+    state_dim: int = 64,
+    adaptive: bool = False,
+    **kwargs
+) -> nn.Module:
+    """
+    Factory function to create Spiking SSM.
+
+    Args:
+        hidden_size: Size of input/output hidden dimension.
+        state_dim: Size of internal state dimension.
+        adaptive: Whether to use adaptive variant with multiple timescales.
+        **kwargs: Additional arguments passed to the model.
+
+    Returns:
+        SpikeSSM or AdaptiveSpikeSSM module.
+    """
+    if adaptive:
+        return AdaptiveSpikeSSM(
+            hidden_size=hidden_size,
+            state_dim=state_dim,
+            **kwargs
+        )
+    return SpikeSSM(
+        hidden_size=hidden_size,
+        state_dim=state_dim,
+        **kwargs
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    import jax.random as random
+
+    batch_size, seq_len, hidden_size = 2, 64, 128
+
+    # Test basic SpikeSSM
+    model = SpikeSSM(hidden_size=hidden_size, state_dim=64)
+    key = random.PRNGKey(42)
+    x = random.normal(key, (batch_size, seq_len, hidden_size))
+
+    params = model.init(key, x)
+    output = model.apply(params, x)
+    logger.info(f"SpikeSSM - Input: {x.shape}, Output: {output.shape}")
+
+    # Test adaptive version
+    adaptive_model = AdaptiveSpikeSSM(hidden_size=hidden_size, state_dim=64)
+    adaptive_params = adaptive_model.init(key, x)
+    adaptive_output = adaptive_model.apply(adaptive_params, x)
+    logger.info(f"AdaptiveSpikeSSM - Output: {adaptive_output.shape}")

--- a/capibara/ssm/ssm_tpu.py
+++ b/capibara/ssm/ssm_tpu.py
@@ -1,0 +1,231 @@
+"""
+SSM TPU Module - State Space Model optimized for TPU execution.
+
+This module implements a classic State Space Model (SSM) block optimized for TPU
+execution using JAX and Flax. The SSM provides O(n) complexity for sequence modeling
+compared to O(n^2) for standard attention mechanisms.
+
+The SSM formulation follows:
+    h[t+1] = A @ h[t] + B @ x[t]  (state update)
+    y[t] = C @ h[t] + D @ x[t]    (output)
+
+Key Features:
+    - TPU-optimized scan operations via jax.lax.scan
+    - Efficient memory usage for long sequences
+    - Stable initialization for state transition matrix
+    - Support for batched inputs
+
+Reference:
+    Gu, A., Goel, K., & Re, C. (2021). Efficiently Modeling Long Sequences
+    with Structured State Spaces. arXiv:2111.00396
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple, Any
+
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SSMConfig:
+    """Configuration for SSM block.
+
+    Attributes:
+        hidden_size: Size of input/output hidden dimension.
+        state_dim: Size of internal state dimension. Larger values capture
+            more complex dynamics but increase computation.
+        dt_min: Minimum discretization step for continuous-time SSM.
+        dt_max: Maximum discretization step for continuous-time SSM.
+        use_stable_init: Whether to use stable initialization for matrix A.
+    """
+    hidden_size: int = 256
+    state_dim: int = 64
+    dt_min: float = 0.001
+    dt_max: float = 0.1
+    use_stable_init: bool = True
+
+
+class SSMBlock(nn.Module):
+    """
+    State Space Model block optimized for TPU execution.
+
+    Implements the classic SSM recurrence with efficient JAX scan operations.
+    The model maintains an internal state that captures sequence history,
+    enabling O(n) sequence processing.
+
+    Attributes:
+        hidden_size: Size of the input/output hidden dimension.
+        state_dim: Size of the internal state dimension (default: 64).
+
+    Note:
+        The state transition matrix A is initialized to be stable (eigenvalues < 1)
+        to prevent gradient explosion during training.
+        For optimal performance, JIT compile the module at the call site:
+        >>> model = SSMBlock(hidden_size=256)
+        >>> jit_apply = jax.jit(model.apply)
+    """
+    hidden_size: int
+    state_dim: int = 64
+
+    @nn.compact
+    def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
+        """
+        Forward pass through the SSM block.
+
+        Args:
+            inputs: Input tensor of shape [batch, seq_len, hidden_size].
+
+        Returns:
+            Output tensor of shape [batch, seq_len, hidden_size].
+
+        Note:
+            Uses jax.lax.scan for efficient TPU execution, which automatically
+            handles sequence-level parallelism on TPU hardware.
+        """
+        batch_size, seq_len, _ = inputs.shape
+
+        # State transition matrix A - initialized to be stable
+        A = self.param(
+            "A",
+            lambda rng, shape: jax.random.normal(rng, shape) * 0.1 - 0.5,
+            (self.state_dim, self.state_dim)
+        )
+
+        # Input matrix B - projects input to state space
+        B = self.param(
+            "B",
+            nn.initializers.xavier_uniform(),
+            (self.state_dim, self.hidden_size)
+        )
+
+        # Output matrix C - projects state to output space
+        C = self.param(
+            "C",
+            nn.initializers.xavier_uniform(),
+            (self.hidden_size, self.state_dim)
+        )
+
+        # Skip connection D - direct input-to-output connection
+        D = self.param(
+            "D",
+            nn.initializers.zeros,
+            (self.hidden_size,)
+        )
+
+        def step(carry: jnp.ndarray, x: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+            """Single step of the SSM recurrence."""
+            h = carry  # Previous hidden state
+
+            # State update: h[t+1] = A @ h[t] + B @ x[t]
+            h_next = jnp.dot(h, A.T) + jnp.dot(x, B.T)
+
+            # Output: y[t] = C @ h[t+1] + D @ x[t]
+            y = jnp.dot(h_next, C.T) + D * x
+
+            return h_next, y
+
+        # Initialize hidden state to zeros
+        h0 = jnp.zeros((batch_size, self.state_dim))
+
+        # Apply scan over sequence dimension
+        # Transpose to [seq, batch, hidden] for scan
+        _, outputs = jax.lax.scan(step, h0, jnp.transpose(inputs, (1, 0, 2)))
+
+        # Transpose back to [batch, seq, hidden]
+        outputs = jnp.transpose(outputs, (1, 0, 2))
+
+        return outputs
+
+
+class BidirectionalSSM(nn.Module):
+    """
+    Bidirectional SSM that processes sequences in both directions.
+
+    Combines forward and backward SSM passes for tasks requiring
+    full sequence context (e.g., classification, NER).
+
+    Attributes:
+        hidden_size: Size of input/output hidden dimension.
+        state_dim: Size of internal state dimension.
+
+    Note:
+        For optimal performance, JIT compile the module at the call site:
+        >>> model = BidirectionalSSM(hidden_size=256)
+        >>> jit_apply = jax.jit(model.apply)
+    """
+    hidden_size: int
+    state_dim: int = 64
+
+    @nn.compact
+    def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
+        """
+        Forward pass through bidirectional SSM.
+
+        Args:
+            inputs: Input tensor of shape [batch, seq_len, hidden_size].
+
+        Returns:
+            Output tensor of shape [batch, seq_len, hidden_size].
+        """
+        forward_ssm = SSMBlock(
+            hidden_size=self.hidden_size,
+            state_dim=self.state_dim,
+            name='forward_ssm'
+        )
+        backward_ssm = SSMBlock(
+            hidden_size=self.hidden_size,
+            state_dim=self.state_dim,
+            name='backward_ssm'
+        )
+
+        forward_out = forward_ssm(inputs)
+        backward_out = backward_ssm(jnp.flip(inputs, axis=1))
+        backward_out = jnp.flip(backward_out, axis=1)
+
+        combined = jnp.concatenate([forward_out, backward_out], axis=-1)
+        return nn.Dense(self.hidden_size, name='output_proj')(combined)
+
+
+def create_ssm_block(
+    hidden_size: int,
+    state_dim: int = 64,
+    bidirectional: bool = False
+) -> nn.Module:
+    """
+    Factory function to create SSM block.
+
+    Args:
+        hidden_size: Size of input/output hidden dimension.
+        state_dim: Size of internal state dimension.
+        bidirectional: Whether to use bidirectional processing.
+
+    Returns:
+        SSMBlock or BidirectionalSSM module.
+    """
+    if bidirectional:
+        return BidirectionalSSM(hidden_size=hidden_size, state_dim=state_dim)
+    return SSMBlock(hidden_size=hidden_size, state_dim=state_dim)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    # Test SSM block
+    import jax.random as random
+
+    batch_size, seq_len, hidden_size = 2, 128, 256
+    model = SSMBlock(hidden_size=hidden_size, state_dim=64)
+
+    key = random.PRNGKey(42)
+    x = random.normal(key, (batch_size, seq_len, hidden_size))
+    params = model.init(key, x)
+    output = model.apply(params, x)
+
+    logger.info(f"SSM test - Input: {x.shape}, Output: {output.shape}")

--- a/capibara/sub_models/__init__.py
+++ b/capibara/sub_models/__init__.py
@@ -1,0 +1,17 @@
+"""
+CapibaraGPT v3 sub_models package shim.
+
+This module aliases the top-level `sub_models` package so that both
+`sub_models.*` and `capibara.sub_models.*` imports work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+_sub_models = importlib.import_module("sub_models")
+
+# Expose as capibara.sub_models
+sys.modules[__name__] = _sub_models

--- a/capibara/vq/README.md
+++ b/capibara/vq/README.md
@@ -1,0 +1,932 @@
+# Capibara Vector Quantization (VQ) Module
+
+**Ultra-advanced vector quantization for model compression and efficiency**
+
+##  Table of Contents
+
+1. [Overview](#overview)
+2. [VQ Fundamentals](#vq-fundamentals)
+3. [Architecture](#architecture)
+4. [Quick Start](#quick-start)
+5. [Enhanced VQ System](#enhanced-vq-system)
+6. [Intelligent VQ Integration](#intelligent-vq-integration)
+7. [VQBit Implementations](#vqbit-implementations)
+8. [VIM-VQ Integration](#vim-vq-integration)
+9. [Hardware Optimization](#hardware-optimization)
+10. [Monitoring & Performance](#monitoring--performance)
+11. [Best Practices](#best-practices)
+12. [References](#references)
+
+---
+
+##  Overview
+
+The **CapibaraGPT Vector Quantization (VQ) Module** provides state-of-the-art vector quantization techniques for:
+- **Model Compression**: Reduce model size by 4-16x
+- **Inference Acceleration**: Faster inference through quantized operations
+- **Memory Efficiency**: Lower memory footprint for deployment
+- **Hardware Optimization**: TPU v6, ARM Axion, and GPU-specific optimizations
+- **Multimodal Support**: VQ for text, vision, and audio
+
+### Key Features
+
+ **Multiple VQ Variants**: Standard, Residual, Product, Adaptive
+ **Intelligent Auto-Optimization**: Automatic best-variant selection
+ **Hardware-Aware**: TPU v6, ARM Axion, GPU optimizations
+ **Multimodal**: Text, vision, audio VQ support
+ **Production-Ready**: Monitoring, logging, performance tracking
+ **JAX Native**: Full JAX/Flax integration with JIT compilation
+ **VIM-VQ**: Vision-Mamba vector quantization
+
+### Compression Ratios
+
+| VQ Type | Compression | Quality Loss | Speed | Memory |
+|---------|-------------|--------------|-------|--------|
+| Standard VQ | 4-8x | <2% | Fast | Low |
+| Residual VQ | 8-16x | <3% | Medium | Low |
+| Product VQ | 16-32x | <5% | Fast | Very Low |
+| Adaptive VQ | 8-12x | <2% | Medium | Low |
+
+---
+
+##  VQ Fundamentals
+
+### What is Vector Quantization?
+
+**Vector Quantization (VQ)** maps continuous vectors to discrete codes from a learned codebook:
+
+```
+Input Vector (continuous) → Quantizer → Code Index (discrete) → Codebook Lookup → Reconstructed Vector
+```
+
+**Example:**
+```python
+# Input: 768-dimensional embedding
+embedding = [0.123, -0.456, 0.789, ..., 0.234]  # 768 floats (3072 bytes)
+
+# Quantization: Map to codebook index
+code_index = vq.quantize(embedding)  # Single int (4 bytes)
+
+# Reconstruction: Lookup in codebook
+reconstructed = vq.codebook[code_index]  # 768 floats
+
+# Compression: 3072 bytes → 4 bytes = 768x compression!
+```
+
+### Why VQ for LLMs?
+
+**Benefits:**
+- **Smaller Models**: Deploy on edge devices
+- **Faster Inference**: Quantized ops are faster
+- **Lower Memory**: Fit larger models in RAM
+- **Better Caching**: Smaller activations → better cache utilization
+
+**Trade-offs:**
+- Small quality degradation (<2% typically)
+- Training overhead for codebook learning
+- Reconstruction latency (negligible with optimization)
+
+---
+
+## ️ Architecture
+
+### VQ Module Structure
+
+```
+capibara/vq/
+├──  Core VQ Systems
+│   ├── enhanced_vq_system_v2.py         # Enhanced VQ variants
+│   ├── intelligent_vq_integration.py    # Intelligent VQ manager
+│   └── ultra_vq_orchestrator.py         # System orchestration
+│
+├──  VQBit Implementations
+│   ├── vqbit_layer.py                   # VQBit base layer
+│   ├── adaptive_vq.py                   # Adaptive VQ
+│   ├── multimodal_vqbit.py              # Multimodal VQ
+│   ├── jax_native_integration.py        # JAX optimizations
+│   ├── vq_v33_tpu_v6.py                 # TPU v6 optimized
+│   ├── vq_arm_axion.py                  # ARM Axion optimized
+│   └── vq_monitoring.py                 # Performance monitoring
+│
+├──  VIM-VQ (Vision-Mamba VQ)
+│   ├── core/                            # VIM-VQ core
+│   ├── configs/                         # VIM-VQ configs
+│   └── utils/                           # VIM-VQ utilities
+│
+├──  Monitoring & Config
+│   ├── monitoring/                      # VQ monitoring
+│   └── config/                          # VQ configurations
+│
+└──  Utilities
+    └── stubs/                           # Stub implementations
+```
+
+### System Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────┐
+│            UltraVQOrchestrator (Top Level)              │
+│  - Coordinates all VQ systems                           │
+│  - Auto-selects optimal VQ variant                      │
+│  - Performance monitoring                               │
+└───────────────────┬─────────────────────────────────────┘
+                    │
+        ┌───────────┼───────────┬──────────────┐
+        ▼           ▼           ▼              ▼
+┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
+│Enhanced  │  │Intelligent│  │  VQBit   │  │ VIM-VQ   │
+│VQ System │  │VQ Manager │  │ Variants │  │  System  │
+└────┬─────┘  └────┬─────┘  └────┬─────┘  └────┬─────┘
+     │             │              │             │
+     ▼             ▼              ▼             ▼
+┌─────────────────────────────────────────────────────────┐
+│           Hardware-Specific Optimizations                │
+│  TPU v6 | ARM Axion | CUDA | CPU SIMD | JAX Native      │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+##  Quick Start
+
+### Installation
+
+```bash
+# Install VQ dependencies
+pip install jax jaxlib flax optax
+pip install onnx onnxruntime  # For ONNX export
+pip install tensorboard  # For monitoring
+```
+
+### Basic Usage
+
+```python
+from capibara.vq import create_vq
+
+# Create VQ layer (automatic best-variant selection)
+vq, info = create_vq(
+    use_case="Generatel",
+    num_embeddings=8192,  # Codebook size
+    embedding_dim=768,    # Embedding dimension
+    system_preference="auto"
+)
+
+print(f"Selected system: {info['system']}")
+print(f"Estimated compression: {info['compression_ratio']}x")
+
+# Use VQ layer
+import jax.numpy as jnp
+
+# Input embeddings
+embeddings = jnp.ones((4, 512, 768))  # (batch, seq_len, dim)
+
+# Quantize
+quantized, indices, commitment_loss = vq(embeddings)
+
+print(f"Input shape: {embeddings.shape}")
+print(f"Output shape: {quantized.shape}")
+print(f"Indices shape: {indices.shape}")
+print(f"Commitment loss: {commitment_loss:.4f}")
+```
+
+### Saving & Loading
+
+```python
+# Save VQ codebook
+vq.save_codebook("checkpoints/vq_codebook.npz")
+
+# Load VQ codebook
+vq.load_codebook("checkpoints/vq_codebook.npz")
+
+# Export to ONNX
+vq.export_onnx("models/vq_quantizer.onnx")
+```
+
+---
+
+##  Enhanced VQ System
+
+### Overview
+
+The **Enhanced VQ System** provides multiple advanced VQ variants with automatic optimization.
+
+### Available Variants
+
+#### 1. Standard VQ
+
+**Purpose**: Basic vector quantization
+
+**Algorithm:**
+```python
+# Find nearest codebook vector
+distances = ||embedding - codebook[i]|| for all i
+index = argmin(distances)
+quantized = codebook[index]
+```
+
+**Usage:**
+```python
+from capibara.vq import EnhancedVectorQuantizer, EnhancedVQConfig
+
+config = EnhancedVQConfig(
+    variant="standard",
+    num_embeddings=4096,
+    embedding_dim=512,
+    commitment_weight=0.25
+)
+
+vq = EnhancedVectorQuantizer(config)
+```
+
+**Best For**: Generatel-purpose compression
+
+#### 2. Residual VQ (RVQ)
+
+**Purpose**: Multi-stage quantization for higher compression
+
+**Algorithm:**
+```python
+# Stage 1
+quantized_1, residual_1 = vq_1(embedding)
+
+# Stage 2 (quantize residual)
+quantized_2, residual_2 = vq_2(residual_1)
+
+# Stage 3
+quantized_3, residual_3 = vq_3(residual_2)
+
+# Final reconstruction
+quantized = quantized_1 + quantized_2 + quantized_3
+```
+
+**Usage:**
+```python
+config = EnhancedVQConfig(
+    variant="residual",
+    num_embeddings=2048,  # Per stage
+    embedding_dim=512,
+    num_residual_layers=3  # 3 stages
+)
+
+rvq = EnhancedVectorQuantizer(config)
+quantized, indices = rvq(embeddings)  # indices is 3D: (batch, seq, stages)
+```
+
+**Compression**: 8-16x (vs 4-8x for standard VQ)
+
+**Best For**: Maximum compression with acceptable quality
+
+#### 3. Product VQ (PQ)
+
+**Purpose**: Subspace quantization for extreme compression
+
+**Algorithm:**
+```python
+# Split embedding into M subspaces
+subvectors = split(embedding, num_subspaces=M)
+
+# Quantize each subspace independently
+indices = [vq_i.quantize(subvectors[i]) for i in range(M)]
+
+# Reconstruct
+quantized_subvectors = [vq_i.lookup(indices[i]) for i in range(M)]
+quantized = concatenate(quantized_subvectors)
+```
+
+**Usage:**
+```python
+config = EnhancedVQConfig(
+    variant="product",
+    num_embeddings=256,  # Per subspace
+    embedding_dim=768,
+    num_subspaces=8  # Split into 8 subspaces
+)
+
+pq = EnhancedVectorQuantizer(config)
+```
+
+**Compression**: 16-32x (extreme compression)
+
+**Best For**: Edge deployment, memory-constrained scenarios
+
+#### 4. Adaptive VQ
+
+**Purpose**: Dynamic codebook that adapts to data distribution
+
+**Features:**
+- Online codebook learning
+- Automatic dead code detection and replacement
+- Usage-based codebook optimization
+
+**Usage:**
+```python
+config = EnhancedVQConfig(
+    variant="adaptive",
+    num_embeddings=8192,
+    embedding_dim=768,
+    adaptive_learning_rate=0.01,
+    dead_code_threshold=100  # Replace codes unused for 100 steps
+)
+
+adaptive_vq = EnhancedVectorQuantizer(config)
+
+# Training loop
+for batch in dataloader:
+    quantized, indices, loss = adaptive_vq(batch, training=True)
+
+    # Codebook automatically adapts
+    if adaptive_vq.step % 100 == 0:
+        stats = adaptive_vq.get_codebook_stats()
+        print(f"Active codes: {stats['active_codes']}/{stats['total_codes']}")
+```
+
+**Best For**: Long training runs, evolving data distributions
+
+### Factory Functions
+
+```python
+from capibara.vq import create_enhanced_vq_layer
+
+# Create standard VQ
+standard_vq = create_enhanced_vq_layer(
+    variant="standard",
+    num_embeddings=4096,
+    embedding_dim=512
+)
+
+# Create residual VQ
+residual_vq = create_enhanced_vq_layer(
+    variant="residual",
+    num_embeddings=2048,
+    embedding_dim=512,
+    num_residual_layers=3
+)
+
+# Create product VQ
+product_vq = create_enhanced_vq_layer(
+    variant="product",
+    num_embeddings=256,
+    embedding_dim=768,
+    num_subspaces=8
+)
+```
+
+### Benchmarking
+
+```python
+from capibara.vq import benchmark_vq_variants
+
+# Benchmark all variants
+results = benchmark_vq_variants(
+    test_data=test_embeddings,
+    variants=["standard", "residual", "product", "adaptive"],
+    metrics=["reconstruction_error", "latency", "compression_ratio"]
+)
+
+# Results
+for variant, metrics in results.items():
+    print(f"\n{variant} VQ:")
+    print(f"  Reconstruction error: {metrics['reconstruction_error']:.4f}")
+    print(f"  Latency: {metrics['latency_ms']:.2f}ms")
+    print(f"  Compression: {metrics['compression_ratio']:.1f}x")
+```
+
+---
+
+##  Intelligent VQ Integration
+
+### Overview
+
+The **Intelligent VQ Manager** automatically selects and optimizes VQ variants based on use case and performance requirements.
+
+### IntelligentVQManager
+
+**Features:**
+- Automatic variant selection
+- Performance profiling
+- Resource-aware optimization
+- Recommendation system
+
+**Usage:**
+```python
+from capibara.vq import IntelligentVQManager, VQManagerConfig
+
+# Create manager
+config = VQManagerConfig(
+    auto_optimize=True,
+    profile_enabled=True,
+    fallback_enabled=True
+)
+
+manager = IntelligentVQManager(config)
+
+# Get optimal VQ for use case
+vq = manager.get_optimal_vq(
+    use_case="research",  # "Generatel", "production", "edge", "research"
+    num_embeddings=8192,
+    embedding_dim=768,
+    performance_requirements={
+        "max_latency_ms": 10.0,
+        "min_quality": 0.95,
+        "max_memory_mb": 500
+    }
+)
+
+print(f"Selected variant: {vq.variant}")
+print(f"Estimated quality: {vq.estimated_quality:.2%}")
+```
+
+### Automatic Optimization
+
+```python
+from capibara.vq import create_optimal_vq
+
+# Automatically create optimal VQ
+vq, info = create_optimal_vq(
+    use_case="production",
+    num_embeddings=4096,
+    embedding_dim=512,
+    performance_requirements={
+        "target_compression": 8.0,  # 8x compression target
+        "max_quality_loss": 0.02,   # <2% quality loss
+        "hardware": "tpu_v6"         # TPU v6 optimization
+    }
+)
+
+print(f"Selected: {info['selected_variant']}")
+print(f"Compression: {info['compression_ratio']}x")
+print(f"Quality: {info['estimated_quality']:.2%}")
+print(f"Hardware: {info['optimized_for']}")
+```
+
+### Recommendations
+
+```python
+from capibara.vq import get_vq_recommendations
+
+# Get recommendations for scenario
+recommendations = get_vq_recommendations(
+    use_case="edge_deployment",
+    constraints={
+        "max_memory_mb": 100,
+        "max_latency_ms": 5.0,
+        "min_accuracy": 0.90
+    }
+)
+
+for i, rec in enumerate(recommendations, 1):
+    print(f"\n{i}. {rec['variant']} VQ")
+    print(f"   Compression: {rec['compression']}x")
+    print(f"   Memory: {rec['memory_mb']}MB")
+    print(f"   Latency: {rec['latency_ms']}ms")
+    print(f"   Quality: {rec['quality']:.2%}")
+```
+
+---
+
+##  VQBit Implementations
+
+### VQBit Overview
+
+**VQBit** is a family of hardware-optimized VQ implementations for production deployment.
+
+### Components
+
+#### 1. Standard VQBit Layer
+
+```python
+from capibara.vq.vqbit import VQBitLayer
+
+vqbit = VQBitLayer(
+    codebook_size=8192,
+    embedding_dim=768,
+    num_bits=8,  # 8-bit quantization
+    use_ema=True  # Exponential moving average for codebook
+)
+
+quantized = vqbit(embeddings, training=True)
+```
+
+#### 2. Adaptive VQBit
+
+**Features:**
+- Dynamic codebook adaptation
+- Dead code handling
+- Usage-based optimization
+
+```python
+from capibara.vq.vqbit import AdaptiveVQBit
+
+adaptive_vqbit = AdaptiveVQBit(
+    codebook_size=8192,
+    embedding_dim=768,
+    adaptation_rate=0.01,
+    dead_code_threshold=1000
+)
+
+# Automatically adapts during training
+for batch in dataloader:
+    quantized = adaptive_vqbit(batch, training=True)
+
+    # Check adaptation stats
+    stats = adaptive_vqbit.get_stats()
+    print(f"Active codes: {stats.active_codes}")
+    print(f"Dead codes replaced: {stats.dead_codes_replaced}")
+```
+
+#### 3. Multimodal VQBit
+
+**Features:**
+- Separate codebooks for text, vision, audio
+- Cross-modal quantization
+- Modality-specific optimization
+
+```python
+from capibara.vq.vqbit import MultimodalVQBit
+
+mm_vqbit = MultimodalVQBit(
+    modalities=["text", "vision", "audio"],
+    codebook_size=4096,  # Per modality
+    embedding_dim=768,
+    shared_codebook=False  # Separate codebooks
+)
+
+# Quantize different modalities
+text_quantized = mm_vqbit.quantize(text_embeddings, modality="text")
+vision_quantized = mm_vqbit.quantize(vision_embeddings, modality="vision")
+audio_quantized = mm_vqbit.quantize(audio_embeddings, modality="audio")
+```
+
+#### 4. JAX Native Integration
+
+**Features:**
+- Full JAX/Flax integration
+- JIT compilation
+- Gradient checkpointing
+- TPU optimization
+
+```python
+from capibara.vq.vqbit import JAXNativeVQ
+
+jax_vq = JAXNativeVQ(
+    codebook_size=8192,
+    embedding_dim=768,
+    use_jit=True,
+    use_gradient_checkpointing=True
+)
+
+# JIT-compiled forward pass
+@jax.jit
+def forward(params, x):
+    return jax_vq.apply(params, x)
+
+output = forward(vq_params, embeddings)
+```
+
+---
+
+## ️ VIM-VQ Integration
+
+### Overview
+
+**VIM-VQ** integrates vector quantization with Vision-Mamba for efficient vision model compression.
+
+### Features
+
+- Vision-specific VQ optimization
+- Mamba-compatible quantization
+- Spatial codebook organization
+- Patch-based quantization
+
+### Usage
+
+```python
+from capibara.vq.vim_vq import VIMVQIntegration
+
+vim_vq = VIMVQIntegration(
+    image_size=224,
+    patch_size=16,
+    codebook_size=8192,
+    embedding_dim=768,
+    mamba_compatible=True
+)
+
+# Quantize image patches
+image = jnp.ones((1, 224, 224, 3))
+quantized_patches, patch_indices = vim_vq.quantize_image(image)
+
+print(f"Patch shape: {quantized_patches.shape}")
+print(f"Indices shape: {patch_indices.shape}")
+```
+
+### Spatial Codebook
+
+```python
+# Create spatial-aware codebook
+vim_vq = VIMVQIntegration(
+    codebook_organization="spatial",  # vs "random"
+    num_spatial_regions=4  # 4x4 grid of codebooks
+)
+
+# Different regions use different parts of codebook
+# Improves reconstruction quality for vision
+```
+
+---
+
+##  Hardware Optimization
+
+### TPU v6 Optimization
+
+**Features:**
+- TPU v6 MXU (Matrix Unit) optimization
+- Hardware-accelerated VQ operations
+- BFloat16 support
+
+```python
+from capibara.vq.vqbit import VQ_V33_TPU_V6
+
+tpu_vq = VQ_V33_TPU_V6(
+    codebook_size=8192,
+    embedding_dim=768,
+    use_mxu=True,  # Use TPU Matrix Unit
+    precision="bfloat16"
+)
+
+# Automatically uses TPU-optimized kernels
+quantized = tpu_vq(embeddings)
+```
+
+**Performance:**
+- 3-5x faster than CPU
+- Native BFloat16 support
+- Optimized for large codebooks
+
+### ARM Axion Optimization
+
+**Features:**
+- ARM NEON SIMD optimization
+- SVE (Scalable Vector Extension) support
+- Cache-friendly implementation
+
+```python
+from capibara.vq.vqbit import VQ_ARM_Axion
+
+arm_vq = VQ_ARM_Axion(
+    codebook_size=4096,
+    embedding_dim=512,
+    use_neon=True,  # ARM NEON SIMD
+    use_sve=True    # Scalable Vector Extension
+)
+
+# Optimized for ARM Axion processors
+quantized = arm_vq(embeddings)
+```
+
+**Performance:**
+- 2-3x faster than unoptimized
+- Better cache utilization
+- Lower power consumption
+
+### GPU Optimization
+
+```python
+from capibara.vq import create_vq
+
+# CUDA-optimized VQ
+gpu_vq, info = create_vq(
+    use_case="Generatel",
+    num_embeddings=8192,
+    embedding_dim=768,
+    hardware="cuda",
+    cuda_streams=4  # Multi-stream
+)
+```
+
+---
+
+##  Monitoring & Performance
+
+### VQ Monitoring
+
+```python
+from capibara.vq.vqbit import VQMonitoring
+
+monitor = VQMonitoring(
+    vq_module=vq,
+    log_interval=100,
+    enable_tensorboard=True
+)
+
+# Training loop with monitoring
+for step, batch in enumerate(dataloader):
+    quantized, indices, loss = vq(batch, training=True)
+
+    # Log metrics
+    monitor.log_step(
+        step=step,
+        loss=loss,
+        indices=indices
+    )
+
+    if step % 100 == 0:
+        stats = monitor.get_stats()
+        print(f"Codebook usage: {stats['usage_rate']:.2%}")
+        print(f"Avg distance: {stats['avg_distance']:.4f}")
+```
+
+### Performance Metrics
+
+```python
+from capibara.vq import get_vq_usage_stats
+
+# Get comprehensive stats
+stats = get_vq_usage_stats(vq)
+
+print(f"Active codes: {stats['active_codes']}/{stats['total_codes']}")
+print(f"Usage entropy: {stats['usage_entropy']:.4f}")
+print(f"Reconstruction error: {stats['reconstruction_error']:.4f}")
+print(f"Compression ratio: {stats['compression_ratio']:.1f}x")
+print(f"Throughput: {stats['throughput_tokens_per_sec']:.0f} tokens/s")
+```
+
+### TensorBoard Integration
+
+```python
+from torch.utils.tensorboard import SummaryWriter
+
+writer = SummaryWriter('runs/vq_training')
+
+# Log VQ metrics
+monitor.set_tensorboard_writer(writer)
+
+# Automatically logs:
+# - Codebook usage histogram
+# - Reconstruction error
+# - Commitment loss
+# - Distance distributions
+```
+
+---
+
+##  Best Practices
+
+### 1. Choose Right VQ Variant
+
+```python
+# Generatel-purpose: Standard VQ
+if use_case == "Generatel":
+    vq = create_vq(variant="standard", num_embeddings=8192)
+
+# Maximum compression: Product VQ
+elif use_case == "edge":
+    vq = create_vq(variant="product", num_subspaces=8)
+
+# Long training: Adaptive VQ
+elif use_case == "research":
+    vq = create_vq(variant="adaptive")
+
+# High quality: Residual VQ
+elif use_case == "production":
+    vq = create_vq(variant="residual", num_residual_layers=3)
+```
+
+### 2. Codebook Size Selection
+
+```python
+# Rule of thumb: codebook_size ≈ sqrt(num_tokens)
+num_tokens = 1_000_000
+optimal_codebook_size = int(num_tokens ** 0.5)  # ~1000
+
+# Adjust based on quality requirements
+if high_quality_needed:
+    codebook_size = optimal_codebook_size * 4  # 4000
+else:
+    codebook_size = optimal_codebook_size  # 1000
+```
+
+### 3. Training Stability
+
+```python
+config = EnhancedVQConfig(
+    num_embeddings=8192,
+    embedding_dim=768,
+
+    # Commitment weight (higher = more stable)
+    commitment_weight=0.25,  # Default
+
+    # Codebook initialization
+    init_method="kmeans",  # vs "random"
+
+    # EMA for smoother updates
+    use_ema=True,
+    ema_decay=0.99
+)
+```
+
+### 4. Dead Code Handling
+
+```python
+# Enable dead code replacement
+adaptive_vq = AdaptiveVQBit(
+    dead_code_threshold=1000,  # Replace after 1000 unused steps
+    dead_code_strategy="random_reset"  # or "split_popular"
+)
+
+# Monitor dead codes
+if step % 1000 == 0:
+    dead_codes = adaptive_vq.get_dead_codes()
+    print(f"Dead codes: {len(dead_codes)}")
+
+    if len(dead_codes) > 100:
+        adaptive_vq.reset_dead_codes()
+```
+
+### 5. Hardware-Specific Optimization
+
+```python
+import platform
+
+# Auto-detect hardware
+if platform.processor() == "arm":
+    vq = VQ_ARM_Axion(...)
+elif is_tpu_available():
+    vq = VQ_V33_TPU_V6(...)
+elif is_cuda_available():
+    vq = create_vq(hardware="cuda")
+else:
+    vq = create_vq(hardware="cpu")
+```
+
+---
+
+##  References
+
+### Research Papers
+
+**Vector Quantization:**
+- [Neural Discrete Representation Learning (VQ-VAE)](https://arxiv.org/abs/1711.00937)
+- [Generateting Diverse High-Fidelity Images (VQ-VAE-2)](https://arxiv.org/abs/1906.00446)
+- [Taming Transformers for High-Resolution Image Synthesis (VQGAN)](https://arxiv.org/abs/2012.09841)
+
+**Residual VQ:**
+- [Residual Vector Quantization (Zeghidour et al., 2021)](https://arxiv.org/abs/2107.03312)
+- [SoundStream: An End-to-End Neural Audio Codec](https://arxiv.org/abs/2107.03312)
+
+**Product Quantization:**
+- [Product Quantization for Nearest Neighbor Search (Jégou et al., 2011)](https://lear.inrialpes.fr/pubs/2011/JDS11/jegou_searching_with_quantization.pdf)
+- [Optimized Product Quantization (Ge et al., 2013)](https://www.cv-foundation.org/openaccess/content_cvpr_2013/papers/Ge_Optimized_Product_Quantization_2013_CVPR_paper.pdf)
+
+**LLM Quantization:**
+- [LLM.int8(): 8-bit Matrix Multiplication](https://arxiv.org/abs/2208.07339)
+- [GPTQ: Accurate Post-Training Quantization](https://arxiv.org/abs/2210.17323)
+
+### Related Documentation
+
+- [Layers Module](../layers/README.md) - VQ layer implementations
+- [Core Module](../core/README.md) - Core model integration
+- [Inference Module](../inference/README.md) - VQ in inference
+- [TPU Optimization](../core/tpu/README.md) - TPU-specific optimizations
+
+### External Resources
+
+- [Faiss Library](https://github.com/facebookresearch/faiss) - Efficient similarity search
+- [JAX Documentation](https://jax.readthedocs.io/)
+- [TPU Performance Guide](https://cloud.google.com/tpu/docs/performance-guide)
+
+---
+
+##  Contributing
+
+Contributions welcome! Priority areas:
+
+1. **New VQ Variants**: Implement additional VQ algorithms
+2. **Hardware Optimization**: Add support for new hardware (e.g., NPU)
+3. **Multimodal**: Expand multimodal VQ capabilities
+4. **Performance**: Optimize existing implementations
+5. **Documentation**: More examples and tutorials
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+##  License
+
+Part of the CapibaraGPT v3 project. See [LICENSE](../../LICENSE) for details.
+
+---
+
+**Maintained by**: Capibara Ultra VQ Team
+**Last Updated**: 2025-11-16
+**Version**: 2024.1.0
+**Status**: Production-Ready Ultra
+
+## Example quick
+
+Example (pseudo-code) para vector quantization:
+
+```python
+# vq = VectorQuantizer(config)
+# codes = vq.encode(inputs)
+# reconstructed = vq.decode(codes)
+```

--- a/capibara/vq/__init__.py
+++ b/capibara/vq/__init__.py
@@ -1,0 +1,96 @@
+"""
+Vector Quantization Module - CapibaraGPT v3
+
+Advanced vector quantization system supporting:
+- ultra_vq_orchestrator: Main VQ orchestration
+- vqbit_layer: VQbit layer implementation
+- multi_modal_vq_intelligence: Multi-modal VQ
+- adaptive_vq_performance_intelligence: Adaptive optimization
+- vq_arm_axion: ARM Axion optimizations
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# VQbit package (submodule) availability
+try:
+    from . import vqbit  # noqa: F401
+    VQBIT_PACKAGE_AVAILABLE = True
+except Exception as e:
+    vqbit = None  # type: ignore
+    VQBIT_PACKAGE_AVAILABLE = False
+    logger.debug("VQ subpackage 'vqbit' unavailable: %s", e)
+
+# Ultra VQ orchestrator
+try:
+    from .ultra_vq_orchestrator import (
+        UltraVQOrchestrator,
+        create_ultra_vq_system,
+    )
+    ORCHESTRATOR_AVAILABLE = True
+except Exception as e:
+    ORCHESTRATOR_AVAILABLE = False
+    UltraVQOrchestrator = None
+    create_ultra_vq_system = None
+    logger.debug("Ultra VQ orchestrator unavailable: %s", e)
+
+# VQbit layer
+try:
+    from .vqbit_layer import VQbitLayer
+    VQBIT_AVAILABLE = True
+except Exception as e:
+    VQBIT_AVAILABLE = False
+    VQbitLayer = None
+    logger.debug("VQbit layer unavailable: %s", e)
+
+# Multi-modal VQ
+try:
+    from .multi_modal_vq_intelligence import MultiModalVQ
+    MULTIMODAL_AVAILABLE = True
+except Exception as e:
+    MULTIMODAL_AVAILABLE = False
+    MultiModalVQ = None
+    logger.debug("Multi-modal VQ unavailable: %s", e)
+
+# Adaptive VQ
+try:
+    from .adaptive_vq_performance_intelligence import AdaptiveVQ
+    ADAPTIVE_AVAILABLE = True
+except Exception as e:
+    ADAPTIVE_AVAILABLE = False
+    AdaptiveVQ = None
+    logger.debug("Adaptive VQ unavailable: %s", e)
+
+# ARM Axion optimizations
+try:
+    from .vq_arm_axion import VQArmAxion
+    ARM_AVAILABLE = True
+except Exception as e:
+    ARM_AVAILABLE = False
+    VQArmAxion = None
+    logger.debug("ARM Axion VQ unavailable: %s", e)
+
+
+__all__ = [
+    # Subpackage
+    "vqbit",
+    "VQBIT_PACKAGE_AVAILABLE",
+    # Orchestrator
+    "UltraVQOrchestrator",
+    "create_ultra_vq_system",
+    # VQbit
+    "VQbitLayer",
+    # Multi-modal
+    "MultiModalVQ",
+    # Adaptive
+    "AdaptiveVQ",
+    # ARM
+    "VQArmAxion",
+    # Flags
+    "ORCHESTRATOR_AVAILABLE",
+    "VQBIT_AVAILABLE",
+    "MULTIMODAL_AVAILABLE",
+    "ADAPTIVE_AVAILABLE",
+    "ARM_AVAILABLE",
+]

--- a/capibara/vq/adaptive_vq_performance_intelligence.py
+++ b/capibara/vq/adaptive_vq_performance_intelligence.py
@@ -1,0 +1,871 @@
+"""
+Adaptive VQ Performance Intelligence - CapibaraGPT v3024
+=======================================================
+
+Sistema ultra-advanced de inteligencia adaptativa for optimization de rendimiento VQ:
+- Auto-Optimization Engine: Motor de auto-optimization inteligente
+- Performance Prediction AI: prediction inteligente de rendimiento
+- Resource Management Intelligence: Gestión inteligente de recursos
+- Adaptive Algorithm Selection: Selección adaptativa de algoritmos
+- Real-Time Performance Tuning: setting de rendimiento en tiempo real
+- Intelligent Caching Strategy: Estrategia de caché inteligente
+- Dynamic Load Balancing: Balanceamiento dinámico de load
+- Performance Pattern Learning: Aprendizaje de patrones de rendimiento
+
+Revoluciona la optimization VQ with inteligencia adaptativa ultra-avanzada.
+"""
+
+import os
+import sys
+import time
+import logging
+import asyncio
+import numpy as np
+from typing import Dict, Any, Optional, List, Union, Tuple, Callable
+from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from enum import Enum
+import json
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from collections import deque, defaultdict
+import psutil
+import gc
+
+# Path setup
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(script_dir))
+if project_root not in sys.path:
+    pass  # Using proper imports instead of sys.path manipulation
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Safe imports
+# ============================================================================
+
+# JAX and ML libraries
+ML_LIBRARIES_AVAILABLE = True
+try:
+    from capibara.jax import jax, jnp
+    import flax.linen as nn
+    logger.info(" ML libraries available for Adaptive VQ Performance")
+except ImportError as e:
+    logger.debug("ML libraries not available: %s", e)
+    ML_LIBRARIES_AVAILABLE = False
+
+# Ultra VQ System integration
+ULTRA_VQ_AVAILABLE = True
+try:
+    from .ultra_vq_orchestrator import VQModality, VQTechnique, UltraVQConfig
+    from .multi_modal_vq_intelligence import ModalFusionStrategy
+    logger.info(" Ultra VQ System integration available")
+except ImportError as e:
+    logger.debug("Ultra VQ System not available: %s", e)
+    ULTRA_VQ_AVAILABLE = False
+
+# ============================================================================
+# Configuration and Enums
+# ============================================================================
+
+class OptimizationStrategy(str, Enum):
+    """Performance optimization strategies."""
+    THROUGHPUT_FOCUSED = "throughput_focused"        # Maximize throughput
+    LATENCY_FOCUSED = "latency_focused"              # Minimize latency
+    MEMORY_EFFICIENT = "memory_efficient"            # Optimize memory usage
+    ENERGY_EFFICIENT = "energy_efficient"            # Optimize energy consumption
+    BALANCED = "balanced"                            # Balanced optimization
+    ADAPTIVE = "adaptive"                            # Adaptive strategy selection
+    PREDICTIVE = "predictive"                        # Predictive optimization
+    ULTRA_EFFICIENT = "ultra_efficient"             # Ultra-efficient optimization
+
+class ResourceType(str, Enum):
+    """Types of system resources."""
+    CPU = "cpu"
+    MEMORY = "memory"
+    GPU = "gpu"
+    STORAGE = "storage"
+    NETWORK = "network"
+    CACHE = "cache"
+
+class PerformanceObjective(str, Enum):
+    """Performance optimization objectives."""
+    MINIMIZE_LATENCY = "minimize_latency"
+    MAXIMIZE_THROUGHPUT = "maximize_throughput"
+    MINIMIZE_MEMORY = "minimize_memory"
+    MAXIMIZE_QUALITY = "maximize_quality"
+    MINIMIZE_ENERGY = "minimize_energy"
+    MAXIMIZE_EFFICIENCY = "maximize_efficiency"
+    OPTIMIZE_BALANCE = "optimize_balance"
+
+class AdaptationMode(str, Enum):
+    """Adaptation modes for performance intelligence."""
+    REACTIVE = "reactive"                            # React to changes
+    PROACTIVE = "proactive"                         # Anticipate changes
+    PREDICTIVE = "predictive"                       # Predict future needs
+    SELF_LEARNING = "self_learning"                 # Learn from experience
+    EVOLUTIONARY = "evolutionary"                   # Evolve strategies
+    ULTRA_ADAPTIVE = "ultra_adaptive"               # Ultra-adaptive mode
+
+@dataclass
+class AdaptiveVQPerformanceConfig:
+    """Configuration for adaptive VQ performance intelligence."""
+    
+    # Optimization configuration
+    optimization_strategy: OptimizationStrategy = OptimizationStrategy.ULTRA_EFFICIENT
+    performance_objectives: List[PerformanceObjective] = field(default_factory=lambda: [
+        PerformanceObjective.MAXIMIZE_EFFICIENCY,
+        PerformanceObjective.MINIMIZE_LATENCY,
+        PerformanceObjective.MAXIMIZE_QUALITY
+    ])
+    adaptation_mode: AdaptationMode = AdaptationMode.ULTRA_ADAPTIVE
+    
+    # Resource management
+    monitored_resources: List[ResourceType] = field(default_factory=lambda: [
+        ResourceType.CPU, ResourceType.MEMORY, ResourceType.GPU, ResourceType.CACHE
+    ])
+    resource_thresholds: Dict[str, float] = field(default_factory=lambda: {
+        "cpu_usage": 0.8,
+        "memory_usage": 0.85,
+        "gpu_usage": 0.9,
+        "cache_hit_rate": 0.8
+    })
+    
+    # Performance parameters
+    enable_auto_optimization: bool = True
+    enable_performance_prediction: bool = True
+    enable_intelligent_caching: bool = True
+    enable_dynamic_load_balancing: bool = True
+    enable_pattern_learning: bool = True
+    
+    # Adaptation parameters
+    adaptation_frequency: float = 5.0  # Seconds between adaptations
+    learning_rate: float = 0.01
+    prediction_horizon: int = 100  # Steps ahead for prediction
+    
+    # Performance targets
+    target_latency_ms: float = 50.0
+    target_throughput_ops_sec: float = 1000.0
+    target_memory_efficiency: float = 0.9
+    target_quality_score: float = 0.95
+    
+    # Intelligent features
+    enable_anomaly_detection: bool = True
+    enable_adaptive_algorithms: bool = True
+    enable_self_healing: bool = True
+
+@dataclass
+class SystemResourceMetrics:
+    """System resource metrics."""
+    cpu_usage: float = 0.0
+    memory_usage: float = 0.0
+    gpu_usage: float = 0.0
+    storage_usage: float = 0.0
+    network_bandwidth: float = 0.0
+    cache_hit_rate: float = 0.0
+    timestamp: float = 0.0
+
+@dataclass
+class PerformanceMetrics:
+    """VQ performance metrics."""
+    latency_ms: float = 0.0
+    throughput_ops_sec: float = 0.0
+    memory_efficiency: float = 0.0
+    quality_score: float = 0.0
+    energy_efficiency: float = 0.0
+    compression_ratio: float = 0.0
+    error_rate: float = 0.0
+    overall_score: float = 0.0
+
+@dataclass
+class AdaptationState:
+    """State of the adaptive performance system."""
+    current_strategy: OptimizationStrategy = OptimizationStrategy.BALANCED
+    current_objectives: List[PerformanceObjective] = field(default_factory=list)
+    adaptation_history: List[Dict[str, Any]] = field(default_factory=list)
+    performance_history: List[PerformanceMetrics] = field(default_factory=list)
+    resource_history: List[SystemResourceMetrics] = field(default_factory=list)
+    learned_patterns: Dict[str, Any] = field(default_factory=dict)
+    prediction_models: Dict[str, Any] = field(default_factory=dict)
+
+# ============================================================================
+# Adaptive VQ Performance Intelligence System
+# ============================================================================
+
+class AdaptiveVQPerformanceIntelligence:
+    """Sistema ultra-advanced de inteligencia adaptativa for rendimiento VQ."""
+    
+    def __init__(self, config: AdaptiveVQPerformanceConfig):
+        self.config = config
+        self.state = AdaptationState()
+        self.performance_cache = {}
+        self.optimization_cache = {}
+        
+        # Intelligence components
+        self.auto_optimizer = None
+        self.performance_predictor = None
+        self.resource_manager = None
+        self.pattern_learner = None
+        self.anomaly_detector = None
+        
+        # Optimization engines
+        self.algorithm_selector = None
+        self.cache_manager = None
+        self.load_balancer = None
+        
+        # Performance tracking
+        self.global_metrics = {
+            "total_optimizations": 0,
+            "successful_adaptations": 0,
+            "performance_improvements": 0,
+            "resource_savings": 0.0,
+            "prediction_accuracy": 0.0,
+            "system_efficiency": 1.0
+        }
+        
+        # Threading and async management
+        self.executor = ThreadPoolExecutor(max_workers=12)
+        self.performance_lock = threading.Lock()
+        self.monitoring_active = False
+        
+        # Initialize the performance intelligence system
+        self._initialize_performance_intelligence()
+    
+    def _initialize_performance_intelligence(self):
+        """Initialize the adaptive performance intelligence system."""
+        
+        logger.info(" Initializing Adaptive VQ Performance Intelligence")
+        
+        # Initialize auto-optimization engine
+        self._initialize_auto_optimizer()
+        
+        # Initialize performance predictor
+        self._initialize_performance_predictor()
+        
+        # Initialize resource manager
+        self._initialize_resource_manager()
+        
+        # Initialize pattern learner
+        self._initialize_pattern_learner()
+        
+        # Initialize anomaly detector
+        self._initialize_anomaly_detector()
+        
+        # Initialize optimization engines
+        self._initialize_optimization_engines()
+        
+        # Start monitoring loops
+        self._start_monitoring_loops()
+        
+        logger.info(f" Adaptive VQ Performance Intelligence initialized")
+        logger.info(f"    Strategy: {self.config.optimization_strategy.value}")
+        logger.info(f"    Objectives: {len(self.config.performance_objectives)}")
+        logger.info(f"    Adaptation: {self.config.adaptation_mode.value}")
+    
+    def _initialize_auto_optimizer(self):
+        """Initialize auto-optimization engine."""
+        
+        if self.config.enable_auto_optimization:
+            self.auto_optimizer = UltraAutoOptimizer(
+                strategy=self.config.optimization_strategy,
+                objectives=self.config.performance_objectives,
+                learning_rate=self.config.learning_rate
+            )
+            
+            logger.info(" Ultra Auto-Optimizer initialized")
+    
+    def _initialize_performance_predictor(self):
+        """Initialize performance prediction system."""
+        
+        if self.config.enable_performance_prediction:
+            self.performance_predictor = PerformancePredictor(
+                prediction_horizon=self.config.prediction_horizon,
+                monitored_resources=self.config.monitored_resources
+            )
+            
+            logger.info(" Performance Predictor initialized")
+    
+    def _initialize_resource_manager(self):
+        """Initialize intelligent resource manager."""
+        
+        self.resource_manager = IntelligentResourceManager(
+            monitored_resources=self.config.monitored_resources,
+            resource_thresholds=self.config.resource_thresholds,
+            enable_dynamic_balancing=self.config.enable_dynamic_load_balancing
+        )
+        
+        logger.info(" Intelligent Resource Manager initialized")
+    
+    def _initialize_pattern_learner(self):
+        """Initialize pattern learning system."""
+        
+        if self.config.enable_pattern_learning:
+            self.pattern_learner = PerformancePatternLearner(
+                adaptation_mode=self.config.adaptation_mode,
+                learning_rate=self.config.learning_rate
+            )
+            
+            logger.info(" Performance Pattern Learner initialized")
+    
+    def _initialize_anomaly_detector(self):
+        """Initialize anomaly detection system."""
+        
+        if self.config.enable_anomaly_detection:
+            self.anomaly_detector = PerformanceAnomalyDetector(
+                monitored_metrics=["latency", "throughput", "memory", "quality"],
+                detection_sensitivity=0.8
+            )
+            
+            logger.info(" Performance Anomaly Detector initialized")
+    
+    def _initialize_optimization_engines(self):
+        """Initialize optimization engines."""
+        
+        # Algorithm selector
+        if self.config.enable_adaptive_algorithms:
+            self.algorithm_selector = AdaptiveAlgorithmSelector(
+                available_techniques=[t for t in VQTechnique],
+                selection_criteria=self.config.performance_objectives
+            )
+        
+        # cache manager
+        if self.config.enable_intelligent_caching:
+            self.cache_manager = IntelligentCacheManager(
+                cache_size_mb=1024,
+                replacement_strategy="ultra_adaptive"
+            )
+        
+        # Load balancer
+        if self.config.enable_dynamic_load_balancing:
+            self.load_balancer = DynamicLoadBalancer(
+                balancing_strategy="performance_aware",
+                adaptation_threshold=0.1
+            )
+        
+        logger.info(" Optimization engines initialized")
+    
+    def _start_monitoring_loops(self):
+        """Start background monitoring loops."""
+        
+        self.monitoring_active = True
+        
+        # Start resource monitoring
+        asyncio.create_task(self._resource_monitoring_loop())
+        
+        # Start performance monitoring
+        asyncio.create_task(self._performance_monitoring_loop())
+        
+        # Start adaptation loop
+        asyncio.create_task(self._adaptation_loop())
+        
+        logger.info(" Monitoring loops started")
+    
+    async def optimize_vq_performance(
+        self,
+        current_metrics: PerformanceMetrics,
+        workload_characteristics: Dict[str, Any],
+        optimization_target: str = "global_efficiency"
+    ) -> Dict[str, Any]:
+        """Execute adaptive VQ performance optimization."""
+        
+        start_time = time.time()
+        
+        optimization_result = {
+            "optimization_target": optimization_target,
+            "status": "processing",
+            "current_metrics": current_metrics,
+            "workload_characteristics": workload_characteristics,
+            "optimizations_applied": [],
+            "performance_improvements": {},
+            "resource_optimizations": {},
+            "predictive_insights": {}
+        }
+        
+        try:
+            with self.performance_lock:
+                # 1. Analyze current performance
+                performance_analysis = await self._analyze_current_performance(
+                    current_metrics, workload_characteristics
+                )
+                optimization_result["performance_analysis"] = performance_analysis
+                
+                # 2. Predict future performance needs
+                if self.performance_predictor:
+                    prediction_result = await self._predict_performance_needs(
+                        current_metrics, workload_characteristics
+                    )
+                    optimization_result["predictive_insights"] = prediction_result
+                
+                # 3. Select optimal optimization strategy
+                optimal_strategy = await self._select_optimal_strategy(
+                    performance_analysis, workload_characteristics
+                )
+                optimization_result["selected_strategy"] = optimal_strategy.value
+                
+                # 4. Apply auto-optimizations
+                if self.auto_optimizer:
+                    auto_optimizations = await self._apply_auto_optimizations(
+                        current_metrics, optimal_strategy
+                    )
+                    optimization_result["optimizations_applied"].extend(auto_optimizations)
+                
+                # 5. Optimize resource allocation
+                resource_optimization = await self._optimize_resource_allocation(
+                    workload_characteristics, optimal_strategy
+                )
+                optimization_result["resource_optimizations"] = resource_optimization
+                
+                # 6. Apply intelligent caching optimizations
+                if self.cache_manager:
+                    cache_optimization = await self._optimize_caching_strategy(
+                        workload_characteristics
+                    )
+                    optimization_result["cache_optimizations"] = cache_optimization
+                
+                # 7. Learn from optimization results
+                if self.pattern_learner:
+                    learning_insights = await self._learn_from_optimization(
+                        optimization_result
+                    )
+                    optimization_result["learning_insights"] = learning_insights
+                
+                optimization_time = (time.time() - start_time) * 1000
+                optimization_result["optimization_time_ms"] = optimization_time
+                optimization_result["status"] = "completed"
+                
+                # Update global metrics
+                self._update_global_metrics(optimization_result)
+                
+                return optimization_result
+        
+        except Exception as e:
+            logger.error(f"VQ performance optimization failed: {e}")
+            optimization_result["status"] = "failed"
+            optimization_result["error"] = str(e)
+            return optimization_result
+    
+    async def adaptive_algorithm_selection(
+        self,
+        data_characteristics: Dict[str, Any],
+        performance_requirements: Dict[str, float]
+    ) -> Dict[str, Any]:
+        """Execute adaptive algorithm selection based on characteristics."""
+        
+        selection_result = {
+            "data_characteristics": data_characteristics,
+            "performance_requirements": performance_requirements,
+            "recommended_algorithms": [],
+            "selection_reasoning": {},
+            "expected_performance": {}
+        }
+        
+        try:
+            if not self.algorithm_selector:
+                selection_result["error"] = "Algorithm selector not available"
+                return selection_result
+            
+            # Analyze data characteristics
+            analysis = await self._analyze_data_for_algorithm_selection(
+                data_characteristics
+            )
+            selection_result["data_analysis"] = analysis
+            
+            # Select optimal algorithms
+            recommendations = await self.algorithm_selector.select_algorithms(
+                data_characteristics, performance_requirements
+            )
+            selection_result["recommended_algorithms"] = recommendations
+            
+            # Generate selection reasoning
+            reasoning = await self._generate_selection_reasoning(
+                recommendations, data_characteristics, performance_requirements
+            )
+            selection_result["selection_reasoning"] = reasoning
+            
+            # Predict expected performance
+            if self.performance_predictor:
+                performance_prediction = await self._predict_algorithm_performance(
+                    recommendations, data_characteristics
+                )
+                selection_result["expected_performance"] = performance_prediction
+            
+            return selection_result
+            
+        except Exception as e:
+            logger.error(f"Adaptive algorithm selection failed: {e}")
+            selection_result["error"] = str(e)
+            return selection_result
+    
+    async def intelligent_resource_optimization(
+        self,
+        current_usage: SystemResourceMetrics,
+        workload_forecast: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Execute intelligent resource optimization."""
+        
+        resource_result = {
+            "current_usage": current_usage,
+            "workload_forecast": workload_forecast,
+            "optimization_recommendations": {},
+            "resource_adjustments": {},
+            "efficiency_improvements": {}
+        }
+        
+        try:
+            # Analyze current resource utilization
+            utilization_analysis = await self._analyze_resource_utilization(
+                current_usage
+            )
+            resource_result["utilization_analysis"] = utilization_analysis
+            
+            # Generate optimization recommendations
+            if self.resource_manager:
+                recommendations = await self.resource_manager.generate_optimizations(
+                    current_usage, workload_forecast
+                )
+                resource_result["optimization_recommendations"] = recommendations
+            
+            # Apply dynamic load balancing
+            if self.load_balancer:
+                balancing_result = await self._apply_dynamic_load_balancing(
+                    current_usage, workload_forecast
+                )
+                resource_result["load_balancing"] = balancing_result
+            
+            # Optimize memory and cache usage
+            memory_optimization = await self._optimize_memory_usage(
+                current_usage, workload_forecast
+            )
+            resource_result["memory_optimization"] = memory_optimization
+            
+            return resource_result
+            
+        except Exception as e:
+            logger.error(f"Intelligent resource optimization failed: {e}")
+            resource_result["error"] = str(e)
+            return resource_result
+    
+    def get_performance_intelligence_status(self) -> Dict[str, Any]:
+        """Get comprehensive performance intelligence status."""
+        
+        return {
+            "config": {
+                "optimization_strategy": self.config.optimization_strategy.value,
+                "adaptation_mode": self.config.adaptation_mode.value,
+                "performance_objectives": [obj.value for obj in self.config.performance_objectives],
+                "monitored_resources": [res.value for res in self.config.monitored_resources]
+            },
+            "components": {
+                "auto_optimizer": self.auto_optimizer is not None,
+                "performance_predictor": self.performance_predictor is not None,
+                "resource_manager": self.resource_manager is not None,
+                "pattern_learner": self.pattern_learner is not None,
+                "anomaly_detector": self.anomaly_detector is not None,
+                "algorithm_selector": self.algorithm_selector is not None,
+                "cache_manager": self.cache_manager is not None,
+                "load_balancer": self.load_balancer is not None
+            },
+            "state": {
+                "current_strategy": self.state.current_strategy.value,
+                "adaptation_history_size": len(self.state.adaptation_history),
+                "performance_history_size": len(self.state.performance_history),
+                "learned_patterns": len(self.state.learned_patterns)
+            },
+            "capabilities": {
+                "auto_optimization": self.config.enable_auto_optimization,
+                "performance_prediction": self.config.enable_performance_prediction,
+                "intelligent_caching": self.config.enable_intelligent_caching,
+                "dynamic_load_balancing": self.config.enable_dynamic_load_balancing,
+                "pattern_learning": self.config.enable_pattern_learning,
+                "anomaly_detection": self.config.enable_anomaly_detection
+            },
+            "performance": self.global_metrics,
+            "monitoring": {
+                "active": self.monitoring_active,
+                "adaptation_frequency": self.config.adaptation_frequency
+            }
+        }
+    
+    # ============================================================================
+    # Private Helper Methods and Monitoring Loops
+    # ============================================================================
+    
+    async def _resource_monitoring_loop(self):
+        """Background resource monitoring loop."""
+        
+        while self.monitoring_active:
+            try:
+                # Collect resource metrics
+                resource_metrics = await self._collect_resource_metrics()
+                
+                # Store in history
+                self.state.resource_history.append(resource_metrics)
+                if len(self.state.resource_history) > 1000:
+                    self.state.resource_history = self.state.resource_history[-1000:]
+                
+                # Check for resource anomalies
+                if self.anomaly_detector:
+                    await self._check_resource_anomalies(resource_metrics)
+                
+                await asyncio.sleep(self.config.adaptation_frequency)
+                
+            except Exception as e:
+                logger.error(f"Resource monitoring error: {e}")
+                await asyncio.sleep(10)
+    
+    async def _performance_monitoring_loop(self):
+        """Background performance monitoring loop."""
+        
+        while self.monitoring_active:
+            try:
+                # Collect performance metrics
+                performance_metrics = await self._collect_performance_metrics()
+                
+                # Store in history
+                self.state.performance_history.append(performance_metrics)
+                if len(self.state.performance_history) > 1000:
+                    self.state.performance_history = self.state.performance_history[-1000:]
+                
+                # Check for performance anomalies
+                if self.anomaly_detector:
+                    await self._check_performance_anomalies(performance_metrics)
+                
+                await asyncio.sleep(self.config.adaptation_frequency)
+                
+            except Exception as e:
+                logger.error(f"Performance monitoring error: {e}")
+                await asyncio.sleep(10)
+    
+    async def _adaptation_loop(self):
+        """Background adaptation loop."""
+        
+        while self.monitoring_active:
+            try:
+                # Check if adaptation is needed
+                adaptation_needed = await self._check_adaptation_needed()
+                
+                if adaptation_needed:
+                    # Execute adaptation
+                    adaptation_result = await self._execute_adaptation()
+                    
+                    # Store adaptation in history
+                    self.state.adaptation_history.append(adaptation_result)
+                    if len(self.state.adaptation_history) > 100:
+                        self.state.adaptation_history = self.state.adaptation_history[-100:]
+                
+                await asyncio.sleep(self.config.adaptation_frequency * 2)
+                
+            except Exception as e:
+                logger.error(f"Adaptation loop error: {e}")
+                await asyncio.sleep(20)
+    
+    async def _collect_resource_metrics(self) -> SystemResourceMetrics:
+        """Collect current system resource metrics."""
+        
+        return SystemResourceMetrics(
+            cpu_usage=psutil.cpu_percent(interval=0.1),
+            memory_usage=psutil.virtual_memory().percent / 100.0,
+            gpu_usage=0.0,  # Placeholder - would integrate with gpu monitoring
+            storage_usage=psutil.disk_usage('/').percent / 100.0,
+            network_bandwidth=0.0,  # Placeholder
+            cache_hit_rate=0.8,  # Placeholder
+            timestamp=time.time()
+        )
+    
+    async def _collect_performance_metrics(self) -> PerformanceMetrics:
+        """Collect current VQ performance metrics."""
+        
+        # Placeholder implementation - would integrate with current VQ metrics
+        return PerformanceMetrics(
+            latency_ms=np.random.uniform(10, 100),
+            throughput_ops_sec=np.random.uniform(500, 1500),
+            memory_efficiency=np.random.uniform(0.7, 0.95),
+            quality_score=np.random.uniform(0.85, 0.98),
+            energy_efficiency=np.random.uniform(0.8, 0.95),
+            compression_ratio=np.random.uniform(0.05, 0.2),
+            error_rate=np.random.uniform(0.0, 0.05),
+            overall_score=np.random.uniform(0.8, 0.95)
+        )
+    
+    def _update_global_metrics(self, optimization_result: Dict[str, Any]):
+        """Update global performance metrics."""
+        
+        self.global_metrics["total_optimizations"] += 1
+        
+        if optimization_result["status"] == "completed":
+            self.global_metrics["successful_adaptations"] += 1
+            
+            # Update efficiency metrics
+            if "performance_improvements" in optimization_result:
+                self.global_metrics["performance_improvements"] += 1
+
+# ============================================================================
+# Intelligence Components
+# ============================================================================
+
+class UltraAutoOptimizer:
+    """Ultra-advanced auto-optimization engine."""
+    
+    def __init__(self, strategy: OptimizationStrategy, 
+                 objectives: List[PerformanceObjective], learning_rate: float):
+        self.strategy = strategy
+        self.objectives = objectives
+        self.learning_rate = learning_rate
+
+class PerformancePredictor:
+    """Performance prediction system."""
+    
+    def __init__(self, prediction_horizon: int, monitored_resources: List[ResourceType]):
+        self.prediction_horizon = prediction_horizon
+        self.monitored_resources = monitored_resources
+
+class IntelligentResourceManager:
+    """Intelligent resource management system."""
+    
+    def __init__(self, monitored_resources: List[ResourceType], 
+                 resource_thresholds: Dict[str, float], enable_dynamic_balancing: bool):
+        self.monitored_resources = monitored_resources
+        self.resource_thresholds = resource_thresholds
+        self.enable_dynamic_balancing = enable_dynamic_balancing
+    
+    async def generate_optimizations(
+        self, current_usage: SystemResourceMetrics, workload_forecast: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Generate resource optimization recommendations."""
+        return {"optimizations": [], "estimated_improvement": 0.1}
+
+class PerformancePatternLearner:
+    """Performance pattern learning system."""
+    
+    def __init__(self, adaptation_mode: AdaptationMode, learning_rate: float):
+        self.adaptation_mode = adaptation_mode
+        self.learning_rate = learning_rate
+
+class PerformanceAnomalyDetector:
+    """Performance anomaly detection system."""
+    
+    def __init__(self, monitored_metrics: List[str], detection_sensitivity: float):
+        self.monitored_metrics = monitored_metrics
+        self.detection_sensitivity = detection_sensitivity
+
+class AdaptiveAlgorithmSelector:
+    """Adaptive algorithm selection system."""
+    
+    def __init__(self, available_techniques: List[VQTechnique], 
+                 selection_criteria: List[PerformanceObjective]):
+        self.available_techniques = available_techniques
+        self.selection_criteria = selection_criteria
+    
+    async def select_algorithms(
+        self, data_characteristics: Dict[str, Any], 
+        performance_requirements: Dict[str, float]
+    ) -> List[VQTechnique]:
+        """Select optimal algorithms based on characteristics."""
+        return [VQTechnique.ULTRA_HYBRID]
+
+class IntelligentCacheManager:
+    """Intelligent cache management system."""
+    
+    def __init__(self, cache_size_mb: int, replacement_strategy: str):
+        self.cache_size_mb = cache_size_mb
+        self.replacement_strategy = replacement_strategy
+
+class DynamicLoadBalancer:
+    """Dynamic load balancing system."""
+    
+    def __init__(self, balancing_strategy: str, adaptation_threshold: float):
+        self.balancing_strategy = balancing_strategy
+        self.adaptation_threshold = adaptation_threshold
+
+# ============================================================================
+# Factory Functions
+# ============================================================================
+
+def create_adaptive_vq_performance_intelligence(
+    config: Optional[AdaptiveVQPerformanceConfig] = None,
+    **kwargs
+) -> AdaptiveVQPerformanceIntelligence:
+    """Create adaptive VQ performance intelligence system."""
+    
+    if config is None:
+        config = AdaptiveVQPerformanceConfig(**kwargs)
+    
+    return AdaptiveVQPerformanceIntelligence(config)
+
+def create_adaptive_performance_config(
+    optimization_strategy: OptimizationStrategy = OptimizationStrategy.ULTRA_EFFICIENT,
+    adaptation_mode: AdaptationMode = AdaptationMode.ULTRA_ADAPTIVE,
+    enable_all_features: bool = True,
+    **kwargs
+) -> AdaptiveVQPerformanceConfig:
+    """Create optimized adaptive performance configuration."""
+    
+    return AdaptiveVQPerformanceConfig(
+        optimization_strategy=optimization_strategy,
+        adaptation_mode=adaptation_mode,
+        enable_auto_optimization=enable_all_features,
+        enable_performance_prediction=enable_all_features,
+        enable_intelligent_caching=enable_all_features,
+        enable_dynamic_load_balancing=enable_all_features,
+        enable_pattern_learning=enable_all_features,
+        enable_anomaly_detection=enable_all_features,
+        enable_adaptive_algorithms=enable_all_features,
+        enable_self_healing=enable_all_features,
+        **kwargs
+    )
+
+def demonstrate_adaptive_vq_performance_intelligence():
+    """Demonstrate the adaptive VQ performance intelligence system."""
+    
+    logger.info(" ADAPTIVE VQ PERFORMANCE INTELLIGENCE DEMONSTRATION")
+    logger.info("=" * 60)
+    
+    # Create configuration
+    config = create_adaptive_performance_config(
+        optimization_strategy=OptimizationStrategy.ULTRA_EFFICIENT,
+        adaptation_mode=AdaptationMode.ULTRA_ADAPTIVE,
+        enable_all_features=True
+    )
+    
+    logger.info(f" Configuration created:")
+    logger.info(f"   - Strategy: {config.optimization_strategy.value}")
+    logger.info(f"   - Adaptation: {config.adaptation_mode.value}")
+    logger.info(f"   - Objectives: {len(config.performance_objectives)}")
+    
+    # Create performance intelligence system
+    performance_ai = create_adaptive_vq_performance_intelligence(config)
+    
+    # Get system status
+    status = performance_ai.get_performance_intelligence_status()
+    
+    logger.info(f"\n Performance Intelligence Status:")
+    logger.info(f"   - Components: {sum(status['components'].values())}/8")
+    logger.info(f"   - Capabilities: {sum(status['capabilities'].values())}/6")
+    logger.info(f"   - Monitoring: {'' if status['monitoring']['active'] else ''}")
+    
+    return performance_ai
+
+__all__ = [
+    # Configuration and enums
+    'OptimizationStrategy',
+    'ResourceType',
+    'PerformanceObjective',
+    'AdaptationMode',
+    'AdaptiveVQPerformanceConfig',
+    'SystemResourceMetrics',
+    'PerformanceMetrics',
+    'AdaptationState',
+    
+    # Main performance intelligence system
+    'AdaptiveVQPerformanceIntelligence',
+    
+    # Factory functions
+    'create_adaptive_vq_performance_intelligence',
+    'create_adaptive_performance_config',
+    'demonstrate_adaptive_vq_performance_intelligence',
+    
+    # Status flags
+    'ML_LIBRARIES_AVAILABLE',
+    'ULTRA_VQ_AVAILABLE'
+]

--- a/capibara/vq/config/vq_config.py
+++ b/capibara/vq/config/vq_config.py
@@ -1,0 +1,318 @@
+"""
+Configurations for VQ (Vector Quantization) components of CapibaraGPT.
+Includes configurations for blocks, VQ codes, and general parameters.
+"""
+
+import os
+import sys
+import tomli
+import logging
+import numpy as np
+from pathlib import Path
+
+from dataclasses import dataclass
+from pydantic import BaseModel, Field, validator
+from typing import Literal, Dict, Optional, Union, Any
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class ModalityConfig:
+    """Configuration for a specific modality."""
+    codebook_size: int
+    embedding_dim: int
+    adaptive_enabled: bool
+    backend: str
+    
+    def __post_init__(self):
+        """validation post-initialization."""
+        if self.codebook_size <= 0:
+            raise ValueError("codebook_size must be positive")
+        if self.embedding_dim <= 0:
+            raise ValueError("embedding_dim must be positive")
+        if self.backend not in ["jax", "torch", "flax"]:
+            raise ValueError("backend must be one of: jax, torch, flax")
+
+@dataclass
+class BackendConfig:
+    """Configuration for a specific VQ backend."""
+    batch_size: int = 32
+    optimization_level: int = 3
+    precision: str = "bfloat16"
+    memory_efficient: bool = True
+    device: Optional[str] = None
+    compiled: Optional[bool] = None
+    diff_method: Optional[str] = None
+    
+    def __post_init__(self):
+        """validation post-initialization."""
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if not 0 <= self.optimization_level <= 3:
+            raise ValueError("optimization_level must be between 0 and 3")
+        if self.precision not in ["bfloat16", "float32", "float16", "mixed"]:
+            raise ValueError("precision must be one of: bfloat16, float32, float16, mixed")
+
+class VQConfig(BaseModel):
+    """Complete configuration for the VQ module."""
+    
+    # General configuration
+    experimental: bool = True
+    debug_mode: bool = False
+    log_level: str = "INFO"
+
+    # VQbit configuration
+    beta: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description="Commitment factor for VQbit"
+    )
+    decay: float = Field(
+        default=0.99,
+        ge=0.0,
+        le=1.0,
+        description="Decay rate for EMA"
+    )
+    epsilon: float = Field(
+        default=1e-5,
+        gt=0.0,
+        description="Epsilon for numerical stability"
+    )
+
+    # Modality configuration
+    modalities: Dict[str, ModalityConfig]
+
+    # Backend configuration
+    backends: Dict[str, BackendConfig]
+
+    # Training configuration
+    learning_rate: float = Field(
+        default=1e-4,
+        gt=0.0,
+        description="Learning rate"
+    )
+    batch_size: int = Field(
+        default=32,
+        gt=0,
+        description="Batch size"
+    )
+    max_epochs: int = Field(
+        default=100,
+        gt=0,
+        description="Maximum number of epochs"
+    )
+    early_stopping_patience: int = Field(
+        default=10,
+        gt=0,
+        description="Patience for early stopping"
+    )
+    gradient_clip: float = Field(
+        default=1.0,
+        gt=0.0,
+        description="Maximum gradient value"
+    )
+
+    # Metrics configuration
+    track_vq_metrics: bool = True
+    track_vqbit_metrics: bool = True
+    track_performance_metrics: bool = True
+    save_metrics_interval: int = Field(
+        default=100,
+        gt=0,
+        description="Interval for saving metrics"
+    )
+
+    # Optimization configuration
+    use_mixed_precision: bool = True
+    use_gradient_accumulation: bool = True
+    accumulation_steps: int = Field(
+        default=4,
+        gt=0,
+        description="Gradient accumulation steps"
+    )
+    use_amp: bool = True
+
+    # Memory configuration
+    max_memory_usage: str = Field(
+        default="16GB",
+        description="Maximum memory usage"
+    )
+    clear_cache_interval: int = Field(
+        default=1000,
+        gt=0,
+        description="Interval for clearing cache"
+    )
+    use_memory_efficient_attention: bool = True
+
+    # Dimension configuration
+    hidden_size: int = Field(
+        default=512,
+        gt=0,
+        description="Hidden space size"
+    )
+    output_size: int = Field(
+        default=512,
+        gt=0,
+        description="Output size"
+    )
+    
+    @validator('max_memory_usage')
+    def validate_memory_usage(cls, v):
+        """Validates memory usage format."""
+        if not v.endswith(('GB', 'MB')):
+            raise ValueError("max_memory_usage must end with GB or MB")
+        return v
+    
+    @validator('log_level')
+    def validate_log_level(cls, v):
+        """Validates the logging level."""
+        valid_levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+        if v.upper() not in valid_levels:
+            raise ValueError(f"log_level must be one of {valid_levels}")
+        return v.upper()
+    
+    @classmethod
+    def from_toml(cls, config_path: str = "configs_toml/vq.toml") -> "VQConfig":
+        """Loads the configuration from a TOML file."""
+        config_path = Path(config_path)
+        if not config_path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {config_path}")
+            
+        with open(config_path, "rb") as f:
+            config_dict = tomli.load(f)
+            
+        # Load general configuration
+        general = config_dict.get("general", {})
+        vqbit = config_dict.get("vqbit", {})
+
+        # Load modality configuration
+        modalities = {}
+        for name, mod_config in config_dict.get("modalities", {}).items():
+            modalities[name] = ModalityConfig(
+                codebook_size=mod_config["codebook_size"],
+                embedding_dim=mod_config["embedding_dim"],
+                adaptive_enabled=mod_config["adaptive_enabled"],
+                backend=mod_config["backend"]
+            )
+
+        # Load backend configuration
+        backends = {}
+        for name, backend_config in config_dict.get("vq", {}).get("backends", {}).items():
+            backends[name] = BackendConfig(**backend_config)
+
+        # Load training configuration
+        training = config_dict.get("training", {})
+
+        # Load metrics configuration
+        metrics = config_dict.get("metrics", {})
+
+        # Load optimization configuration
+        optimization = config_dict.get("optimization", {})
+
+        # Load memory configuration
+        memory = config_dict.get("memory", {})
+
+        # Build complete configuration
+        config_data = {
+            **general,
+            **vqbit,
+            **training,
+            **metrics,
+            **optimization,
+            **memory,
+            "modalities": modalities,
+            "backends": backends
+        }
+        
+        return cls(**config_data)
+    
+    def get_vqbit_config(self) -> Dict[str, Any]:
+        """Gets the VQbit configuration."""
+        return {
+            "beta": self.beta,
+            "decay": self.decay,
+            "epsilon": self.epsilon,
+            "track_vqbit_metrics": self.track_vqbit_metrics
+        }
+    
+    def get_vq_config(self) -> Dict[str, Any]:
+        """Gets the VQ configuration."""
+        return {
+            "modalities": self.modalities,
+            "backends": self.backends,
+            "track_vq_metrics": self.track_vq_metrics
+        }
+    
+    def get_memory_config(self) -> Dict[str, Any]:
+        """Gets the memory configuration."""
+        return {
+            "max_memory_usage": self.max_memory_usage,
+            "clear_cache_interval": self.clear_cache_interval,
+            "use_memory_efficient_attention": self.use_memory_efficient_attention,
+            "use_mixed_precision": self.use_mixed_precision
+        }
+    
+    def get_training_config(self) -> Dict[str, Any]:
+        """Gets the training configuration."""
+        return {
+            "learning_rate": self.learning_rate,
+            "batch_size": self.batch_size,
+            "max_epochs": self.max_epochs,
+            "early_stopping_patience": self.early_stopping_patience,
+            "gradient_clip": self.gradient_clip
+        }
+    
+    def get_metrics_config(self) -> Dict[str, Any]:
+        """Gets the metrics configuration."""
+        return {
+            "track_vq_metrics": self.track_vq_metrics,
+            "track_vqbit_metrics": self.track_vqbit_metrics,
+            "track_performance_metrics": self.track_performance_metrics,
+            "save_metrics_interval": self.save_metrics_interval
+        }
+
+# Default configurations
+DEFAULT_VQ_CONFIG = VQConfig(
+    modalities={
+        "text": ModalityConfig(
+            codebook_size=512,
+            embedding_dim=128,
+            adaptive_enabled=True,
+            backend="jax"
+        ),
+        "image": ModalityConfig(
+            codebook_size=1024,
+            embedding_dim=256,
+            adaptive_enabled=True,
+            backend="jax"
+        ),
+        "audio": ModalityConfig(
+            codebook_size=256,
+            embedding_dim=64,
+            adaptive_enabled=True,
+            backend="jax"
+        )
+    },
+    backends={
+        "jax": BackendConfig(
+            batch_size=32,
+            optimization_level=3,
+            precision="bfloat16",
+            memory_efficient=True,
+            device="tpu",
+            compiled=True
+        ),
+        "torch": BackendConfig(
+            batch_size=32,
+            optimization_level=2,
+            precision="float32",
+            memory_efficient=True,
+            device="cuda",
+            compiled=False
+        )
+    }
+)
+
+# Legacy configuration for compatibility
+AdaptiveConfig = VQConfig  # Alias for backward compatibility

--- a/capibara/vq/enhanced_vq_system_v2.py
+++ b/capibara/vq/enhanced_vq_system_v2.py
@@ -1,0 +1,780 @@
+"""
+Enhanced VQ System v2.0 for CapibaraGPT
+Advanced production-ready implementation with cutting-edge features
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Tuple, Optional, List, Any, Union, Callable
+from functools import partial
+import json
+import time
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import flax.linen as nn
+from flax import struct
+
+try:
+    from core.decorators import jit_if_available, profile_execution
+except ImportError:
+    jit_if_available = None
+    profile_execution = None
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Enhanced Configuration System
+# ============================================================================
+
+@dataclass
+class EnhancedVQConfig:
+    """Advanced VQ configuration with new features."""
+    
+    # Core VQ parameters
+    num_embeddings: int = 8192
+    embedding_dim: int = 1024
+    commitment_cost: float = 0.25
+    
+    # EMA updates
+    use_ema: bool = True
+    ema_decay: float = 0.99
+    ema_epsilon: float = 1e-5
+    
+    # Advanced quantization features
+    use_cosine_sim: bool = False
+    use_l2_normalize: bool = False
+    dead_code_threshold: int = 100
+    
+    # Gumbel softmax
+    use_gumbel: bool = False
+    temperature: float = 1.0
+    temperature_decay: float = 0.9999
+    min_temperature: float = 0.5
+    
+    # Multi-stage VQ
+    num_stages: int = 1
+    share_codebook: bool = False
+    
+    # NEW: Product Quantization
+    use_product_quantization: bool = False
+    num_subspaces: int = 8
+    subspace_dim: Optional[int] = None  # Will be computed as embedding_dim // num_subspaces
+    
+    # NEW: Learnable codebook initialization
+    learnable_init: bool = True
+    init_method: str = "xavier"  # "xavier", "kaiming", "orthogonal", "normal"
+    
+    # NEW: Adaptive quantization
+    use_adaptive_commitment: bool = False
+    commitment_schedule: str = "constant"  # "constant", "cosine", "linear"
+    min_commitment: float = 0.1
+    max_commitment: float = 1.0
+    
+    # NEW: Entropy regularization
+    use_entropy_loss: bool = False
+    entropy_weight: float = 0.01
+    
+    # NEW: Diversity loss
+    use_diversity_loss: bool = False
+    diversity_weight: float = 0.1
+    
+    # NEW: Vector compression
+    use_compression: bool = False
+    compression_ratio: float = 0.5
+    
+    # Performance and monitoring
+    dtype: jnp.dtype = jnp.float32
+    use_jit: bool = True
+    enable_monitoring: bool = True
+    log_frequency: int = 100
+    
+    # NEW: Experiment tracking
+    experiment_name: Optional[str] = None
+    checkpoint_dir: Optional[str] = None
+    
+    def __post_init__(self):
+        """Validates and compute derived parameters."""
+        if self.subspace_dim is None and self.use_product_quantization:
+            self.subspace_dim = self.embedding_dim // self.num_subspaces
+            if self.embedding_dim % self.num_subspaces != 0:
+                logger.warning(f"embedding_dim ({self.embedding_dim}) not divisible by num_subspaces ({self.num_subspaces})")
+
+# ============================================================================
+# JIT-compiled distance computation (extracted for JIT compatibility)
+# ============================================================================
+
+def _compute_l2_distances(z_flat: jnp.ndarray, embeddings: jnp.ndarray) -> jnp.ndarray:
+    """L2 distance between inputs and embeddings."""
+    return (
+        jnp.sum(z_flat**2, axis=1, keepdims=True) +
+        jnp.sum(embeddings**2, axis=1) -
+        2 * jnp.matmul(z_flat, embeddings.T)
+    )
+
+
+def _compute_cosine_distances(z_flat: jnp.ndarray, embeddings: jnp.ndarray) -> jnp.ndarray:
+    """Cosine distance (negated similarity) between inputs and embeddings."""
+    return -jnp.matmul(z_flat, embeddings.T)
+
+
+# Apply JIT if available
+if jit_if_available is not None:
+    _compute_l2_distances = jit_if_available()(_compute_l2_distances)
+    _compute_cosine_distances = jit_if_available()(_compute_cosine_distances)
+
+
+# ============================================================================
+# Enhanced Vector Quantizer with New Features
+# ============================================================================
+
+class EnhancedVectorQuantizer(nn.Module):
+    """Production-ready VQ with advanced features."""
+    
+    config: EnhancedVQConfig
+    
+    def setup(self):
+        """Initialize enhanced VQ components."""
+        # Main embedding table
+        self._setup_embeddings()
+        
+        # EMA state if enabled
+        if self.config.use_ema:
+            self._setup_ema_state()
+        
+        # Usage and stats tracking
+        self._setup_tracking()
+        
+        # Temperature for Gumbel softmax
+        if self.config.use_gumbel:
+            self._setup_gumbel()
+        
+        # NEW: Product quantization
+        if self.config.use_product_quantization:
+            self._setup_product_quantization()
+        
+        # NEW: Compression layers
+        if self.config.use_compression:
+            self._setup_compression()
+    
+    def _setup_embeddings(self):
+        """Setup main embedding table with learnable initialization."""
+        if self.config.learnable_init:
+            init_fn = self._get_initializer()
+        else:
+            init_fn = nn.initializers.variance_scaling(1.0, 'fan_in', 'normal', out_axis=0)
+        
+        self.embeddings = nn.Embed(
+            num_embeddings=self.config.num_embeddings,
+            features=self.config.embedding_dim,
+            dtype=self.config.dtype,
+            param_dtype=self.config.dtype,
+            embedding_init=init_fn
+        )
+    
+    def _get_initializer(self):
+        """Get the specified initializer."""
+        if self.config.init_method == "xavier":
+            return nn.initializers.xavier_normal()
+        elif self.config.init_method == "kaiming":
+            return nn.initializers.kaiming_normal()
+        elif self.config.init_method == "orthogonal":
+            return nn.initializers.orthogonal()
+        elif self.config.init_method == "normal":
+            return nn.initializers.normal(stddev=0.02)
+        else:
+            return nn.initializers.variance_scaling(1.0, 'fan_in', 'normal', out_axis=0)
+    
+    def _setup_ema_state(self):
+        """Setup EMA state variables."""
+        self.ema_cluster_size = self.variable(
+            'ema', 'cluster_size',
+            lambda: jnp.zeros(self.config.num_embeddings, dtype=self.config.dtype)
+        )
+        self.ema_embeddings = self.variable(
+            'ema', 'embeddings',
+            lambda: self.embeddings.embedding.value.copy()
+        )
+    
+    def _setup_tracking(self):
+        """Setup usage and statistics tracking."""
+        self.usage_count = self.variable(
+            'stats', 'usage_count',
+            lambda: jnp.zeros(self.config.num_embeddings, dtype=jnp.int32)
+        )
+        
+        # NEW: Enhanced tracking
+        if self.config.enable_monitoring:
+            self.step_count = self.variable(
+                'stats', 'step_count',
+                lambda: jnp.array(0, dtype=jnp.int32)
+            )
+            self.perplexity_history = self.variable(
+                'stats', 'perplexity_history',
+                lambda: jnp.zeros(1000, dtype=self.config.dtype)  # Rolling window
+            )
+    
+    def _setup_gumbel(self):
+        """Setup Gumbel softmax temperature."""
+        self.temperature = self.variable(
+            'stats', 'temperature',
+            lambda: jnp.array(self.config.temperature, dtype=self.config.dtype)
+        )
+    
+    def _setup_product_quantization(self):
+        """Setup product quantization components."""
+        if self.config.subspace_dim is None:
+            raise ValueError("subspace_dim must be specified for product quantization")
+        
+        # Separate codebooks for each subspace
+        self.pq_codebooks = []
+        for i in range(self.config.num_subspaces):
+            codebook = nn.Embed(
+                num_embeddings=self.config.num_embeddings,
+                features=self.config.subspace_dim,
+                dtype=self.config.dtype,
+                embedding_init=self._get_initializer()
+            )
+            self.pq_codebooks.append(codebook)
+    
+    def _setup_compression(self):
+        """Setup compression layers."""
+        compressed_dim = int(self.config.embedding_dim * self.config.compression_ratio)
+        
+        self.compression_encoder = nn.Dense(
+            features=compressed_dim,
+            dtype=self.config.dtype,
+            name="compression_encoder"
+        )
+        
+        self.compression_decoder = nn.Dense(
+            features=self.config.embedding_dim,
+            dtype=self.config.dtype,
+            name="compression_decoder"
+        )
+    
+    def quantize(self, z: jnp.ndarray, training: bool = False) -> Tuple[jnp.ndarray, Dict[str, Any]]:
+        """Enhanced quantization with new features."""
+        batch_shape = z.shape[:-1]
+        z_flat = z.reshape(-1, self.config.embedding_dim)
+        
+        # NEW: Apply compression if enabled
+        if self.config.use_compression:
+            z_compressed = self.compression_encoder(z_flat)
+            z_flat = self.compression_decoder(z_compressed)
+        
+        # Product quantization path
+        if self.config.use_product_quantization:
+            return self._product_quantize(z, z_flat, batch_shape, training)
+        
+        # Standard quantization path
+        return self._standard_quantize(z, z_flat, batch_shape, training)
+    
+    def _standard_quantize(self, z: jnp.ndarray, z_flat: jnp.ndarray, 
+                          batch_shape: Tuple, training: bool) -> Tuple[jnp.ndarray, Dict[str, Any]]:
+        """Standard quantization implementation."""
+        # Get embeddings
+        embeddings = self.embeddings.embedding.value
+        if self.config.use_ema and hasattr(self, 'ema_embeddings'):
+            if self.ema_embeddings.value is not None:
+                embeddings = self.ema_embeddings.value
+        
+        # Normalize if configured
+        if self.config.use_l2_normalize:
+            z_flat = z_flat / (jnp.linalg.norm(z_flat, axis=-1, keepdims=True) + 1e-8)
+            embeddings = embeddings / (jnp.linalg.norm(embeddings, axis=-1, keepdims=True) + 1e-8)
+        
+        # Compute distances
+        distances = self._compute_distances(z_flat, embeddings)
+        
+        # Quantization (Gumbel or hard)
+        if self.config.use_gumbel and training:
+            quantized_flat, encoding_indices = self._gumbel_softmax_quantize(distances, embeddings, z_flat)
+        else:
+            encoding_indices = jnp.argmin(distances, axis=1)
+            quantized_flat = embeddings[encoding_indices]
+        
+        # Reshape to original shape
+        quantized = quantized_flat.reshape(z.shape)
+        encoding_indices = encoding_indices.reshape(batch_shape)
+        
+        # Compute losses
+        losses = self._compute_losses(z, quantized, z_flat, encoding_indices, embeddings, distances)
+        
+        # Straight-through estimator
+        quantized = z + jax.lax.stop_gradient(quantized - z)
+        
+        # Updates during training
+        if training:
+            self._perform_updates(z_flat, encoding_indices)
+        
+        # Compute metrics
+        metrics = self._compute_enhanced_metrics(z, quantized, encoding_indices, distances, losses)
+        
+        return quantized, metrics
+    
+    def _product_quantize(self, z: jnp.ndarray, z_flat: jnp.ndarray,
+                         batch_shape: Tuple, training: bool) -> Tuple[jnp.ndarray, Dict[str, Any]]:
+        """Product quantization implementation."""
+        # Split into subspaces
+        subspaces = jnp.split(z_flat, self.config.num_subspaces, axis=-1)
+        
+        quantized_subspaces = []
+        all_indices = []
+        total_loss = 0.0
+        
+        for i, subspace in enumerate(subspaces):
+            # Get subspace codebook
+            codebook = self.pq_codebooks[i].embedding.value
+            
+            # Quantize subspace
+            distances = self._compute_distances(subspace, codebook)
+            indices = jnp.argmin(distances, axis=1)
+            quantized_subspace = codebook[indices]
+            
+            # Compute subspace loss
+            commitment_loss = jnp.mean((subspace - jax.lax.stop_gradient(quantized_subspace))**2)
+            embedding_loss = jnp.mean((jax.lax.stop_gradient(subspace) - quantized_subspace)**2)
+            subspace_loss = embedding_loss + self.config.commitment_cost * commitment_loss
+            
+            total_loss += subspace_loss
+            quantized_subspaces.append(quantized_subspace)
+            all_indices.append(indices)
+        
+        # Concatenate quantized subspaces
+        quantized_flat = jnp.concatenate(quantized_subspaces, axis=-1)
+        quantized = quantized_flat.reshape(z.shape)
+        
+        # Combine indices (for metrics)
+        combined_indices = jnp.stack(all_indices, axis=-1)
+        
+        # Straight-through estimator
+        quantized = z + jax.lax.stop_gradient(quantized - z)
+        
+        # Basic metrics for PQ
+        mse = jnp.mean((z - quantized)**2)
+        metrics = {
+            'loss': total_loss,
+            'mse': float(mse),
+            'pq_loss': float(total_loss),
+            'num_subspaces': self.config.num_subspaces,
+            'mode': 'product_quantization'
+        }
+        
+        return quantized, metrics
+    
+    def _compute_distances(self, z_flat: jnp.ndarray, embeddings: jnp.ndarray) -> jnp.ndarray:
+        """Compute distances between inputs and embeddings."""
+        if self.config.use_cosine_sim:
+            return _compute_cosine_distances(z_flat, embeddings)
+        return _compute_l2_distances(z_flat, embeddings)
+    
+    def _compute_losses(self, z: jnp.ndarray, quantized: jnp.ndarray,
+                       z_flat: jnp.ndarray, encoding_indices: jnp.ndarray,
+                       embeddings: jnp.ndarray, distances: jnp.ndarray) -> Dict[str, float]:
+        """Compute all loss components."""
+        losses = {}
+        
+        # Standard VQ losses
+        if self.config.use_ema:
+            commitment_loss = jnp.mean((z - jax.lax.stop_gradient(quantized))**2)
+            losses['commitment'] = float(commitment_loss)
+            total_loss = self._get_adaptive_commitment() * commitment_loss
+        else:
+            commitment_loss = jnp.mean((z - jax.lax.stop_gradient(quantized))**2)
+            embedding_loss = jnp.mean((jax.lax.stop_gradient(z) - quantized)**2)
+            losses['commitment'] = float(commitment_loss)
+            losses['embedding'] = float(embedding_loss)
+            total_loss = embedding_loss + self._get_adaptive_commitment() * commitment_loss
+        
+        # NEW: Entropy regularization
+        if self.config.use_entropy_loss:
+            entropy_loss = self._compute_entropy_loss(encoding_indices)
+            losses['entropy'] = float(entropy_loss)
+            total_loss += self.config.entropy_weight * entropy_loss
+        
+        # NEW: Diversity loss
+        if self.config.use_diversity_loss:
+            diversity_loss = self._compute_diversity_loss(embeddings, encoding_indices)
+            losses['diversity'] = float(diversity_loss)
+            total_loss += self.config.diversity_weight * diversity_loss
+        
+        losses['total'] = float(total_loss)
+        return losses
+    
+    def _get_adaptive_commitment(self) -> float:
+        """Get adaptive commitment cost."""
+        if not self.config.use_adaptive_commitment:
+            return self.config.commitment_cost
+        
+        if not hasattr(self, 'step_count'):
+            return self.config.commitment_cost
+        
+        step = float(self.step_count.value)
+        
+        if self.config.commitment_schedule == "cosine":
+            # Cosine annealing
+            progress = step / 10000.0  # Assume 10k steps for full cycle
+            factor = 0.5 * (1 + jnp.cos(jnp.pi * progress))
+            commitment = self.config.min_commitment + (self.config.max_commitment - self.config.min_commitment) * factor
+        elif self.config.commitment_schedule == "linear":
+            # Linear decay
+            progress = jnp.minimum(step / 10000.0, 1.0)
+            commitment = self.config.max_commitment - progress * (self.config.max_commitment - self.config.min_commitment)
+        else:
+            commitment = self.config.commitment_cost
+        
+        return float(commitment)
+    
+    def _compute_entropy_loss(self, encoding_indices: jnp.ndarray) -> jnp.ndarray:
+        """Compute entropy regularization loss."""
+        # Compute empirical distribution
+        indices_flat = encoding_indices.reshape(-1)
+        probs = jnp.bincount(indices_flat, length=self.config.num_embeddings) / len(indices_flat)
+        
+        # Compute entropy
+        entropy = -jnp.sum(probs * jnp.log(probs + 1e-10))
+        
+        # We want high entropy, so minimize negative entropy
+        return -entropy
+    
+    def _compute_diversity_loss(self, embeddings: jnp.ndarray, encoding_indices: jnp.ndarray) -> jnp.ndarray:
+        """Compute diversity loss to encourage usage of all codes."""
+        # Get unique indices and their counts
+        indices_flat = encoding_indices.reshape(-1)
+        unique_indices, counts = jnp.unique(indices_flat, return_counts=True, size=self.config.num_embeddings, fill_value=0)
+        
+        # Compute coefficient of variation (std/mean) of usage
+        mean_usage = jnp.mean(counts)
+        std_usage = jnp.std(counts)
+        diversity_loss = std_usage / (mean_usage + 1e-8)
+        
+        return diversity_loss
+    
+    def _gumbel_softmax_quantize(self, distances: jnp.ndarray, embeddings: jnp.ndarray,
+                                z_flat: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+        """Enhanced Gumbel softmax quantization."""
+        temp = self.temperature.value
+        
+        # Convert distances to logits
+        logits = -distances / temp
+        
+        # Add Gumbel noise
+        gumbel_noise = -jnp.log(-jnp.log(jax.random.uniform(
+            self.make_rng('gumbel'),
+            logits.shape,
+            minval=1e-20
+        )))
+        
+        # Gumbel softmax
+        y_soft = jax.nn.softmax((logits + gumbel_noise) / temp, axis=-1)
+        
+        # Soft quantization
+        quantized = jnp.matmul(y_soft, embeddings)
+        
+        # Hard indices for metrics
+        encoding_indices = jnp.argmax(y_soft, axis=-1)
+        
+        # Update temperature
+        new_temp = jnp.maximum(
+            temp * self.config.temperature_decay,
+            self.config.min_temperature
+        )
+        self.temperature.value = new_temp
+        
+        return quantized, encoding_indices
+    
+    def _perform_updates(self, z_flat: jnp.ndarray, encoding_indices: jnp.ndarray):
+        """Perform all training updates."""
+        # EMA updates
+        if self.config.use_ema:
+            self._update_ema(z_flat, encoding_indices)
+        
+        # Usage tracking
+        self._update_usage(encoding_indices)
+        
+        # Step counting
+        if self.config.enable_monitoring and hasattr(self, 'step_count'):
+            self.step_count.value = self.step_count.value + 1
+    
+    def _update_ema(self, z_flat: jnp.ndarray, encoding_indices: jnp.ndarray):
+        """Update EMA statistics."""
+        # One-hot encoding
+        encodings = jax.nn.one_hot(
+            encoding_indices,
+            self.config.num_embeddings,
+            dtype=self.config.dtype
+        )
+        
+        # Update cluster sizes
+        new_cluster_size = jnp.sum(encodings, axis=0)
+        updated_cluster_size = (
+            self.ema_cluster_size.value * self.config.ema_decay +
+            new_cluster_size * (1 - self.config.ema_decay)
+        )
+        
+        # Update embeddings
+        dw = jnp.matmul(encodings.T, z_flat)
+        updated_embeddings = (
+            self.ema_embeddings.value * self.config.ema_decay +
+            dw * (1 - self.config.ema_decay)
+        )
+        
+        # Laplace smoothing
+        n = jnp.sum(updated_cluster_size)
+        updated_cluster_size = (
+            (updated_cluster_size + self.config.ema_epsilon) /
+            (n + self.config.num_embeddings * self.config.ema_epsilon) * n
+        )
+        
+        # Normalize embeddings
+        normalized_embeddings = updated_embeddings / (updated_cluster_size[:, None] + 1e-8)
+        
+        # Update variables
+        self.ema_cluster_size.value = updated_cluster_size
+        self.ema_embeddings.value = normalized_embeddings
+        self.embeddings.embedding.value = normalized_embeddings
+    
+    def _update_usage(self, encoding_indices: jnp.ndarray):
+        """Update usage statistics and handle dead codes."""
+        # Count usage
+        usage = jnp.bincount(
+            encoding_indices.reshape(-1),
+            minlength=self.config.num_embeddings,
+            length=self.config.num_embeddings
+        )
+        self.usage_count.value = self.usage_count.value + usage
+        
+        # Check for dead code reinitialization
+        total_usage = jnp.sum(self.usage_count.value)
+        if total_usage > 0 and total_usage % (self.config.dead_code_threshold * self.config.num_embeddings) == 0:
+            self._reinit_dead_codes()
+    
+    def _reinit_dead_codes(self):
+        """Reinitialize dead codes with improved strategy."""
+        dead_codes = self.usage_count.value == 0
+        num_dead = jnp.sum(dead_codes)
+        
+        if num_dead > 0:
+            logger.info(f"Reinitializing {num_dead} dead codes")
+            
+            live_indices = jnp.where(~dead_codes)[0]
+            if len(live_indices) > 0:
+                rng = self.make_rng('reinit')
+                
+                # NEW: Improved reinitialization strategy
+                # Sample from high-usage codes with added noise
+                usage_probs = self.usage_count.value[live_indices] / jnp.sum(self.usage_count.value[live_indices])
+                selected = jax.random.choice(rng, live_indices, shape=(num_dead,), p=usage_probs)
+                
+                # Add more noise for better diversity
+                noise_scale = 0.1  # Increased from 0.01
+                noise = jax.random.normal(rng, (num_dead, self.config.embedding_dim)) * noise_scale
+                
+                new_embeddings = self.embeddings.embedding.value[selected] + noise
+                
+                # Update dead codes
+                dead_indices = jnp.where(dead_codes)[0]
+                self.embeddings.embedding.value = self.embeddings.embedding.value.at[dead_indices].set(new_embeddings)
+                
+                if self.config.use_ema:
+                    self.ema_embeddings.value = self.ema_embeddings.value.at[dead_indices].set(new_embeddings)
+            
+            # Reset usage counts
+            self.usage_count.value = jnp.zeros_like(self.usage_count.value)
+    
+    def _compute_enhanced_metrics(self, z: jnp.ndarray, quantized: jnp.ndarray,
+                                 encoding_indices: jnp.ndarray, distances: jnp.ndarray,
+                                 losses: Dict[str, float]) -> Dict[str, Any]:
+        """Compute enhanced metrics with new features."""
+        # Basic metrics
+        mse = jnp.mean((z - quantized)**2)
+        
+        # Perplexity
+        encodings = jax.nn.one_hot(encoding_indices.reshape(-1), self.config.num_embeddings)
+        avg_probs = jnp.mean(encodings, axis=0)
+        perplexity = jnp.exp(-jnp.sum(avg_probs * jnp.log(avg_probs + 1e-10)))
+        
+        # Usage statistics
+        unique_codes = jnp.unique(encoding_indices).shape[0]
+        usage_rate = unique_codes / self.config.num_embeddings
+        
+        # Distance statistics
+        min_distances = jnp.min(distances, axis=1)
+        
+        # NEW: Enhanced metrics
+        metrics = {
+            'mse': float(mse),
+            'perplexity': float(perplexity),
+            'usage_rate': float(usage_rate),
+            'unique_codes': int(unique_codes),
+            'mean_distance': float(jnp.mean(min_distances)),
+            'std_distance': float(jnp.std(min_distances)),
+            'temperature': float(self.temperature.value) if self.config.use_gumbel else 1.0,
+            'commitment_cost': self._get_adaptive_commitment(),
+            **losses  # Include all loss components
+        }
+        
+        # Add step count if monitoring enabled
+        if self.config.enable_monitoring and hasattr(self, 'step_count'):
+            metrics['step'] = int(self.step_count.value)
+            
+            # Update perplexity history
+            step = self.step_count.value % 1000
+            self.perplexity_history.value = self.perplexity_history.value.at[step].set(perplexity)
+            
+            # Rolling average perplexity
+            metrics['avg_perplexity'] = float(jnp.mean(self.perplexity_history.value))
+        
+        return metrics
+    
+    def __call__(self, inputs: jnp.ndarray, training: bool = False) -> Tuple[jnp.ndarray, Dict[str, Any]]:
+        """Main forward pass."""
+        return self.quantize(inputs, training)
+
+# ============================================================================
+# Enhanced Factory Functions
+# ============================================================================
+
+def create_enhanced_vq_layer(
+    num_embeddings: int = 8192,
+    embedding_dim: int = 1024,
+    use_ema: bool = True,
+    use_product_quantization: bool = False,
+    num_subspaces: int = 8,
+    use_adaptive_commitment: bool = False,
+    use_entropy_loss: bool = False,
+    use_diversity_loss: bool = False,
+    experiment_name: Optional[str] = None,
+    **kwargs
+) -> EnhancedVectorQuantizer:
+    """Creates enhanced VQ layer with new features."""
+    config = EnhancedVQConfig(
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        use_ema=use_ema,
+        use_product_quantization=use_product_quantization,
+        num_subspaces=num_subspaces,
+        use_adaptive_commitment=use_adaptive_commitment,
+        use_entropy_loss=use_entropy_loss,
+        use_diversity_loss=use_diversity_loss,
+        experiment_name=experiment_name,
+        **kwargs
+    )
+    return EnhancedVectorQuantizer(config)
+
+# ============================================================================
+# Benchmark and Comparison Tools
+# ============================================================================
+
+def benchmark_vq_variants():
+    """Benchmark different VQ configurations."""
+    import time
+    
+    key = jax.random.PRNGKey(42)
+    x = jax.random.normal(key, (4, 32, 256))
+    
+    configs = [
+        ("Standard VQ", {"use_ema": True}),
+        ("Product VQ", {"use_product_quantization": True, "num_subspaces": 4}),
+        ("Adaptive VQ", {"use_adaptive_commitment": True, "use_entropy_loss": True}),
+        ("Diversity VQ", {"use_diversity_loss": True, "use_entropy_loss": True}),
+        ("Gumbel VQ", {"use_gumbel": True, "temperature": 1.0}),
+    ]
+    
+    results = {}
+    
+    for name, config_kwargs in configs:
+        logger.info(f"\n Benchmarking {name}...")
+        
+        try:
+            vq = create_enhanced_vq_layer(
+                num_embeddings=512,
+                embedding_dim=256,
+                **config_kwargs
+            )
+            
+            params = vq.init(key, x)
+            
+            # Warmup
+            _ = vq.apply(params, x, training=True)
+            
+            # Benchmark
+            start_time = time.time()
+            for _ in range(10):
+                quantized, metrics = vq.apply(params, x, training=True)
+            elapsed = (time.time() - start_time) / 10
+            
+            results[name] = {
+                'time_ms': elapsed * 1000,
+                'perplexity': metrics['perplexity'],
+                'usage_rate': metrics['usage_rate'],
+                'mse': metrics['mse']
+            }
+            
+            logger.info(f"   Time: {elapsed*1000:.2f}ms")
+            logger.info(f"   Perplexity: {metrics['perplexity']:.2f}")
+            logger.info(f"   Usage: {metrics['usage_rate']:.2%}")
+            logger.info(f"   MSE: {metrics['mse']:.6f}")
+            
+        except Exception as e:
+            logger.error(f"    Failed: {e}")
+            results[name] = {"error": str(e)}
+    
+    return results
+
+# ============================================================================
+# Usage Example with Enhanced Features
+# ============================================================================
+
+def enhanced_example_usage():
+    """Demonstrate enhanced VQ system features."""
+    logger.info(" Enhanced VQ System v2.0 Demo")
+    logger.info("=" * 60)
+    
+    key = jax.random.PRNGKey(42)
+    
+    # 1. Enhanced Standard VQ with new features
+    logger.info("\n1️⃣ Enhanced VQ with Adaptive Commitment:")
+    vq = create_enhanced_vq_layer(
+        num_embeddings=1024,
+        embedding_dim=256,
+        use_adaptive_commitment=True,
+        use_entropy_loss=True,
+        use_diversity_loss=True,
+        experiment_name="enhanced_demo"
+    )
+    
+    x = jax.random.normal(key, (4, 32, 256))
+    params = vq.init(key, x)
+    
+    quantized, metrics = vq.apply(params, x, training=True)
+    logger.info(f"   Enhanced metrics: {len(metrics)} tracked")
+    logger.info(f"   Adaptive commitment: {metrics['commitment_cost']:.3f}")
+    logger.info(f"   Total loss: {metrics['total']:.6f}")
+    
+    # 2. Product Quantization
+    logger.info("\n2️⃣ Product Quantization:")
+    pq_vq = create_enhanced_vq_layer(
+        num_embeddings=256,
+        embedding_dim=256,
+        use_product_quantization=True,
+        num_subspaces=8,
+        experiment_name="pq_demo"
+    )
+    
+    params_pq = pq_vq.init(key, x)
+    quantized_pq, metrics_pq = pq_vq.apply(params_pq, x, training=True)
+    logger.info(f"   PQ subspaces: {metrics_pq['num_subspaces']}")
+    logger.info(f"   PQ loss: {metrics_pq['pq_loss']:.6f}")
+    
+    # 3. Run benchmarks
+    logger.info("\n3️⃣ Benchmarking VQ variants...")
+    benchmark_results = benchmark_vq_variants()
+    
+    logger.info("\n Enhanced VQ Demo completed!")
+    return benchmark_results
+
+if __name__ == "__main__":
+    enhanced_example_usage()

--- a/capibara/vq/intelligent_vq_integration.py
+++ b/capibara/vq/intelligent_vq_integration.py
@@ -1,0 +1,635 @@
+"""
+Intelligent VQ Integration System
+Advanced integration layer that unifies all VQ capabilities in CapibaraGPT
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Tuple, Optional, List, Any, Union, Callable
+from functools import partial
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import flax.linen as nn
+from flax import struct
+
+# Import our enhanced VQ system
+from .enhanced_vq_system_v2 import (
+    EnhancedVectorQuantizer,
+    EnhancedVQConfig,
+    create_enhanced_vq_layer,
+    benchmark_vq_variants
+)
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Intelligent VQ Manager
+# ============================================================================
+
+@dataclass
+class VQManagerConfig:
+    """Configurestion for the VQ Manager."""
+    
+    # System selection
+    auto_select_vq: bool = True
+    default_vq_system: str = "enhanced"  # "enhanced", "legacy", "adaptive"
+    
+    # Performance thresholds for auto-selection
+    max_latency_ms: float = 10.0
+    min_perplexity: float = 50.0
+    min_usage_rate: float = 0.1
+    
+    # Integration settings
+    enable_fallback: bool = True
+    enable_monitoring: bool = True
+    enable_benchmarking: bool = True
+    
+    # Caching and optimization
+    cache_configurations: bool = True
+    enable_jit_compilation: bool = True
+    
+    # Experiment tracking
+    log_performance: bool = True
+    experiment_tracking: bool = False
+
+class IntelligentVQManager:
+    """
+    Intelligent VQ Manager that automatically selects and optimizes VQ configurations
+    based on use case, performance requirements, and hardware constraints.
+    """
+    
+    def __init__(self, config: VQManagerConfig):
+        self.config = config
+        self.performance_cache = {}
+        self.configuration_cache = {}
+        self.usage_stats = {
+            'enhanced': 0,
+            'legacy': 0,
+            'product': 0,
+            'adaptive': 0
+        }
+        
+        # Initialize available VQ systems
+        self._initialize_vq_systems()
+    
+    def _initialize_vq_systems(self):
+        """Initialize all available VQ systems."""
+        self.vq_systems = {
+            'enhanced_standard': {
+                'factory': create_enhanced_vq_layer,
+                'config': {'use_ema': True, 'use_adaptive_commitment': False},
+                'description': 'Enhanced standard VQ with EMA updates',
+                'use_cases': ['general', 'fast_inference', 'stable_training']
+            },
+            'enhanced_adaptive': {
+                'factory': create_enhanced_vq_layer,
+                'config': {
+                    'use_ema': True, 
+                    'use_adaptive_commitment': True,
+                    'use_entropy_loss': True,
+                    'use_diversity_loss': True
+                },
+                'description': 'Adaptive VQ with entropy and diversity regularization',
+                'use_cases': ['research', 'high_quality', 'codebook_optimization']
+            },
+            'product_quantization': {
+                'factory': create_enhanced_vq_layer,
+                'config': {
+                    'use_product_quantization': True,
+                    'num_subspaces': 8,
+                    'use_ema': True
+                },
+                'description': 'Product quantization for memory efficiency',
+                'use_cases': ['large_scale', 'memory_constrained', 'compression']
+            },
+            'gumbel_differentiable': {
+                'factory': create_enhanced_vq_layer,
+                'config': {
+                    'use_gumbel': True,
+                    'temperature': 1.0,
+                    'use_ema': True
+                },
+                'description': 'Differentiable VQ with Gumbel softmax',
+                'use_cases': ['end_to_end_training', 'gradient_flow', 'research']
+            },
+            'compression_optimized': {
+                'factory': create_enhanced_vq_layer,
+                'config': {
+                    'use_compression': True,
+                    'compression_ratio': 0.5,
+                    'use_ema': True
+                },
+                'description': 'VQ with neural compression layers',
+                'use_cases': ['bandwidth_limited', 'storage_optimization']
+            }
+        }
+    
+    def auto_select_vq(self, 
+                      use_case: str,
+                      num_embeddings: int = 8192,
+                      embedding_dim: int = 1024,
+                      performance_requirements: Optional[Dict[str, float]] = None,
+                      **kwargs) -> Tuple[nn.Module, Dict[str, Any]]:
+        """
+        Automatically select the best VQ configuration for the given use case.
+        
+        Args:
+            use_case: Use case identifier ('general', 'research', 'large_scale', etc.)
+            num_embeddings: Number of embeddings in codebook
+            embedding_dim: Embedding dimension
+            performance_requirements: Dict with 'max_latency_ms', 'min_perplexity', etc.
+            **kwargs: Additional configuration parameters
+            
+        Returns:
+            Tuple of (vq_module, selection_info)
+        """
+        if not self.config.auto_select_vq:
+            # Use default system
+            return self._create_vq_system(
+                self.config.default_vq_system,
+                num_embeddings,
+                embedding_dim,
+                **kwargs
+            )
+        
+        # Merge performance requirements
+        perf_reqs = {
+            'max_latency_ms': self.config.max_latency_ms,
+            'min_perplexity': self.config.min_perplexity,
+            'min_usage_rate': self.config.min_usage_rate,
+        }
+        if performance_requirements:
+            perf_reqs.update(performance_requirements)
+        
+        # Find matching VQ systems
+        candidates = self._find_candidate_systems(use_case, perf_reqs)
+        
+        if not candidates:
+            logger.warning(f"No VQ systems found for use case '{use_case}', using default")
+            return self._create_vq_system(
+                'enhanced_standard',
+                num_embeddings,
+                embedding_dim,
+                **kwargs
+            )
+        
+        # Benchmark candidates if enabled
+        if self.config.enable_benchmarking and len(candidates) > 1:
+            best_system = self._benchmark_candidates(
+                candidates, 
+                num_embeddings, 
+                embedding_dim, 
+                perf_reqs,
+                **kwargs
+            )
+        else:
+            best_system = candidates[0]
+        
+        # Create and return the selected system
+        vq_module, creation_info = self._create_vq_system(
+            best_system,
+            num_embeddings,
+            embedding_dim,
+            **kwargs
+        )
+        
+        # Track usage
+        self.usage_stats[best_system] += 1
+        
+        selection_info = {
+            'selected_system': best_system,
+            'candidates': candidates,
+            'use_case': use_case,
+            'performance_requirements': perf_reqs,
+            **creation_info
+        }
+        
+        return vq_module, selection_info
+    
+    def _find_candidate_systems(self, use_case: str, perf_reqs: Dict[str, float]) -> List[str]:
+        """Find VQ systems that match the use case and performance requirements."""
+        candidates = []
+        
+        for system_name, system_info in self.vq_systems.items():
+            # Check if use case matches
+            if use_case in system_info['use_cases'] or 'general' in system_info['use_cases']:
+                candidates.append(system_name)
+        
+        # Apply performance-based filtering
+        if perf_reqs['max_latency_ms'] < 5.0:
+            # Remove slow systems for low-latency requirements
+            candidates = [c for c in candidates if 'product_quantization' not in c]
+        
+        if perf_reqs.get('memory_constrained', False):
+            # Prioritize memory-efficient systems
+            if 'product_quantization' in candidates:
+                candidates = ['product_quantization'] + [c for c in candidates if c != 'product_quantization']
+        
+        return candidates or ['enhanced_standard']  # Always have a fallback
+    
+    def _benchmark_candidates(self, 
+                            candidates: List[str],
+                            num_embeddings: int,
+                            embedding_dim: int,
+                            perf_reqs: Dict[str, float],
+                            **kwargs) -> str:
+        """Benchmark candidate systems and select the best one."""
+        import time
+        
+        # Check cache first
+        cache_key = (tuple(candidates), num_embeddings, embedding_dim, tuple(sorted(kwargs.items())))
+        if cache_key in self.performance_cache:
+            return self.performance_cache[cache_key]
+        
+        # Create test data
+        key = jax.random.PRNGKey(42)
+        test_data = jax.random.normal(key, (2, 16, embedding_dim))
+        
+        best_system = candidates[0]
+        best_score = float('-inf')
+        benchmark_results = {}
+        
+        for system_name in candidates:
+            try:
+                # Create VQ system
+                vq_module, _ = self._create_vq_system(
+                    system_name, 
+                    num_embeddings, 
+                    embedding_dim,
+                    **kwargs
+                )
+                
+                # Initialize
+                params = vq_module.init(key, test_data)
+                
+                # Warmup
+                _ = vq_module.apply(params, test_data, training=True)
+                
+                # Benchmark performance
+                start_time = time.time()
+                quantized, metrics = vq_module.apply(params, test_data, training=True)
+                latency_ms = (time.time() - start_time) * 1000
+                
+                # Compute score based on requirements
+                score = self._compute_performance_score(
+                    latency_ms, 
+                    metrics, 
+                    perf_reqs
+                )
+                
+                benchmark_results[system_name] = {
+                    'latency_ms': latency_ms,
+                    'metrics': metrics,
+                    'score': score
+                }
+                
+                if score > best_score:
+                    best_score = score
+                    best_system = system_name
+                
+                logger.info(f"Benchmarked {system_name}: latency={latency_ms:.2f}ms, score={score:.3f}")
+                
+            except Exception as e:
+                logger.warning(f"Failed to benchmark {system_name}: {e}")
+                benchmark_results[system_name] = {'error': str(e)}
+        
+        # Cache result
+        if self.config.cache_configurations:
+            self.performance_cache[cache_key] = best_system
+        
+        return best_system
+    
+    def _compute_performance_score(self, 
+                                 latency_ms: float,
+                                 metrics: Dict[str, Any],
+                                 perf_reqs: Dict[str, float]) -> float:
+        """Compute a performance score for ranking VQ systems."""
+        score = 0.0
+        
+        # Latency component (lower is better)
+        if latency_ms <= perf_reqs['max_latency_ms']:
+            score += 1.0 - (latency_ms / perf_reqs['max_latency_ms'])
+        else:
+            score -= (latency_ms - perf_reqs['max_latency_ms']) / perf_reqs['max_latency_ms']
+        
+        # Perplexity component (higher is better)
+        perplexity = metrics.get('perplexity', 0)
+        if perplexity >= perf_reqs['min_perplexity']:
+            score += min(perplexity / 100.0, 1.0)  # Cap at 1.0
+        else:
+            score -= (perf_reqs['min_perplexity'] - perplexity) / perf_reqs['min_perplexity']
+        
+        # Usage rate component (higher is better)
+        usage_rate = metrics.get('usage_rate', 0)
+        if usage_rate >= perf_reqs['min_usage_rate']:
+            score += usage_rate
+        else:
+            score -= (perf_reqs['min_usage_rate'] - usage_rate) * 2
+        
+        # MSE component (lower is better)
+        mse = metrics.get('mse', 1.0)
+        score += max(0, 1.0 - mse * 10)  # Penalize high MSE
+        
+        return score
+    
+    def _create_vq_system(self, 
+                         system_name: str,
+                         num_embeddings: int,
+                         embedding_dim: int,
+                         **kwargs) -> Tuple[nn.Module, Dict[str, Any]]:
+        """Creates a VQ system instance."""
+        if system_name not in self.vq_systems:
+            raise ValueError(f"Unknown VQ system: {system_name}")
+        
+        system_info = self.vq_systems[system_name]
+        
+        # Merge configurations
+        config = {
+            'num_embeddings': num_embeddings,
+            'embedding_dim': embedding_dim,
+            **system_info['config'],
+            **kwargs
+        }
+        
+        # Add experiment tracking if enabled
+        if self.config.experiment_tracking:
+            config['experiment_name'] = f"{system_name}_{num_embeddings}_{embedding_dim}"
+            config['enable_monitoring'] = True
+        
+        # Create VQ module
+        vq_module = system_info['factory'](**config)
+        
+        creation_info = {
+            'system_name': system_name,
+            'description': system_info['description'],
+            'config': config,
+            'use_cases': system_info['use_cases']
+        }
+        
+        return vq_module, creation_info
+    
+    def get_usage_statistics(self) -> Dict[str, Any]:
+        """Get usage statistics for all VQ systems."""
+        total_usage = sum(self.usage_stats.values())
+        
+        stats = {
+            'total_creations': total_usage,
+            'system_usage': self.usage_stats.copy(),
+            'system_percentages': {
+                name: (count / total_usage * 100) if total_usage > 0 else 0
+                for name, count in self.usage_stats.items()
+            },
+            'available_systems': list(self.vq_systems.keys()),
+            'cache_size': len(self.performance_cache)
+        }
+        
+        return stats
+    
+    def get_recommended_config(self, use_case: str) -> Dict[str, Any]:
+        """Get recommended configuration for a use case without creating the system."""
+        candidates = self._find_candidate_systems(use_case, {
+            'max_latency_ms': self.config.max_latency_ms,
+            'min_perplexity': self.config.min_perplexity,
+            'min_usage_rate': self.config.min_usage_rate
+        })
+        
+        recommended_system = candidates[0] if candidates else 'enhanced_standard'
+        
+        return {
+            'recommended_system': recommended_system,
+            'candidates': candidates,
+            'system_info': self.vq_systems.get(recommended_system, {}),
+            'use_case': use_case
+        }
+    
+    def benchmark_all_systems(self, 
+                            num_embeddings: int = 1024,
+                            embedding_dim: int = 256) -> Dict[str, Any]:
+        """Benchmark all available VQ systems."""
+        return benchmark_vq_variants()
+
+# ============================================================================
+# High-level API for Easy Usage
+# ============================================================================
+
+# Global VQ manager instance
+_global_vq_manager = None
+
+def get_vq_manager(config: Optional[VQManagerConfig] = None) -> IntelligentVQManager:
+    """Get the global VQ manager instance."""
+    global _global_vq_manager
+    
+    if _global_vq_manager is None or config is not None:
+        if config is None:
+            config = VQManagerConfig()
+        _global_vq_manager = IntelligentVQManager(config)
+    
+    return _global_vq_manager
+
+def create_optimal_vq(use_case: str = "general",
+                     num_embeddings: int = 8192,
+                     embedding_dim: int = 1024,
+                     performance_requirements: Optional[Dict[str, float]] = None,
+                     **kwargs) -> Tuple[nn.Module, Dict[str, Any]]:
+    """
+    Create an optimal VQ system for the given use case.
+    
+    Args:
+        use_case: One of 'general', 'research', 'large_scale', 'memory_constrained',
+                 'fast_inference', 'high_quality', 'compression', 'end_to_end_training'
+        num_embeddings: Number of embeddings in codebook
+        embedding_dim: Embedding dimension
+        performance_requirements: Dict with performance constraints
+        **kwargs: Additional VQ configuration parameters
+        
+    Returns:
+        Tuple of (vq_module, selection_info)
+        
+    Examples:
+        # General purpose VQ
+        vq, info = create_optimal_vq("general", 4096, 512)
+        
+        # Research with high quality requirements
+        vq, info = create_optimal_vq(
+            "research", 
+            8192, 
+            1024,
+            performance_requirements={'min_perplexity': 100.0}
+        )
+        
+        # Memory-constrained deployment
+        vq, info = create_optimal_vq("memory_constrained", 2048, 256)
+    """
+    manager = get_vq_manager()
+    return manager.auto_select_vq(
+        use_case=use_case,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        performance_requirements=performance_requirements,
+        **kwargs
+    )
+
+def get_vq_recommendations(use_case: str) -> Dict[str, Any]:
+    """Get VQ system recommendations for a use case."""
+    manager = get_vq_manager()
+    return manager.get_recommended_config(use_case)
+
+def get_vq_usage_stats() -> Dict[str, Any]:
+    """Get usage statistics for VQ systems."""
+    manager = get_vq_manager()
+    return manager.get_usage_statistics()
+
+# ============================================================================
+# Integration with Existing CapibaraGPT Systems
+# ============================================================================
+
+class CapibaraVQIntegration:
+    """Integration layer for CapibaraGPT's existing VQ systems."""
+    
+    def __init__(self):
+        self.manager = get_vq_manager()
+        self.legacy_systems = self._load_legacy_systems()
+    
+    def _load_legacy_systems(self) -> Dict[str, Any]:
+        """Load existing VQ systems from CapibaraGPT."""
+        legacy = {}
+        
+        try:
+            # Try to import existing VQ components
+            from . import ultra_vq_orchestrator
+            legacy['ultra_orchestrator'] = ultra_vq_orchestrator
+        except ImportError:
+            pass
+        
+        try:
+            from . import vqbit_layer
+            legacy['vqbit'] = vqbit_layer
+        except ImportError:
+            pass
+        
+        try:
+            from . import multi_modal_vq_intelligence
+            legacy['multimodal'] = multi_modal_vq_intelligence
+        except ImportError:
+            pass
+        
+        return legacy
+    
+    def create_unified_vq(self, 
+                         use_case: str = "general",
+                         prefer_legacy: bool = False,
+                         **kwargs) -> Tuple[nn.Module, Dict[str, Any]]:
+        """
+        Create a unified VQ system that can fall back to legacy systems.
+        
+        Args:
+            use_case: VQ use case
+            prefer_legacy: Whether to prefer legacy systems
+            **kwargs: VQ configuration parameters
+            
+        Returns:
+            Tuple of (vq_module, system_info)
+        """
+        if prefer_legacy and self.legacy_systems:
+            # Try to use legacy systems first
+            logger.info("Using legacy VQ system as requested")
+            # Implementation would depend on legacy system APIs
+            pass
+        
+        # Use enhanced VQ system
+        return create_optimal_vq(use_case=use_case, **kwargs)
+    
+    def migrate_legacy_config(self, legacy_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Migrate legacy VQ configuration to enhanced system."""
+        enhanced_config = {}
+        
+        # Map common parameters
+        mapping = {
+            'codebook_size': 'num_embeddings',
+            'embedding_size': 'embedding_dim',
+            'beta': 'commitment_cost',
+            'use_exponential_moving_average': 'use_ema',
+            'ema_decay_rate': 'ema_decay'
+        }
+        
+        for legacy_key, enhanced_key in mapping.items():
+            if legacy_key in legacy_config:
+                enhanced_config[enhanced_key] = legacy_config[legacy_key]
+        
+        return enhanced_config
+
+# ============================================================================
+# Usage Examples and Demonstrations
+# ============================================================================
+
+def demo_intelligent_integration():
+    """Demonstrate the intelligent VQ integration system."""
+    logger.info(" Intelligent VQ Integration Demo")
+    logger.info("=" * 50)
+    
+    # 1. Auto-selection for different use cases
+    logger.info("\n1️⃣ Auto-selection for different use cases:")
+    
+    use_cases = [
+        ("general", "General purpose AI model"),
+        ("research", "Research with high quality requirements"),
+        ("memory_constrained", "Mobile/edge deployment"),
+        ("large_scale", "Large language model training"),
+        ("fast_inference", "Real-time inference"),
+    ]
+    
+    for use_case, description in use_cases:
+        logger.info(f"\n {use_case.upper()}: {description}")
+        
+        try:
+            vq, info = create_optimal_vq(
+                use_case=use_case,
+                num_embeddings=1024,
+                embedding_dim=256
+            )
+            
+            logger.info(f"    Selected: {info['selected_system']}")
+            logger.info(f"    Description: {info['description']}")
+            logger.info(f"    Candidates: {', '.join(info['candidates'])}")
+            
+        except Exception as e:
+            logger.error(f"    Error: {e}")
+    
+    # 2. Performance requirements
+    logger.info(f"\n2️⃣ Performance-constrained selection:")
+    
+    vq, info = create_optimal_vq(
+        use_case="general",
+        num_embeddings=2048,
+        embedding_dim=512,
+        performance_requirements={
+            'max_latency_ms': 2.0,  # Very strict latency
+            'min_perplexity': 80.0
+        }
+    )
+    
+    logger.info(f"    Low-latency system: {info['selected_system']}")
+    
+    # 3. Usage statistics
+    logger.info(f"\n3️⃣ Usage statistics:")
+    stats = get_vq_usage_stats()
+    logger.info(f"    Total VQ creations: {stats['total_creations']}")
+    logger.info(f"    System usage:")
+    for system, percentage in stats['system_percentages'].items():
+        logger.info(f"      {system}: {percentage:.1f}%")
+    
+    # 4. Recommendations
+    logger.info(f"\n4️⃣ System recommendations:")
+    for use_case, _ in use_cases[:3]:
+        rec = get_vq_recommendations(use_case)
+        logger.info(f"   {use_case}: {rec['recommended_system']}")
+    
+    logger.info(f"\n Intelligent VQ Integration Demo completed!")
+
+if __name__ == "__main__":
+    demo_intelligent_integration()

--- a/capibara/vq/monitoring/vq_monitoring.py
+++ b/capibara/vq/monitoring/vq_monitoring.py
@@ -1,0 +1,357 @@
+"""
+Sistema de monitoreo for vector Quantization en tpu v6.
+Proporciona métricas detalladas de rendimiento, memory and costos.
+"""
+
+import jax
+import time
+import logging
+import numpy as np
+import jax.numpy as jnp
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Any
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class VQMonitoringConfig:
+    """setup for el sistema de monitoreo VQ."""
+    enable_performance_tracking: bool = True
+    enable_memory_tracking: bool = True
+    enable_cost_tracking: bool = True
+    enable_diversity_tracking: bool = True
+    metrics_window_size: int = 1000
+    log_interval_steps: int = 100
+    alert_memory_threshold: float = 0.95  # 95% uso memory
+    alert_performance_threshold: float = 0.5  # 50% rendimiento esperado
+    alert_cost_threshold: float = 1000.0  # USD by hora
+    alert_diversity_threshold: float = 0.8  # 80% diversidad mínima
+
+
+class VQPerformanceMetrics:
+    """Métricas de rendimiento for operaciones VQ."""
+    
+    def __init__(self, config: VQMonitoringConfig):
+        self.config = config
+        self.reset_metrics()
+        
+    def reset_metrics(self):
+        """Reset all performance metrics."""
+        self.metrics = {
+            'vq_encode_time': [],
+            'ml_layers_time': [],
+            'attention_time': [],
+            'total_time': [],
+            'tflops_utilization': [],
+            'operations_per_second': [],
+            'batch_throughput': []
+        }
+        
+    def update_metrics(self, 
+                      operation_type: str,
+                      duration: float,
+                      batch_size: int,
+                      num_operations: int):
+        """Update performance metrics for an operation."""
+        # Add duration to appropriate metric
+        if operation_type in self.metrics:
+            self.metrics[operation_type].append(duration)
+            
+            # Keep only recent metrics
+            if len(self.metrics[operation_type]) > self.config.metrics_window_size:
+                self.metrics[operation_type] = self.metrics[operation_type][-self.config.metrics_window_size:]
+        
+        # Calculate operations per second
+        ops_per_second = num_operations / duration
+        self.metrics['operations_per_second'].append(ops_per_second)
+        
+        # Calculate batch throughput
+        throughput = batch_size / duration
+        self.metrics['batch_throughput'].append(throughput)
+        
+        # Calculate TFLOPS utilization
+        theoretical_peak = 1293.0  # tpu v6 peak TFLOPS
+        actual_tflops = (num_operations * 2) / (duration * 1e12)  # *2 for FMA
+        utilization = actual_tflops / theoretical_peak
+        self.metrics['tflops_utilization'].append(utilization)
+        
+        # Check for performance alerts
+        if utilization < self.config.alert_performance_threshold:
+            logger.warning(
+                f"Low performance alert - Utilization: {utilization:.2%}, "
+                f"Operation: {operation_type}"
+            )
+    
+    def get_summary(self) -> Dict[str, float]:
+        """Get summary of recent performance metrics."""
+        summary = {}
+        for metric, values in self.metrics.items():
+            if values:
+                summary[f"avg_{metric}"] = np.mean(values[-100:])
+                summary[f"max_{metric}"] = np.max(values[-100:])
+                summary[f"min_{metric}"] = np.min(values[-100:])
+        return summary
+
+
+class VQMemoryTracker:
+    """Monitor memory usage for operaciones VQ."""
+    
+    def __init__(self, config: VQMonitoringConfig):
+        self.config = config
+        self.reset_tracking()
+        
+    def reset_tracking(self):
+        """Reset memory tracking metrics."""
+        self.metrics = {
+            'total_allocated': [],
+            'peak_allocated': [],
+            'fragmentation': [],
+            'cache_size': [],
+            'cache_hit_rate': []
+        }
+        self.peak_memory = 0
+        
+    def update_tracking(self, 
+                       current_allocated: int,
+                       cache_size: int,
+                       cache_hits: int,
+                       cache_misses: int):
+        """Update memory tracking metrics."""
+        # Update allocated memory metrics
+        self.metrics['total_allocated'].append(current_allocated)
+        self.peak_memory = max(self.peak_memory, current_allocated)
+        self.metrics['peak_allocated'].append(self.peak_memory)
+        
+        # Calculate memory fragmentation
+        fragmentation = 1.0 - (current_allocated / self.peak_memory)
+        self.metrics['fragmentation'].append(fragmentation)
+        
+        # Update cache metrics
+        self.metrics['cache_size'].append(cache_size)
+        hit_rate = cache_hits / (cache_hits + cache_misses) if (cache_hits + cache_misses) > 0 else 0
+        self.metrics['cache_hit_rate'].append(hit_rate)
+        
+        # Check for memory alerts
+        total_memory = jax.device_get(jax.devices()[0].memory_stats()['bytes_in_use'])
+        memory_utilization = current_allocated / total_memory
+        if memory_utilization > self.config.alert_memory_threshold:
+            logger.warning(
+                f"High memory usage alert - Utilization: {memory_utilization:.2%}, "
+                f"Allocated: {current_allocated / 1e9:.2f}GB"
+            )
+    
+    def get_summary(self) -> Dict[str, float]:
+        """Get summary of memory metrics."""
+        return {
+            'current_memory_gb': self.metrics['total_allocated'][-1] / 1e9,
+            'peak_memory_gb': self.peak_memory / 1e9,
+            'avg_fragmentation': np.mean(self.metrics['fragmentation'][-100:]),
+            'cache_hit_rate': np.mean(self.metrics['cache_hit_rate'][-100:])
+        }
+
+
+class VQCostTracker:
+    """Monitor costos de operaciones VQ."""
+    
+    def __init__(self, config: VQMonitoringConfig):
+        self.config = config
+        self.reset_tracking()
+        
+        # Costos by hora tpu v6 (estimados)
+        self.tpu_cost_per_hour = 100.0  # USD
+        self.network_cost_per_gb = 0.12  # USD
+        
+    def reset_tracking(self):
+        """Reset cost tracking metrics."""
+        self.metrics = {
+            'compute_cost': [],
+            'memory_cost': [],
+            'network_cost': [],
+            'total_cost': [],
+            'cost_per_operation': []
+        }
+        self.start_time = time.time()
+        
+    def update_tracking(self,
+                       duration: float,
+                       num_operations: int,
+                       memory_used_gb: float,
+                       network_transfer_gb: float):
+        """Update cost tracking metrics."""
+        # Calculate costs for this period
+        hours = duration / 3600.0
+        compute_cost = hours * self.tpu_cost_per_hour
+        memory_cost = memory_used_gb * 0.05  # USD per GB-hour
+        network_cost = network_transfer_gb * self.network_cost_per_gb
+        
+        # Update metrics
+        self.metrics['compute_cost'].append(compute_cost)
+        self.metrics['memory_cost'].append(memory_cost)
+        self.metrics['network_cost'].append(network_cost)
+        
+        total_cost = compute_cost + memory_cost + network_cost
+        self.metrics['total_cost'].append(total_cost)
+        
+        cost_per_op = total_cost / num_operations
+        self.metrics['cost_per_operation'].append(cost_per_op)
+        
+        # Check for cost alerts
+        hourly_rate = total_cost / hours
+        if hourly_rate > self.config.alert_cost_threshold:
+            logger.warning(
+                f"High cost alert - Rate: ${hourly_rate:.2f}/hour, "
+                f"Cost per op: ${cost_per_op:.6f}"
+            )
+    
+    def get_summary(self) -> Dict[str, float]:
+        """Get summary of cost metrics."""
+        total_time = time.time() - self.start_time
+        return {
+            'total_cost_usd': sum(self.metrics['total_cost']),
+            'cost_per_hour_usd': sum(self.metrics['total_cost']) / (total_time / 3600),
+            'avg_cost_per_op_usd': np.mean(self.metrics['cost_per_operation'][-100:])
+        }
+
+
+class VQDiversityTracker:
+    """Monitor diversidad and coherencia de códigos VQ."""
+    
+    def __init__(self, config: VQMonitoringConfig):
+        self.config = config
+        self.reset_tracking()
+        
+    def reset_tracking(self):
+        """Reset diversity tracking metrics."""
+        self.metrics = {
+            'code_usage': [],
+            'entropy': [],
+            'perplexity': [],
+            'coherence': []
+        }
+        
+    def update_tracking(self,
+                       code_usage: jnp.ndarray,
+                       encoded_states: jnp.ndarray,
+                       original_states: jnp.ndarray):
+        """Update diversity tracking metrics."""
+        # Calculate code usage distribution
+        usage_dist = jnp.mean(code_usage, axis=0)
+        self.metrics['code_usage'].append(usage_dist)
+        
+        # Calculate entropy of code usage
+        entropy = -jnp.sum(usage_dist * jnp.log(usage_dist + 1e-10))
+        self.metrics['entropy'].append(float(entropy))
+        
+        # Calculate perplexity
+        perplexity = jnp.exp(entropy)
+        self.metrics['perplexity'].append(float(perplexity))
+        
+        # Calculate coherence (similarity between estados originales and codificados)
+        coherence = jnp.mean(
+            jnp.sum(original_states * encoded_states, axis=-1) /
+            (jnp.linalg.norm(original_states, axis=-1) * 
+             jnp.linalg.norm(encoded_states, axis=-1) + 1e-10)
+        )
+        self.metrics['coherence'].append(float(coherence))
+        
+        # Check for diversity alerts
+        normalized_entropy = entropy / jnp.log(len(usage_dist))
+        if normalized_entropy < self.config.alert_diversity_threshold:
+            logger.warning(
+                f"Low diversity alert - Normalized entropy: {normalized_entropy:.2%}, "
+                f"Perplexity: {perplexity:.2f}"
+            )
+    
+    def get_summary(self) -> Dict[str, float]:
+        """Get summary of diversity metrics."""
+        return {
+            'avg_entropy': np.mean(self.metrics['entropy'][-100:]),
+            'avg_perplexity': np.mean(self.metrics['perplexity'][-100:]),
+            'avg_coherence': np.mean(self.metrics['coherence'][-100:]),
+            'active_codes_ratio': np.mean(
+                [np.sum(u > 0.01) / len(u) for u in self.metrics['code_usage'][-100:]]
+            )
+        }
+
+
+class VQMonitoringSystem:
+    """Sistema complete de monitoreo VQ."""
+    
+    def __init__(self, config: Optional[VQMonitoringConfig] = None):
+        self.config = config or VQMonitoringConfig()
+        self.performance = VQPerformanceMetrics(self.config)
+        self.memory = VQMemoryTracker(self.config)
+        self.cost = VQCostTracker(self.config)
+        self.diversity = VQDiversityTracker(self.config)
+        
+    def start_operation(self) -> float:
+        """Start tracking a new operation."""
+        return time.time()
+        
+    def end_operation(self,
+                     start_time: float,
+                     operation_type: str,
+                     batch_size: int,
+                     num_operations: int,
+                     memory_used: int,
+                     cache_info: Dict[str, int],
+                     code_usage: jnp.ndarray,
+                     encoded_states: jnp.ndarray,
+                     original_states: jnp.ndarray,
+                     network_transfer: float = 0.0):
+        """Track completion of an operation."""
+        duration = time.time() - start_time
+        
+        # Update all tracking systems
+        self.performance.update_metrics(
+            operation_type, duration, batch_size, num_operations
+        )
+        
+        self.memory.update_tracking(
+            memory_used,
+            cache_info['size'],
+            cache_info['hits'],
+            cache_info['misses']
+        )
+        
+        self.cost.update_tracking(
+            duration,
+            num_operations,
+            memory_used / 1e9,  # Convert to GB
+            network_transfer
+        )
+        
+        self.diversity.update_tracking(
+            code_usage,
+            encoded_states,
+            original_states
+        )
+        
+        # Log periodic summaries
+        self._log_summaries()
+        
+    def _log_summaries(self):
+        """Log summaries of all metrics periodically."""
+        total_ops = len(self.performance.metrics['total_time'])
+        if total_ops % self.config.log_interval_steps == 0:
+            perf_summary = self.performance.get_summary()
+            mem_summary = self.memory.get_summary()
+            cost_summary = self.cost.get_summary()
+            div_summary = self.diversity.get_summary()
+            
+            logger.info(
+                f"VQ Monitoring Summary (Step {total_ops}):\n"
+                f"Performance: {perf_summary}\n"
+                f"Memory: {mem_summary}\n"
+                f"Cost: {cost_summary}\n"
+                f"Diversity: {div_summary}"
+            )
+    
+    def get_full_summary(self) -> Dict[str, Any]:
+        """Get comprehensive summary of all metrics."""
+        return {
+            'performance': self.performance.get_summary(),
+            'memory': self.memory.get_summary(),
+            'cost': self.cost.get_summary(),
+            'diversity': self.diversity.get_summary()
+        } 

--- a/capibara/vq/multi_modal_vq_intelligence.py
+++ b/capibara/vq/multi_modal_vq_intelligence.py
@@ -1,0 +1,826 @@
+"""
+Multi-Modal VQ Intelligence - CapibaraGPT v3024
+===============================================
+
+Sistema ultra-advanced de inteligencia multi-modal for vector Quantization:
+- Cross-Modal Learning: Aprendizaje between modalidades with transfer learning
+- Attention-Based VQ: Mecanismos de atención for VQ inteligente
+- Modal Fusion Intelligence: Fusión inteligente de representaciones
+- Adaptive Modal Switching: change adaptativo between modalidades
+- Unified VQ Representation: Representación unificada cross-modal
+- Emergent Pattern Detection: Detección de patrones emergentes
+- Modal Coherence Optimization: optimization de coherencia modal
+
+Revoluciona la quantization with inteligencia multi-modal ultra-avanzada.
+"""
+
+import os
+import sys
+import time
+import logging
+import asyncio
+import numpy as np
+from typing import Dict, Any, Optional, List, Union, Tuple, Callable
+from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from enum import Enum
+import json
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from collections import deque, defaultdict
+import math
+
+# Path setup
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(script_dir))
+if project_root not in sys.path:
+    pass  # Using proper imports instead of sys.path manipulation
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Safe imports
+# ============================================================================
+
+# JAX and ML libraries
+ML_LIBRARIES_AVAILABLE = True
+try:
+    from capibara.jax import jax, jnp
+    import flax.linen as nn
+    logger.info(" ML libraries available for Multi-Modal VQ")
+except ImportError as e:
+    logger.debug("ML libraries not available: %s", e)
+    ML_LIBRARIES_AVAILABLE = False
+
+# Ultra VQ System integration
+ULTRA_VQ_AVAILABLE = True
+try:
+    from .ultra_vq_orchestrator import VQModality, VQTechnique, UltraVQConfig
+    logger.info(" Ultra VQ System integration available")
+except ImportError as e:
+    logger.debug("Ultra VQ System not available: %s", e)
+    ULTRA_VQ_AVAILABLE = False
+
+# ============================================================================
+# Configuration and Enums
+# ============================================================================
+
+class ModalFusionStrategy(str, Enum):
+    """Strategies for modal fusion."""
+    EARLY_FUSION = "early_fusion"                # Fuse at input level
+    LATE_FUSION = "late_fusion"                  # Fuse at output level
+    INTERMEDIATE_FUSION = "intermediate_fusion"  # Fuse at intermediate layers
+    ATTENTION_FUSION = "attention_fusion"        # Attention-based fusion
+    ADAPTIVE_FUSION = "adaptive_fusion"          # Adaptive fusion strategy
+    HIERARCHICAL_FUSION = "hierarchical_fusion" # Hierarchical fusion
+    QUANTUM_FUSION = "quantum_fusion"            # Quantum-inspired fusion
+    ULTRA_FUSION = "ultra_fusion"               # Ultra-advanced fusion
+
+class CrossModalLearningMode(str, Enum):
+    """Cross-modal learning modes."""
+    TRANSFER_LEARNING = "transfer_learning"      # Transfer between modalities
+    CONTRASTIVE_LEARNING = "contrastive_learning" # Contrastive learning
+    SELF_SUPERVISED = "self_supervised"          # Self-supervised learning
+    ADVERSARIAL = "adversarial"                  # Adversarial learning
+    COOPERATIVE = "cooperative"                  # Cooperative learning
+    EMERGENT = "emergent"                        # Emergent learning patterns
+    ULTRA_LEARNING = "ultra_learning"           # Ultra-advanced learning
+
+class AttentionMechanism(str, Enum):
+    """Attention mechanisms for VQ."""
+    SELF_ATTENTION = "self_attention"            # Self-attention
+    CROSS_ATTENTION = "cross_attention"          # Cross-modal attention
+    MULTI_HEAD = "multi_head"                    # Multi-head attention
+    SPARSE_ATTENTION = "sparse_attention"        # Sparse attention
+    ADAPTIVE_ATTENTION = "adaptive_attention"    # Adaptive attention
+    QUANTUM_ATTENTION = "quantum_attention"      # Quantum attention
+    ULTRA_ATTENTION = "ultra_attention"          # Ultra-advanced attention
+
+@dataclass
+class MultiModalVQConfig:
+    """Configuration for multi-modal VQ intelligence."""
+    
+    # Fusion configuration
+    fusion_strategy: ModalFusionStrategy = ModalFusionStrategy.ULTRA_FUSION
+    learning_mode: CrossModalLearningMode = CrossModalLearningMode.ULTRA_LEARNING
+    attention_mechanism: AttentionMechanism = AttentionMechanism.ULTRA_ATTENTION
+    
+    # Modality configuration
+    supported_modalities: List[VQModality] = field(default_factory=lambda: [
+        VQModality.TEXT, VQModality.VISION, VQModality.AUDIO, 
+        VQModality.CODE, VQModality.MATHEMATICAL
+    ])
+    
+    # Cross-modal parameters
+    enable_cross_modal_transfer: bool = True
+    enable_modal_coherence_optimization: bool = True
+    enable_emergent_pattern_detection: bool = True
+    enable_adaptive_modal_switching: bool = True
+    
+    # Attention parameters
+    attention_heads: int = 16
+    attention_dim: int = 1024
+    attention_dropout: float = 0.1
+    
+    # Fusion parameters
+    fusion_hidden_dims: List[int] = field(default_factory=lambda: [2048, 1024, 512])
+    fusion_activation: str = "gelu"
+    fusion_dropout: float = 0.1
+    
+    # Learning parameters
+    cross_modal_learning_rate: float = 0.001
+    coherence_loss_weight: float = 0.1
+    diversity_loss_weight: float = 0.05
+    
+    # Performance parameters
+    enable_real_time_fusion: bool = True
+    enable_adaptive_compression: bool = True
+    target_coherence_score: float = 0.9
+
+@dataclass
+class ModalRepresentation:
+    """Representation for a single modality."""
+    modality: VQModality
+    embeddings: np.ndarray
+    quantized_codes: np.ndarray
+    attention_weights: Optional[np.ndarray] = None
+    coherence_score: float = 0.0
+    complexity_measure: float = 0.0
+
+@dataclass
+class CrossModalCoherence:
+    """Cross-modal coherence metrics."""
+    pairwise_coherence: Dict[Tuple[str, str], float] = field(default_factory=dict)
+    global_coherence: float = 0.0
+    modal_alignment: Dict[str, float] = field(default_factory=dict)
+    semantic_consistency: float = 0.0
+    temporal_coherence: float = 0.0
+
+# ============================================================================
+# Multi-Modal VQ Intelligence System
+# ============================================================================
+
+class MultiModalVQIntelligence:
+    """Sistema ultra-advanced de inteligencia multi-modal for VQ."""
+    
+    def __init__(self, config: MultiModalVQConfig):
+        self.config = config
+        self.modal_representations = {}
+        self.cross_modal_cache = {}
+        self.attention_cache = {}
+        
+        # Intelligence components
+        self.fusion_engine = None
+        self.attention_manager = None
+        self.coherence_optimizer = None
+        self.pattern_detector = None
+        
+        # Learning components
+        self.cross_modal_learner = None
+        self.adaptive_controller = None
+        
+        # Performance tracking
+        self.performance_metrics = {
+            "fusion_efficiency": 0.0,
+            "cross_modal_accuracy": 0.0,
+            "attention_effectiveness": 0.0,
+            "coherence_score": 0.0,
+            "pattern_detection_rate": 0.0,
+            "adaptive_improvement": 0.0
+        }
+        
+        # Threading and async management
+        self.executor = ThreadPoolExecutor(max_workers=8)
+        self.intelligence_lock = threading.Lock()
+        
+        # Initialize the intelligence system
+        self._initialize_intelligence_system()
+    
+    def _initialize_intelligence_system(self):
+        """Initialize the multi-modal VQ intelligence system."""
+        
+        logger.info(" Initializing Multi-Modal VQ Intelligence")
+        
+        # Initialize fusion engine
+        self._initialize_fusion_engine()
+        
+        # Initialize attention manager
+        self._initialize_attention_manager()
+        
+        # Initialize coherence optimizer
+        self._initialize_coherence_optimizer()
+        
+        # Initialize pattern detector
+        self._initialize_pattern_detector()
+        
+        # Initialize cross-modal learner
+        self._initialize_cross_modal_learner()
+        
+        # Initialize adaptive controller
+        self._initialize_adaptive_controller()
+        
+        logger.info(f" Multi-Modal VQ Intelligence initialized")
+        logger.info(f"    Fusion: {self.config.fusion_strategy.value}")
+        logger.info(f"    Learning: {self.config.learning_mode.value}")
+        logger.info(f"   ️ Attention: {self.config.attention_mechanism.value}")
+    
+    def _initialize_fusion_engine(self):
+        """Initialize modal fusion engine."""
+        
+        self.fusion_engine = UltraModalFusionEngine(
+            strategy=self.config.fusion_strategy,
+            supported_modalities=self.config.supported_modalities,
+            hidden_dims=self.config.fusion_hidden_dims,
+            activation=self.config.fusion_activation,
+            dropout=self.config.fusion_dropout
+        )
+        
+        logger.info(" Ultra Modal Fusion Engine initialized")
+    
+    def _initialize_attention_manager(self):
+        """Initialize attention management system."""
+        
+        self.attention_manager = UltraAttentionManager(
+            mechanism=self.config.attention_mechanism,
+            num_heads=self.config.attention_heads,
+            attention_dim=self.config.attention_dim,
+            dropout=self.config.attention_dropout
+        )
+        
+        logger.info(" Ultra Attention Manager initialized")
+    
+    def _initialize_coherence_optimizer(self):
+        """Initialize coherence optimization system."""
+        
+        if self.config.enable_modal_coherence_optimization:
+            self.coherence_optimizer = ModalCoherenceOptimizer(
+                target_coherence=self.config.target_coherence_score,
+                coherence_weight=self.config.coherence_loss_weight
+            )
+            
+            logger.info(" Modal Coherence Optimizer initialized")
+    
+    def _initialize_pattern_detector(self):
+        """Initialize emergent pattern detection."""
+        
+        if self.config.enable_emergent_pattern_detection:
+            self.pattern_detector = EmergentPatternDetector(
+                modalities=self.config.supported_modalities,
+                detection_threshold=0.8
+            )
+            
+            logger.info(" Emergent Pattern Detector initialized")
+    
+    def _initialize_cross_modal_learner(self):
+        """Initialize cross-modal learning system."""
+        
+        if self.config.enable_cross_modal_transfer:
+            self.cross_modal_learner = CrossModalLearner(
+                learning_mode=self.config.learning_mode,
+                learning_rate=self.config.cross_modal_learning_rate,
+                modalities=self.config.supported_modalities
+            )
+            
+            logger.info(" Cross-Modal Learner initialized")
+    
+    def _initialize_adaptive_controller(self):
+        """Initialize adaptive modal switching."""
+        
+        if self.config.enable_adaptive_modal_switching:
+            self.adaptive_controller = AdaptiveModalController(
+                modalities=self.config.supported_modalities,
+                switching_threshold=0.1
+            )
+            
+            logger.info(" Adaptive Modal Controller initialized")
+    
+    async def process_multi_modal_data(
+        self,
+        modal_data: Dict[str, np.ndarray],
+        fusion_target: str = "unified_representation"
+    ) -> Dict[str, Any]:
+        """Process multi-modal data with ultra-advanced intelligence."""
+        
+        start_time = time.time()
+        
+        processing_result = {
+            "input_modalities": list(modal_data.keys()),
+            "fusion_target": fusion_target,
+            "status": "processing",
+            "modal_representations": {},
+            "fused_representation": None,
+            "attention_maps": {},
+            "coherence_metrics": {},
+            "emergent_patterns": {},
+            "intelligence_insights": {}
+        }
+        
+        try:
+            with self.intelligence_lock:
+                # 1. Process individual modalities
+                modal_representations = await self._process_individual_modalities(modal_data)
+                processing_result["modal_representations"] = modal_representations
+                
+                # 2. Apply cross-modal attention
+                attention_result = await self._apply_cross_modal_attention(modal_representations)
+                processing_result["attention_maps"] = attention_result
+                
+                # 3. Execute modal fusion
+                fusion_result = await self._execute_modal_fusion(
+                    modal_representations, attention_result
+                )
+                processing_result["fused_representation"] = fusion_result
+                
+                # 4. Optimize cross-modal coherence
+                if self.coherence_optimizer:
+                    coherence_result = await self._optimize_cross_modal_coherence(
+                        modal_representations, fusion_result
+                    )
+                    processing_result["coherence_metrics"] = coherence_result
+                
+                # 5. Detect emergent patterns
+                if self.pattern_detector:
+                    pattern_result = await self._detect_emergent_patterns(
+                        modal_representations, fusion_result
+                    )
+                    processing_result["emergent_patterns"] = pattern_result
+                
+                # 6. Apply cross-modal learning
+                if self.cross_modal_learner:
+                    learning_result = await self._apply_cross_modal_learning(
+                        modal_representations, fusion_result
+                    )
+                    processing_result["learning_insights"] = learning_result
+                
+                # 7. Generate intelligence insights
+                intelligence_insights = await self._generate_intelligence_insights(
+                    processing_result
+                )
+                processing_result["intelligence_insights"] = intelligence_insights
+                
+                processing_time = (time.time() - start_time) * 1000
+                processing_result["processing_time_ms"] = processing_time
+                processing_result["status"] = "completed"
+                
+                # Update performance metrics
+                self._update_performance_metrics(processing_result)
+                
+                return processing_result
+        
+        except Exception as e:
+            logger.error(f"Multi-modal processing failed: {e}")
+            processing_result["status"] = "failed"
+            processing_result["error"] = str(e)
+            return processing_result
+    
+    async def adaptive_modal_fusion(
+        self,
+        modal_data: Dict[str, np.ndarray],
+        adaptation_criteria: Dict[str, float]
+    ) -> Dict[str, Any]:
+        """Execute adaptive modal fusion based on data characteristics."""
+        
+        fusion_result = {
+            "adaptation_criteria": adaptation_criteria,
+            "selected_strategy": None,
+            "fusion_performance": {},
+            "adaptive_improvements": {}
+        }
+        
+        try:
+            # Analyze data characteristics for each modality
+            modal_characteristics = {}
+            for modality, data in modal_data.items():
+                characteristics = await self._analyze_modal_characteristics(data)
+                modal_characteristics[modality] = characteristics
+            
+            # Select optimal fusion strategy
+            optimal_strategy = await self._select_optimal_fusion_strategy(
+                modal_characteristics, adaptation_criteria
+            )
+            fusion_result["selected_strategy"] = optimal_strategy.value
+            
+            # Execute adaptive fusion
+            if self.adaptive_controller:
+                adaptive_result = await self.adaptive_controller.execute_adaptive_fusion(
+                    modal_data, optimal_strategy
+                )
+                fusion_result["fusion_performance"] = adaptive_result
+            
+            # Apply adaptive improvements
+            if adaptive_result.get("improvement_opportunities"):
+                improvements = await self._apply_adaptive_improvements(
+                    modal_data, adaptive_result["improvement_opportunities"]
+                )
+                fusion_result["adaptive_improvements"] = improvements
+            
+            return fusion_result
+            
+        except Exception as e:
+            logger.error(f"Adaptive modal fusion failed: {e}")
+            fusion_result["error"] = str(e)
+            return fusion_result
+    
+    async def cross_modal_knowledge_transfer(
+        self,
+        source_modality: VQModality,
+        target_modality: VQModality,
+        transfer_data: Dict[str, np.ndarray]
+    ) -> Dict[str, Any]:
+        """Execute cross-modal knowledge transfer."""
+        
+        transfer_result = {
+            "source_modality": source_modality.value,
+            "target_modality": target_modality.value,
+            "transfer_effectiveness": 0.0,
+            "knowledge_mappings": {},
+            "transfer_insights": {}
+        }
+        
+        try:
+            if not self.cross_modal_learner:
+                transfer_result["error"] = "Cross-modal learner not available"
+                return transfer_result
+            
+            # Execute knowledge transfer
+            transfer_output = await self.cross_modal_learner.transfer_knowledge(
+                source_modality, target_modality, transfer_data
+            )
+            
+            # Measure transfer effectiveness
+            effectiveness = await self._measure_transfer_effectiveness(
+                transfer_output, source_modality, target_modality
+            )
+            transfer_result["transfer_effectiveness"] = effectiveness
+            
+            # Generate knowledge mappings
+            mappings = await self._generate_knowledge_mappings(
+                transfer_output, source_modality, target_modality
+            )
+            transfer_result["knowledge_mappings"] = mappings
+            
+            # Extract transfer insights
+            insights = await self._extract_transfer_insights(transfer_output)
+            transfer_result["transfer_insights"] = insights
+            
+            return transfer_result
+            
+        except Exception as e:
+            logger.error(f"Cross-modal knowledge transfer failed: {e}")
+            transfer_result["error"] = str(e)
+            return transfer_result
+    
+    def get_intelligence_status(self) -> Dict[str, Any]:
+        """Get comprehensive intelligence system status."""
+        
+        return {
+            "config": {
+                "fusion_strategy": self.config.fusion_strategy.value,
+                "learning_mode": self.config.learning_mode.value,
+                "attention_mechanism": self.config.attention_mechanism.value,
+                "supported_modalities": [m.value for m in self.config.supported_modalities]
+            },
+            "components": {
+                "fusion_engine": self.fusion_engine is not None,
+                "attention_manager": self.attention_manager is not None,
+                "coherence_optimizer": self.coherence_optimizer is not None,
+                "pattern_detector": self.pattern_detector is not None,
+                "cross_modal_learner": self.cross_modal_learner is not None,
+                "adaptive_controller": self.adaptive_controller is not None
+            },
+            "capabilities": {
+                "cross_modal_transfer": self.config.enable_cross_modal_transfer,
+                "coherence_optimization": self.config.enable_modal_coherence_optimization,
+                "pattern_detection": self.config.enable_emergent_pattern_detection,
+                "adaptive_switching": self.config.enable_adaptive_modal_switching
+            },
+            "performance": self.performance_metrics,
+            "cache_status": {
+                "modal_representations": len(self.modal_representations),
+                "cross_modal_cache": len(self.cross_modal_cache),
+                "attention_cache": len(self.attention_cache)
+            }
+        }
+    
+    # ============================================================================
+    # Private Helper Methods
+    # ============================================================================
+    
+    async def _process_individual_modalities(
+        self, 
+        modal_data: Dict[str, np.ndarray]
+    ) -> Dict[str, ModalRepresentation]:
+        """Process each modality individually."""
+        
+        representations = {}
+        
+        for modality_str, data in modal_data.items():
+            try:
+                modality = VQModality(modality_str)
+                
+                # Create embeddings
+                embeddings = await self._create_modal_embeddings(data, modality)
+                
+                # Quantize representations
+                quantized_codes = await self._quantize_modal_data(embeddings, modality)
+                
+                # Compute complexity measure
+                complexity = self._compute_modal_complexity(data)
+                
+                representations[modality_str] = ModalRepresentation(
+                    modality=modality,
+                    embeddings=embeddings,
+                    quantized_codes=quantized_codes,
+                    complexity_measure=complexity
+                )
+                
+            except Exception as e:
+                logger.error(f"Failed to process modality {modality_str}: {e}")
+        
+        return representations
+    
+    async def _apply_cross_modal_attention(
+        self,
+        modal_representations: Dict[str, ModalRepresentation]
+    ) -> Dict[str, Any]:
+        """Apply cross-modal attention mechanisms."""
+        
+        if not self.attention_manager:
+            return {}
+        
+        return await self.attention_manager.compute_cross_modal_attention(
+            modal_representations
+        )
+    
+    async def _execute_modal_fusion(
+        self,
+        modal_representations: Dict[str, ModalRepresentation],
+        attention_result: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Execute modal fusion with attention guidance."""
+        
+        if not self.fusion_engine:
+            return {}
+        
+        return await self.fusion_engine.fuse_modalities(
+            modal_representations, attention_result
+        )
+    
+    def _update_performance_metrics(self, processing_result: Dict[str, Any]):
+        """Update intelligence performance metrics."""
+        
+        # Update fusion efficiency
+        if "processing_time_ms" in processing_result:
+            efficiency = 1000.0 / max(processing_result["processing_time_ms"], 1.0)
+            self.performance_metrics["fusion_efficiency"] = self._update_running_average(
+                self.performance_metrics["fusion_efficiency"], efficiency, 10
+            )
+        
+        # Update coherence score
+        if "coherence_metrics" in processing_result:
+            coherence = processing_result["coherence_metrics"].get("global_coherence", 0.0)
+            self.performance_metrics["coherence_score"] = coherence
+    
+    def _update_running_average(self, current: float, new_value: float, window: int) -> float:
+        """Update running average with window."""
+        alpha = 1.0 / window
+        return current * (1 - alpha) + new_value * alpha
+    
+    async def _analyze_modal_characteristics(self, data: np.ndarray) -> Dict[str, float]:
+        """Analyze characteristics of modal data."""
+        
+        return {
+            "dimensionality": data.shape[-1] if len(data.shape) > 1 else 1,
+            "sparsity": np.mean(data == 0),
+            "variance": np.var(data),
+            "entropy": self._compute_entropy(data),
+            "complexity": self._compute_modal_complexity(data),
+            "temporal_structure": self._compute_temporal_structure(data)
+        }
+    
+    def _compute_entropy(self, data: np.ndarray) -> float:
+        """Compute entropy of data."""
+        data_flat = data.flatten()
+        unique, counts = np.unique(data_flat, return_counts=True)
+        probabilities = counts / len(data_flat)
+        return -np.sum(probabilities * np.log2(probabilities + 1e-10))
+    
+    def _compute_modal_complexity(self, data: np.ndarray) -> float:
+        """Compute modal complexity measure."""
+        # Combine multiple complexity indicators
+        variance_component = np.var(data)
+        entropy_component = self._compute_entropy(data)
+        
+        if len(data.shape) > 1:
+            # Add correlation structure for multi-dimensional data
+            correlation_matrix = np.corrcoef(data.T)
+            correlation_complexity = np.mean(np.abs(correlation_matrix - np.eye(correlation_matrix.shape[0])))
+            return (variance_component + entropy_component + correlation_complexity) / 3.0
+        else:
+            return (variance_component + entropy_component) / 2.0
+    
+    def _compute_temporal_structure(self, data: np.ndarray) -> float:
+        """Compute temporary structure measure."""
+        if len(data.shape) < 2:
+            return 0.0
+        
+        # Compute autocorrelation for temporary patterns
+        autocorr = np.corrcoef(data[:-1].flatten(), data[1:].flatten())[0, 1]
+        return abs(autocorr) if not np.isnan(autocorr) else 0.0
+
+# ============================================================================
+# Intelligence Components
+# ============================================================================
+
+class UltraModalFusionEngine:
+    """Ultra-advanced modal fusion engine."""
+    
+    def __init__(self, strategy: ModalFusionStrategy, supported_modalities: List[VQModality],
+                 hidden_dims: List[int], activation: str, dropout: float):
+        self.strategy = strategy
+        self.supported_modalities = supported_modalities
+        self.hidden_dims = hidden_dims
+        self.activation = activation
+        self.dropout = dropout
+    
+    async def fuse_modalities(
+        self,
+        modal_representations: Dict[str, ModalRepresentation],
+        attention_result: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Fuse multiple modal representations."""
+        
+        # Ultra fusion implementation
+        return {
+            "fused_embeddings": np.random.randn(1024),  # Placeholder
+            "fusion_weights": {},
+            "fusion_quality": 0.9
+        }
+
+class UltraAttentionManager:
+    """Ultra-advanced attention management."""
+    
+    def __init__(self, mechanism: AttentionMechanism, num_heads: int, 
+                 attention_dim: int, dropout: float):
+        self.mechanism = mechanism
+        self.num_heads = num_heads
+        self.attention_dim = attention_dim
+        self.dropout = dropout
+    
+    async def compute_cross_modal_attention(
+        self,
+        modal_representations: Dict[str, ModalRepresentation]
+    ) -> Dict[str, Any]:
+        """Compute cross-modal attention maps."""
+        
+        # Ultra attention implementation
+        return {
+            "attention_maps": {},
+            "attention_scores": {},
+            "attention_effectiveness": 0.85
+        }
+
+class ModalCoherenceOptimizer:
+    """Modal coherence optimization system."""
+    
+    def __init__(self, target_coherence: float, coherence_weight: float):
+        self.target_coherence = target_coherence
+        self.coherence_weight = coherence_weight
+
+class EmergentPatternDetector:
+    """Emergent pattern detection system."""
+    
+    def __init__(self, modalities: List[VQModality], detection_threshold: float):
+        self.modalities = modalities
+        self.detection_threshold = detection_threshold
+
+class CrossModalLearner:
+    """Cross-modal learning system."""
+    
+    def __init__(self, learning_mode: CrossModalLearningMode, 
+                 learning_rate: float, modalities: List[VQModality]):
+        self.learning_mode = learning_mode
+        self.learning_rate = learning_rate
+        self.modalities = modalities
+    
+    async def transfer_knowledge(
+        self,
+        source_modality: VQModality,
+        target_modality: VQModality,
+        transfer_data: Dict[str, np.ndarray]
+    ) -> Dict[str, Any]:
+        """Transfer knowledge between modalities."""
+        
+        return {
+            "transfer_mappings": {},
+            "effectiveness_score": 0.8,
+            "learned_patterns": []
+        }
+
+class AdaptiveModalController:
+    """Adaptive modal switching controller."""
+    
+    def __init__(self, modalities: List[VQModality], switching_threshold: float):
+        self.modalities = modalities
+        self.switching_threshold = switching_threshold
+    
+    async def execute_adaptive_fusion(
+        self,
+        modal_data: Dict[str, np.ndarray],
+        strategy: ModalFusionStrategy
+    ) -> Dict[str, Any]:
+        """Execute adaptive fusion with optimal strategy."""
+        
+        return {
+            "fusion_result": {},
+            "adaptation_score": 0.75,
+            "improvement_opportunities": []
+        }
+
+# ============================================================================
+# Factory Functions
+# ============================================================================
+
+def create_multi_modal_vq_intelligence(
+    config: Optional[MultiModalVQConfig] = None,
+    **kwargs
+) -> MultiModalVQIntelligence:
+    """Create multi-modal VQ intelligence system."""
+    
+    if config is None:
+        config = MultiModalVQConfig(**kwargs)
+    
+    return MultiModalVQIntelligence(config)
+
+def create_multi_modal_vq_config(
+    fusion_strategy: ModalFusionStrategy = ModalFusionStrategy.ULTRA_FUSION,
+    learning_mode: CrossModalLearningMode = CrossModalLearningMode.ULTRA_LEARNING,
+    enable_all_features: bool = True,
+    **kwargs
+) -> MultiModalVQConfig:
+    """Create optimized multi-modal VQ configuration."""
+    
+    return MultiModalVQConfig(
+        fusion_strategy=fusion_strategy,
+        learning_mode=learning_mode,
+        attention_mechanism=AttentionMechanism.ULTRA_ATTENTION,
+        enable_cross_modal_transfer=enable_all_features,
+        enable_modal_coherence_optimization=enable_all_features,
+        enable_emergent_pattern_detection=enable_all_features,
+        enable_adaptive_modal_switching=enable_all_features,
+        **kwargs
+    )
+
+def demonstrate_multi_modal_vq_intelligence():
+    """Demonstrate the multi-modal VQ intelligence system."""
+    
+    logger.info(" MULTI-MODAL VQ INTELLIGENCE DEMONSTRATION")
+    logger.info("=" * 60)
+    
+    # Create configuration
+    config = create_multi_modal_vq_config(
+        fusion_strategy=ModalFusionStrategy.ULTRA_FUSION,
+        learning_mode=CrossModalLearningMode.ULTRA_LEARNING,
+        enable_all_features=True
+    )
+    
+    logger.info(f" Configuration created:")
+    logger.info(f"   - Fusion: {config.fusion_strategy.value}")
+    logger.info(f"   - Learning: {config.learning_mode.value}")
+    logger.warning(f"   - Attention: {config.attention_mechanism.value}")
+    
+    # Create intelligence system
+    intelligence = create_multi_modal_vq_intelligence(config)
+    
+    # Get system status
+    status = intelligence.get_intelligence_status()
+    
+    logger.info(f"\n Intelligence Status:")
+    logger.info(f"   - Components: {sum(status['components'].values())}/6")
+    logger.info(f"   - Capabilities: {sum(status['capabilities'].values())}/4")
+    logger.info(f"   - Modalities: {len(status['config']['supported_modalities'])}")
+    
+    return intelligence
+
+__all__ = [
+    # Configuration and enums
+    'ModalFusionStrategy',
+    'CrossModalLearningMode',
+    'AttentionMechanism',
+    'MultiModalVQConfig',
+    'ModalRepresentation',
+    'CrossModalCoherence',
+    
+    # Main intelligence system
+    'MultiModalVQIntelligence',
+    
+    # Factory functions
+    'create_multi_modal_vq_intelligence',
+    'create_multi_modal_vq_config',
+    'demonstrate_multi_modal_vq_intelligence',
+    
+    # Status flags
+    'ML_LIBRARIES_AVAILABLE',
+    'ULTRA_VQ_AVAILABLE'
+]

--- a/capibara/vq/quantum_submodel_fixed.py
+++ b/capibara/vq/quantum_submodel_fixed.py
@@ -1,0 +1,364 @@
+"""
+Quantum Submodel (Fixed) - Trainable quantum-inspired neural submodel.
+
+This module provides a trainable quantum-inspired submodel for CapibaraGPT,
+implementing VQ-bit layers and quantum wrappers with JAX/Flax JIT safety.
+Supports manifold projection for geometric transformations.
+
+Key Components:
+    - QuantumSubmodelConfig: Configuration dataclass for submodel settings
+    - QuantumSubmodel: Main Flax module for quantum-inspired processing
+
+Features:
+    - Token embedding layer
+    - VQ-bit quantization layer
+    - Quantum wrapper for quantum-inspired operations
+    - Optional manifold projection
+
+Author: Skydesk International Dev Team.
+"""
+
+# ============================================================================
+# CapibaraHybrid - Quantum Submodel (TRAINABLE VERSION)
+# JAX / Flax / JIT safe
+# ============================================================================
+
+import chex
+import flax.linen as nn
+from flax import struct
+from capibara.jax import jax
+from capibara.jax import numpy as jnp
+from typing import Dict, Tuple, Any
+
+# ============================================================================
+# CONFIG
+# ============================================================================
+
+@struct.dataclass
+class QuantumSubmodelConfig:
+    vocab_size: int
+    embedding_dim: int
+    vqbit_config: Dict[str, Any]
+    quantum_wrapper_config: Dict[str, Any]
+    use_manifold_projection: bool = False
+    manifold_curvature: float = -1.0
+
+# ============================================================================
+# MAIN SUBMODEL
+# ============================================================================
+
+class QuantumSubmodel(nn.Module):
+    config: QuantumSubmodelConfig
+
+    def setup(self):
+        # 🔴 REQUIRED: token → embedding
+        self.embedding = nn.Embed(
+            num_embeddings=self.config.vocab_size,
+            features=self.config.embedding_dim
+        )
+
+        self.vqbit = VQbitLayerFixed(self.config.vqbit_config)
+        self.quantum = QuantumWrapperFixed(self.config.quantum_wrapper_config)
+
+        if self.config.use_manifold_projection:
+            self.manifold = ManifoldProjection(
+                curvature=self.config.manifold_curvature
+            )
+    
+    def __call__(self, 
+                 x: Dict[str, jnp.ndarray],  #  FIXED: Consistent signature
+                 deterministic: bool = True,
+                 **kwargs) -> Tuple[Dict[str, jnp.ndarray], Dict[str, float]]:
+        """
+        Forward pass with corrected input/output types.
+        
+        Args:
+            x: Dict containing 'tokens', 'attention_mask', etc.
+            deterministic: Whether to use deterministic mode
+            
+        Returns:
+            Tuple of (outputs, metrics) with correct metric names
+        """
+        #  Input validation
+        chex.assert_type(x, dict)
+        tokens = x["tokens"]
+
+        # (B, S, D)
+        embedded = self.embedding(tokens)
+
+        quantized, vq_metrics = self.vqbit(
+            embedded, deterministic=deterministic
+        )
+
+        out, q_metrics = self.quantum(
+            quantized, deterministic=deterministic
+        )
+
+        if self.config.use_manifold_projection:
+            quantum_out = self.manifold_projection(quantum_out)
+        
+        #  FIXED: Use real metric names
+        aggregated_metrics = {
+            # VQbit metrics (real names)
+            'commitment_loss': vqbit_metrics.get('commitment_loss', 0.0),
+            'codebook_usage': vqbit_metrics.get('usage', 0.0),
+            'quantization_loss': vqbit_metrics.get('quantization_loss', 0.0),
+            
+            # Quantum wrapper metrics (real names)  
+            'coherence_score': quantum_metrics.get('coherence', 0.0),
+            'fidelity_score': quantum_metrics.get('fidelity', 0.0),
+            'quantum_efficiency': quantum_metrics.get('efficiency', 0.0),
+            
+            #  REMOVED: Fake metrics
+            # 'loss': DOES NOT EXIST
+            # 'quantum_advantage': DOES NOT EXIST
+        }
+        
+        # Construct output dict with same structure as input
+        outputs = {
+            'tokens': quantum_out,
+            'attention_mask': x.get('attention_mask', None)
+        }
+
+        return {
+            "tokens": out,
+            "attention_mask": x.get("attention_mask", None)
+        }, metrics
+
+# ============================================================================
+# VQBIT (EMA – JIT SAFE)
+# ============================================================================
+
+class VQbitLayerFixed(nn.Module):
+    config: Dict[str, Any]
+
+    def setup(self):
+        self.codebook_size = self.config["codebook_size"]
+        self.embedding_dim = self.config["embedding_dim"]
+        self.commitment_cost = self.config.get("commitment_cost", 0.25)
+        self.ema_decay = self.config.get("ema_decay", 0.99)
+
+        self.codebook = self.param(
+            "codebook",
+            nn.initializers.normal(0.1),
+            (self.codebook_size, self.embedding_dim),
+        )
+
+        self.ema_cluster_size = self.variable(
+            "ema", "cluster_size", lambda: jnp.zeros(self.codebook_size)
+        )
+        self.ema_w = self.variable(
+            "ema", "w", lambda: jnp.zeros_like(self.codebook)
+        )
+
+    def __call__(
+        self,
+        x: jnp.ndarray,
+        deterministic: bool
+    ) -> Tuple[jnp.ndarray, Dict[str, jnp.ndarray]]:
+
+        B, S, D = x.shape
+        flat = x.reshape(-1, D)
+
+        distances = (
+            jnp.sum(flat ** 2, axis=1, keepdims=True)
+            + jnp.sum(self.codebook ** 2, axis=1)
+            - 2 * flat @ self.codebook.T
+        )
+    
+    def __call__(self, 
+                 x: jnp.ndarray, 
+                 deterministic: bool = True) -> Tuple[jnp.ndarray, Dict[str, float]]:
+        """
+        VQbit quantization with corrected metrics.
+        
+        Returns real metric names: commitment_loss, usage, quantization_loss
+        """
+        batch_size, seq_len, dim = x.shape
+        
+        # Flatten for quantization
+        flat_x = x.reshape(-1, dim)
+        
+        # Find nearest codebook entries
+        distances = jnp.sum(flat_x**2, axis=1, keepdims=True) + \
+                   jnp.sum(self.codebook**2, axis=1) - \
+                   2 * jnp.dot(flat_x, self.codebook.T)
+        
+        encoding_indices = jnp.argmin(distances, axis=1)
+        quantized = self.codebook[encoding_indices]
+        
+        #  FIXED: Real metric names only
+        commitment_loss = jnp.mean((jnp.stop_gradient(quantized) - flat_x) ** 2)
+        quantization_loss = jnp.mean((quantized - jnp.stop_gradient(flat_x)) ** 2)
+        
+        # Codebook usage (percentage of codes used)
+        unique_indices = jnp.unique(encoding_indices)
+        usage = len(unique_indices) / self.codebook_size
+        
+        # Update EMA during training
+        if not deterministic:
+            self._ema_update(indices, flat)
+
+        quantized = flat + jax.lax.stop_gradient(quantized - flat)
+        quantized = quantized.reshape(B, S, D)
+
+        return quantized, {
+            "commitment_loss": commit_loss,
+            "quantization_loss": quant_loss,
+            "usage": usage,
+        }
+
+    def _ema_update(self, indices, flat):
+        one_hot = jax.nn.one_hot(indices, self.codebook_size)
+
+        cluster_size = (
+            self.ema_decay * self.ema_cluster_size.value
+            + (1 - self.ema_decay) * jnp.sum(one_hot, axis=0)
+        )
+
+        dw = one_hot.T @ flat
+        w = self.ema_decay * self.ema_w.value + (1 - self.ema_decay) * dw
+
+        self.ema_cluster_size.value = cluster_size
+        self.ema_w.value = w
+
+        # 🔴 sync codebook
+        n = cluster_size + 1e-5
+        self.codebook = w / n[:, None]
+
+# ============================================================================
+# QUANTUM WRAPPER (FFT – SAFE)
+# ============================================================================
+
+class QuantumWrapperFixed(nn.Module):
+    config: Dict[str, Any]
+
+    def setup(self):
+        self.use_fft = self.config.get("use_fft", True)
+
+    def __call__(self, x, deterministic=True):
+        if not self.use_fft:
+            return x, self._metrics(x, x)
+
+        x_c = x.astype(jnp.complex64)
+        fft = jnp.fft.fft(x_c, axis=-1)
+        out = jnp.real(jnp.fft.ifft(fft, axis=-1))
+
+        return out, self._metrics(x, out)
+
+    def _metrics(self, x_in, x_out):
+        num = jnp.sum(x_in * x_out)
+        den = jnp.linalg.norm(x_in) * jnp.linalg.norm(x_out) + 1e-8
+        coherence = jnp.clip(num / den, 0.0, 1.0)
+
+        mse = jnp.mean((x_in - x_out) ** 2)
+        fidelity = jnp.exp(-mse)
+
+        return {
+            "coherence": coherence,
+            "fidelity": fidelity,
+            "efficiency": coherence * fidelity,
+        }
+
+# ============================================================================
+# MANIFOLD
+# ============================================================================
+
+def test_quantum_submodel_integration():
+    """Test complete integration with fixed signatures."""
+    
+    # Configuration
+    config = QuantumSubmodelConfig(
+        vqbit_config={
+            'codebook_size': 256,
+            'embedding_dim': 128,
+            'commitment_cost': 0.25,
+            'ema_decay': 0.99
+        },
+        quantum_wrapper_config={
+            'use_fft': True,
+            'phase_modulation': True,
+            'coherence_threshold': 0.8
+        },
+        enable_metrics=True,
+        use_manifold_projection=True,
+        manifold_curvature=-1.0  # Hyperbolic
+    )
+    
+    # Initialize model
+    model = QuantumSubmodel(config)
+    
+    # Test data
+    data_loader = TestDataLoaderFixed(batch_size=2, seq_len=64)
+    test_batch = data_loader.generate_batch()
+    
+    # Initialize parameters
+    key = jax.random.PRNGKey(42)
+    
+    # Dummy forward pass for initialization
+    dummy_input = {
+        'tokens': jnp.ones((1, 64), dtype=jnp.int32),
+        'attention_mask': jnp.ones((1, 64), dtype=jnp.int32)
+    }
+    
+    variables = model.init(key, dummy_input)
+    
+    # Forward pass with real data
+    outputs, metrics = model.apply(variables, test_batch, deterministic=True)
+    
+    #  Validate outputs
+    assert isinstance(outputs, dict), "Output should be dict"
+    assert 'tokens' in outputs, "Output should contain 'tokens'"
+    assert isinstance(metrics, dict), "Metrics should be dict"
+    
+    #  Validate real metric names
+    expected_metrics = [
+        'commitment_loss', 'codebook_usage', 'quantization_loss',
+        'coherence_score', 'fidelity_score', 'quantum_efficiency'
+    ]
+    
+    for metric in expected_metrics:
+        assert metric in metrics, f"Missing metric: {metric}"
+        assert isinstance(metrics[metric], (float, int)), f"Metric {metric} should be numeric"
+    
+    logger.info(" All P0 fixes validated successfully!")
+    logger.info(f"Output shape: {outputs['tokens'].shape}")
+    logger.info(f"Metrics: {list(metrics.keys())}")
+    return outputs, metrics
+
+# ============================================================================
+# TRAIN STEP (OPTAX READY)
+# ============================================================================
+
+def create_train_step(model, optimizer):
+    @jax.jit
+    def train_step(state, batch):
+
+        def loss_fn(params):
+            (out, metrics) = model.apply(
+                {"params": params, **state.ema},
+                batch,
+                deterministic=False,
+                mutable=["ema"],
+            )
+            
+            #  FIXED: Use real metric names for loss
+            primary_loss = jnp.mean(outputs['tokens']**2)  # Dummy loss for testing
+            regularization = (
+                metrics['commitment_loss'] + 
+                metrics['quantization_loss'] * 0.1
+            )
+
+            return loss, (metrics)
+
+        (loss, metrics), grads = jax.value_and_grad(
+            loss_fn, has_aux=True
+        )(state.params)
+
+        state = state.apply_gradients(grads=grads)
+        return state, metrics
+
+if __name__ == "__main__":
+    # Run integration test
+    outputs, metrics = test_quantum_submodel_integration()
+    logger.info("\n P0 fixes complete - ready for pilot training!")

--- a/capibara/vq/stubs/flax.pyi
+++ b/capibara/vq/stubs/flax.pyi
@@ -1,0 +1,72 @@
+"""Stubs mejorados para Flax con tipos precisos."""
+from typing import (Any, Callable, Dict, List, Optional, Protocol, Sequence, 
+                   Tuple, TypeVar, Union, runtime_checkable)
+import numpy as np
+from capibara.jax import jax
+from capibara.jax.numpy import Array
+from capibara.jax.random import PRNGKey
+
+T = TypeVar('T')
+Shape = Tuple[int, ...]
+Dtype = np.dtype
+ParameterDict = Dict[str, Dict[str, Array]]
+Initializer = Callable[[PRNGKey, Shape, Dtype], Array]
+
+# Protocolos base ------------------------------------------------------
+@runtime_checkable
+class Module(Protocol):
+    name: str
+    parent: Optional['Module']
+    
+    def setup(self) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def init(self, rng: PRNGKey, *args: Any, **kwargs: Any) -> ParameterDict: ...
+    def apply(self, variables: ParameterDict, *args: Any, **kwargs: Any) -> Array: ...
+    def lazy_init(self, rng: PRNGKey, *args: Any, **kwargs: Any) -> ParameterDict: ...
+
+# Capas comunes --------------------------------------------------------
+class Dense(Module):
+    features: int
+    use_bias: bool
+    kernel_init: Initializer
+    bias_init: Initializer
+    dtype: Dtype
+    param_dtype: Dtype
+    
+    def __call__(self, inputs: Array) -> Array: ...
+
+class LayerNorm(Module):
+    epsilon: float
+    dtype: Dtype
+    use_bias: bool
+    use_scale: bool
+    bias_init: Initializer
+    scale_init: Initializer
+    
+    def __call__(self, x: Array) -> Array: ...
+
+class Dropout(Module):
+    rate: float
+    broadcast_dims: Sequence[int]
+    
+    def __call__(self, x: Array, deterministic: bool) -> Array: ...
+
+# Decoradores ----------------------------------------------------------
+def compact(fn: Callable[..., Any]) -> Callable[..., Any]: ...
+
+def remat(
+    fn: Callable[..., Any],
+    prevent_cse: bool = True,
+    static_argnums: Union[int, Sequence[int]] = (),
+) -> Callable[..., Any]: ...
+
+# Inicializadores ------------------------------------------------------
+class initializers:
+    @staticmethod
+    def zeros() -> Initializer: ...
+    @staticmethod
+    def ones() -> Initializer: ...
+    @staticmethod
+    def uniform(scale: float = 0.01) -> Initializer: ...
+    @staticmethod
+    def normal(stddev: float = 0.01) -> Initializer: ...

--- a/capibara/vq/stubs/jax.pyi
+++ b/capibara/vq/stubs/jax.pyi
@@ -1,0 +1,183 @@
+"""Type stubs for JAX core functionality."""
+
+from typing import (
+    Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple, TypeVar, Union,
+    overload, runtime_checkable
+)
+import numpy as np
+from typing_extensions import Literal
+
+__all__ = [
+    'Array', 'PRNGKey', 'Shape', 'Dtype',
+    'random', 'numpy', 'lax', 'errors',
+    'random_key', 'random_split', 'random_normal', 'random_uniform',
+    'vmap', 'jit', 'grad', 'value_and_grad', 'config'
+]
+
+T = TypeVar('T')
+Shape = Tuple[int, ...]
+Dtype = np.dtype
+
+@runtime_checkable
+class Array(Protocol):
+    """Protocol for JAX array objects."""
+    
+    shape: Shape
+    dtype: Dtype
+    ndim: int
+    size: int
+    
+    def __array__(self, dtype: Optional[Dtype] = None) -> np.ndarray:
+        """Convert to NumPy array."""
+        ...
+    
+    def __getitem__(self, key: Any) -> 'Array':
+        """Array indexing."""
+        ...
+    
+    def __setitem__(self, key: Any, value: Any) -> None:
+        """In-place array modification."""
+        ...
+    
+    def reshape(self, *shape: int) -> 'Array':
+        """Reshape the array."""
+        ...
+    
+    def astype(self, dtype: Dtype) -> 'Array':
+        """Convert array to different dtype."""
+        ...
+    
+    def transpose(self, *axes: int) -> 'Array':
+        """Transpose array dimensions."""
+        ...
+
+class PRNGKey(Array):
+    """Pseudorandom number generator key."""
+    ...
+
+# Core modules
+class JaxRandomModule(Protocol):
+    """Type stub for jax.random module."""
+    
+    def normal(self, key: PRNGKey, shape: Shape, dtype: Dtype = ...) -> Array:
+        ...
+    
+    def uniform(self, key: PRNGKey, shape: Shape, dtype: Dtype = ...) -> Array:
+        ...
+    
+    def split(self, key: PRNGKey, num: int) -> Tuple[PRNGKey, ...]:
+        ...
+
+random: JaxRandomModule = ...
+numpy: Any = ...  # Would be more precise in a complete stub
+lax: Any = ...    # Would be more precise in a complete stub
+errors: Any = ...
+
+# Random functions
+def random_key(seed: int) -> PRNGKey:
+    """Creates a pseudorandom number generator key from an integer seed."""
+    ...
+
+def random_split(key: PRNGKey, num: int = 2) -> Tuple[PRNGKey, ...]:
+    """Splits a PRNG key into multiple subkeys."""
+    ...
+
+def random_normal(
+    key: PRNGKey,
+    shape: Shape,
+    dtype: Dtype = np.float32
+) -> Array:
+    """Generates random values from a normal distribution."""
+    ...
+
+def random_uniform(
+    key: PRNGKey,
+    shape: Shape,
+    dtype: Dtype = np.float32,
+    minval: float = 0.0,
+    maxval: float = 1.0
+) -> Array:
+    """Generates random values from a uniform distribution."""
+    ...
+
+# Transformations
+@overload
+def vmap(
+    fun: Callable[..., T],
+    in_axes: Union[int, Sequence[Optional[int]]] = 0,
+    out_axes: Union[int, Sequence[int]] = 0
+) -> Callable[..., Union[T, Tuple[T, ...]]]: ...
+
+@overload
+def vmap(
+    fun: Callable[..., Tuple[T, ...]],
+    in_axes: Union[int, Sequence[Optional[int]]] = 0,
+    out_axes: Union[int, Sequence[int]] = 0
+) -> Callable[..., Tuple[T, ...]]: ...
+
+def vmap(fun, in_axes=0, out_axes=0):
+    """Vectorizes a function along specified axes."""
+    ...
+
+def jit(
+    fun: Callable[..., T],
+    static_argnums: Union[int, Sequence[int]] = (),
+    static_argnames: Union[str, Sequence[str]] = (),
+    donate_argnums: Union[int, Sequence[int]] = ()
+) -> Callable[..., T]:
+    """Compiles a function using XLA."""
+    ...
+
+def grad(
+    fun: Callable[..., T],
+    argnums: Union[int, Sequence[int]] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False,
+    allow_int: bool = False
+) -> Callable[..., Any]:
+    """Computes the gradient of a function."""
+    ...
+
+def value_and_grad(
+    fun: Callable[..., T],
+    argnums: Union[int, Sequence[int]] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False,
+    allow_int: bool = False
+) -> Callable[..., Tuple[T, Any]]:
+    """Computes both the value and gradient of a function."""
+    ...
+
+# Configuration
+class config:
+    """JAX configuration settings."""
+    
+    @staticmethod
+    def enable_memory_stats() -> None:
+        """Enable memory statistics tracking."""
+        ...
+    
+    @staticmethod
+    def disable_memory_stats() -> None:
+        """Disable memory statistics tracking."""
+        ...
+    
+    @staticmethod
+    def read(key: str) -> Any:
+        """Read a configuration value."""
+        ...
+    
+    @staticmethod
+    def update(key: str, value: Any) -> None:
+        """Update a configuration value."""
+        ...
+    
+    @staticmethod
+    def get(key: str) -> Any:
+        """Alias for read()."""
+        ...
+    
+    @staticmethod
+    def set(key: str, value: Any) -> None:
+        """Alias for update()."""
+        ...

--- a/capibara/vq/ultra_vq_orchestrator.py
+++ b/capibara/vq/ultra_vq_orchestrator.py
@@ -1,0 +1,954 @@
+"""
+Ultra VQ Orchestrator - CapibaraGPT v3024
+========================================
+
+Sistema ultra-advanced de vector Quantization with:
+- 9 Técnicas de Quantization: Adaptive, Residual, Product, Binary, Spherical, Learnable, Quantum, Neural, Ultra-Hybrid
+- Multi-Modal Intelligence: Text, Vision, Audio, Code, Mathematical
+- Adaptive VQ Architecture: Self-optimizing codebooks
+- Quantum-Ready Implementation: Preparado for quantum computing
+- Real-Time Optimization: Performance optimization automática
+- Cross-Modal Transfer: Knowledge transfer between modalidades
+- Ultra-Compression: Ratios de compresión ultra-avanzados
+
+Este es el sistema de quantization more advanced jamás creado.
+"""
+
+import os
+import sys
+import time
+import logging
+import asyncio
+import numpy as np
+from typing import Dict, Any, Optional, List, Union, Tuple, Callable
+from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from enum import Enum
+import json
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from collections import deque, defaultdict
+
+# Path setup
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(script_dir))
+if project_root not in sys.path:
+    # Fixed: Using proper imports instead of sys.path manipulation
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Safe imports for ultra systems integration
+# ============================================================================
+
+# JAX and ML libraries
+ML_LIBRARIES_AVAILABLE = True
+try:
+    from capibara.jax import jax, jnp
+    import flax.linen as nn
+    logger.info(" ML libraries available for Ultra VQ")
+except ImportError as e:
+    logger.debug("ML libraries not available: %s", e)
+    ML_LIBRARIES_AVAILABLE = False
+
+# Meta Loop System integration
+META_LOOP_AVAILABLE = True
+try:
+    from capibara.meta_loop import UltraMetaLoopOrchestrator, create_ultra_meta_loop_ecosystem
+    logger.info(" Meta Loop System integration available")
+except ImportError as e:
+    logger.debug("Meta Loop System not available: %s", e)
+    META_LOOP_AVAILABLE = False
+
+# VQ Legacy modules
+VQ_LEGACY_AVAILABLE = True
+try:
+    from .vqbit.vqbit_layer import VQbitLayer
+    from .monitoring.vq_monitoring import VQMonitoringSystem
+    logger.info(" VQ Legacy modules available")
+except ImportError as e:
+    logger.debug("VQ legacy modules not available: %s", e)
+    VQ_LEGACY_AVAILABLE = False
+
+# ============================================================================
+# Configuration and Enums
+# ============================================================================
+
+class VQTechnique(str, Enum):
+    """Advanced vector Quantization techniques."""
+    ADAPTIVE = "adaptive"                    # Adaptive VQ based on data distribution
+    RESIDUAL = "residual"                    # Residual vector Quantization
+    PRODUCT = "product"                      # Product Quantization
+    BINARY = "binary"                        # Binary vector Quantization
+    SPHERICAL = "spherical"                  # Spherical Quantization
+    LEARNABLE = "learnable"                  # Learnable vector Quantization
+    QUANTUM = "quantum"                      # Quantum-inspired VQ
+    NEURAL = "neural"                        # Neural vector Quantization
+    ULTRA_HYBRID = "ultra_hybrid"           # Ultra-advanced hybrid approach
+
+class VQModality(str, Enum):
+    """Supported modalities for vector quantization."""
+    TEXT = "text"
+    VISION = "vision"
+    AUDIO = "audio"
+    CODE = "code"
+    MATHEMATICAL = "mathematical"
+    MULTIMODAL = "multimodal"
+    TEMPORAL = "temporal"
+    SPATIAL = "spatial"
+
+class VQOptimizationMode(str, Enum):
+    """Optimization modes for VQ systems."""
+    COMPRESSION = "compression"              # Maximum compression ratio
+    QUALITY = "quality"                      # Maximum reconstruction quality
+    SPEED = "speed"                         # Maximum processing speed
+    BALANCED = "balanced"                   # Balanced optimization
+    ADAPTIVE = "adaptive"                   # Adaptive optimization
+    ULTRA_EFFICIENT = "ultra_efficient"    # Ultra-efficient processing
+
+class VQArchitecture(str, Enum):
+    """VQ architecture types."""
+    HIERARCHICAL = "hierarchical"           # Hierarchical codebooks
+    DISTRIBUTED = "distributed"             # Distributed quantization
+    CASCADED = "cascaded"                   # Cascaded quantization layers
+    ATTENTION_BASED = "attention_based"     # Attention-based VQ
+    TRANSFORMER = "transformer"            # Transformer-based VQ
+    QUANTUM_READY = "quantum_ready"         # Quantum-ready architecture
+
+@dataclass
+class UltraVQConfig:
+    """Configuration for ultra-advanced VQ system."""
+    
+    # Core VQ configuration
+    vq_technique: VQTechnique = VQTechnique.ULTRA_HYBRID
+    modalities: List[VQModality] = field(default_factory=lambda: [
+        VQModality.TEXT, VQModality.VISION, VQModality.AUDIO
+    ])
+    optimization_mode: VQOptimizationMode = VQOptimizationMode.ULTRA_EFFICIENT
+    architecture: VQArchitecture = VQArchitecture.QUANTUM_READY
+    
+    # Codebook configuration
+    codebook_sizes: Dict[str, int] = field(default_factory=lambda: {
+        "text": 8192,
+        "vision": 16384,
+        "audio": 4096,
+        "code": 8192,
+        "mathematical": 2048,
+        "multimodal": 32768
+    })
+    
+    embedding_dims: Dict[str, int] = field(default_factory=lambda: {
+        "text": 1024,
+        "vision": 2048,
+        "audio": 512,
+        "code": 1024,
+        "mathematical": 768,
+        "multimodal": 4096
+    })
+    
+    # Advanced parameters
+    enable_adaptive_learning: bool = True
+    enable_cross_modal_transfer: bool = True
+    enable_quantum_optimization: bool = True
+    enable_real_time_optimization: bool = True
+    
+    # Performance parameters
+    compression_target: float = 0.1  # Target compression ratio
+    quality_threshold: float = 0.95  # Minimum quality threshold
+    latency_target: float = 10.0     # Target latency in ms
+    
+    # Meta-learning integration
+    enable_meta_learning: bool = True
+    meta_learning_frequency: int = 1000  # Meta-learning every N steps
+    
+    # Monitoring and validation
+    enable_comprehensive_monitoring: bool = True
+    enable_performance_prediction: bool = True
+    enable_anomaly_detection: bool = True
+
+@dataclass
+class VQPerformanceMetrics:
+    """Performance metrics for VQ system."""
+    compression_ratio: float = 0.0
+    reconstruction_quality: float = 0.0
+    processing_latency: float = 0.0
+    codebook_utilization: float = 0.0
+    cross_modal_coherence: float = 0.0
+    quantum_efficiency: float = 0.0
+    adaptive_improvement: float = 0.0
+    overall_score: float = 0.0
+
+@dataclass
+class VQState:
+    """State of the VQ system."""
+    current_iteration: int = 0
+    total_optimizations: int = 0
+    performance_history: List[VQPerformanceMetrics] = field(default_factory=list)
+    adaptation_history: List[Dict[str, Any]] = field(default_factory=list)
+    best_configuration: Optional[Dict[str, Any]] = None
+    current_configuration: Dict[str, Any] = field(default_factory=dict)
+    convergence_status: str = "not_converged"
+    last_optimization_time: float = 0.0
+
+# ============================================================================
+# Ultra VQ Orchestrator
+# ============================================================================
+
+class UltraVQOrchestrator:
+    """Orquestador ultra-advanced de vector Quantization."""
+    
+    def __init__(self, config: UltraVQConfig):
+        self.config = config
+        self.state = VQState()
+        self.performance_history = deque(maxlen=1000)
+        self.optimization_queue = asyncio.Queue()
+        
+        # VQ components
+        self.vq_engines = {}
+        self.codebook_manager = None
+        self.adaptive_controller = None
+        self.quantum_optimizer = None
+        
+        # Meta-learning integration
+        self.meta_loop_orchestrator = None
+        
+        # Monitoring and metrics
+        self.global_metrics = {
+            "total_vq_operations": 0,
+            "successful_optimizations": 0,
+            "failed_optimizations": 0,
+            "average_compression_ratio": 0.0,
+            "average_quality_score": 0.0,
+            "average_latency": 0.0,
+            "system_efficiency": 1.0,
+            "quantum_acceleration": 0.0,
+            "cross_modal_transfer_rate": 0.0
+        }
+        
+        # Threading and async management
+        self.executor = ThreadPoolExecutor(max_workers=16)
+        self.monitoring_task = None
+        self.optimization_task = None
+        self.vq_lock = threading.Lock()
+        
+        # Initialize the orchestrator
+        self._initialize_orchestrator()
+    
+    def _initialize_orchestrator(self):
+        """Initialize the ultra VQ orchestrator."""
+        
+        logger.info(" Initializing Ultra VQ Orchestrator")
+        
+        # Initialize VQ engines
+        self._initialize_vq_engines()
+        
+        # Initialize codebook management
+        self._initialize_codebook_manager()
+        
+        # Initialize adaptive systems
+        self._initialize_adaptive_systems()
+        
+        # Initialize quantum optimization
+        self._initialize_quantum_systems()
+        
+        # Initialize meta-learning integration
+        self._initialize_meta_learning()
+        
+        # Initialize monitoring systems
+        self._initialize_monitoring_systems()
+        
+        logger.info(f" Ultra VQ Orchestrator initialized")
+        logger.info(f"    Technique: {self.config.vq_technique.value}")
+        logger.info(f"    Architecture: {self.config.architecture.value}")
+        logger.info(f"    Modalities: {len(self.config.modalities)}")
+    
+    def _initialize_vq_engines(self):
+        """Initialize VQ engines for different techniques."""
+        
+        self.vq_engines = {
+            VQTechnique.ADAPTIVE: AdaptiveVQEngine(self.config),
+            VQTechnique.RESIDUAL: ResidualVQEngine(self.config),
+            VQTechnique.PRODUCT: ProductVQEngine(self.config),
+            VQTechnique.BINARY: BinaryVQEngine(self.config),
+            VQTechnique.SPHERICAL: SphericalVQEngine(self.config),
+            VQTechnique.LEARNABLE: LearnableVQEngine(self.config),
+            VQTechnique.QUANTUM: QuantumVQEngine(self.config),
+            VQTechnique.NEURAL: NeuralVQEngine(self.config),
+            VQTechnique.ULTRA_HYBRID: UltraHybridVQEngine(self.config)
+        }
+        
+        logger.info(f" {len(self.vq_engines)} VQ engines initialized")
+    
+    def _initialize_codebook_manager(self):
+        """Initialize advanced codebook management."""
+        
+        self.codebook_manager = UltraCodebookManager(
+            codebook_sizes=self.config.codebook_sizes,
+            embedding_dims=self.config.embedding_dims,
+            enable_adaptive=self.config.enable_adaptive_learning,
+            enable_quantum=self.config.enable_quantum_optimization
+        )
+        
+        logger.info(" Ultra Codebook Manager initialized")
+    
+    def _initialize_adaptive_systems(self):
+        """Initialize adaptive VQ systems."""
+        
+        if self.config.enable_adaptive_learning:
+            self.adaptive_controller = AdaptiveVQController(
+                config=self.config,
+                performance_targets={
+                    "compression_ratio": self.config.compression_target,
+                    "quality_threshold": self.config.quality_threshold,
+                    "latency_target": self.config.latency_target
+                }
+            )
+            
+            logger.info(" Adaptive VQ Controller initialized")
+    
+    def _initialize_quantum_systems(self):
+        """Initialize quantum optimization systems."""
+        
+        if self.config.enable_quantum_optimization:
+            self.quantum_optimizer = QuantumVQOptimizer(
+                config=self.config,
+                codebook_manager=self.codebook_manager
+            )
+            
+            logger.info(" Quantum VQ Optimizer initialized")
+    
+    def _initialize_meta_learning(self):
+        """Initialize meta-learning integration."""
+        
+        if self.config.enable_meta_learning and META_LOOP_AVAILABLE:
+            try:
+                # Create meta-learning ecosystem for VQ optimization
+                meta_ecosystem = create_ultra_meta_loop_ecosystem(
+                    meta_learning_strategy="ultra_hybrid",
+                    self_improvement_mode="ultra_dynamic",
+                    enable_smart_contracts=True,
+                    enable_all_features=True
+                )
+                
+                self.meta_loop_orchestrator = meta_ecosystem["orchestrator"]
+                logger.info(" Meta-learning integration initialized")
+                
+            except Exception as e:
+                logger.warning(f"️ Meta-learning integration failed: {e}")
+    
+    def _initialize_monitoring_systems(self):
+        """Initialize comprehensive monitoring systems."""
+        
+        if self.config.enable_comprehensive_monitoring:
+            # Start background monitoring
+            asyncio.create_task(self._start_monitoring_loop())
+            
+            # Start optimization loop
+            asyncio.create_task(self._start_optimization_loop())
+        
+        logger.info(" Monitoring systems initialized")
+    
+    async def ultra_vq_quantize(
+        self,
+        data: np.ndarray,
+        modality: VQModality,
+        technique: Optional[VQTechnique] = None,
+        optimization_target: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Execute ultra-advanced vector quantization."""
+        
+        start_time = time.time()
+        
+        vq_result = {
+            "modality": modality.value,
+            "technique": technique.value if technique else self.config.vq_technique.value,
+            "optimization_target": optimization_target,
+            "status": "processing",
+            "quantized_data": None,
+            "codebook_indices": None,
+            "reconstruction": None,
+            "performance_metrics": {},
+            "quantum_enhancement": {}
+        }
+        
+        try:
+            with self.vq_lock:
+                # 1. Select optimal VQ technique
+                selected_technique = technique or await self._select_optimal_technique(data, modality)
+                vq_result["selected_technique"] = selected_technique.value
+                
+                # 2. Execute VQ with selected technique
+                vq_engine = self.vq_engines[selected_technique]
+                quantization_result = await vq_engine.quantize(data, modality)
+                
+                # 3. Apply adaptive optimization if enabled
+                if self.config.enable_adaptive_learning and self.adaptive_controller:
+                    optimization_result = await self._apply_adaptive_optimization(
+                        quantization_result, modality
+                    )
+                    quantization_result.update(optimization_result)
+                
+                # 4. Apply quantum enhancement if enabled
+                if self.config.enable_quantum_optimization and self.quantum_optimizer:
+                    quantum_result = await self._apply_quantum_enhancement(
+                        quantization_result, modality
+                    )
+                    vq_result["quantum_enhancement"] = quantum_result
+                
+                # 5. Compute performance metrics
+                performance_metrics = await self._compute_performance_metrics(
+                    data, quantization_result, modality
+                )
+                vq_result["performance_metrics"] = performance_metrics
+                
+                # 6. Apply cross-modal transfer if enabled
+                if self.config.enable_cross_modal_transfer:
+                    transfer_result = await self._apply_cross_modal_transfer(
+                        quantization_result, modality
+                    )
+                    vq_result["cross_modal_transfer"] = transfer_result
+                
+                # Update state
+                self.state.current_iteration += 1
+                self.state.total_optimizations += 1
+                self.state.last_optimization_time = time.time()
+                
+                # Store results
+                vq_result.update({
+                    "quantized_data": quantization_result.get("quantized"),
+                    "codebook_indices": quantization_result.get("indices"),
+                    "reconstruction": quantization_result.get("reconstruction"),
+                    "status": "completed"
+                })
+                
+                execution_time = (time.time() - start_time) * 1000
+                vq_result["execution_time_ms"] = execution_time
+                
+                # Update global metrics
+                self._update_global_metrics(vq_result)
+                
+                return vq_result
+        
+        except Exception as e:
+            logger.error(f"Ultra VQ quantization failed: {e}")
+            vq_result["status"] = "failed"
+            vq_result["error"] = str(e)
+            return vq_result
+    
+    async def multi_modal_vq_optimization(
+        self,
+        data_dict: Dict[str, np.ndarray],
+        optimization_objective: str = "global_efficiency"
+    ) -> Dict[str, Any]:
+        """Execute multi-modal VQ optimization."""
+        
+        optimization_result = {
+            "modalities": list(data_dict.keys()),
+            "objective": optimization_objective,
+            "individual_results": {},
+            "cross_modal_coherence": {},
+            "global_optimization": {}
+        }
+        
+        try:
+            # Optimize each modality individually
+            individual_results = {}
+            for modality_str, data in data_dict.items():
+                modality = VQModality(modality_str)
+                
+                vq_result = await self.ultra_vq_quantize(
+                    data, modality, optimization_target=optimization_objective
+                )
+                individual_results[modality_str] = vq_result
+            
+            optimization_result["individual_results"] = individual_results
+            
+            # Cross-modal coherence optimization
+            if len(data_dict) > 1:
+                coherence_result = await self._optimize_cross_modal_coherence(
+                    individual_results
+                )
+                optimization_result["cross_modal_coherence"] = coherence_result
+            
+            # Global optimization across modalities
+            global_result = await self._optimize_global_vq_performance(
+                individual_results, optimization_objective
+            )
+            optimization_result["global_optimization"] = global_result
+            
+            return optimization_result
+            
+        except Exception as e:
+            logger.error(f"Multi-modal VQ optimization failed: {e}")
+            optimization_result["error"] = str(e)
+            return optimization_result
+    
+    async def adaptive_vq_learning(
+        self,
+        training_data: Dict[str, np.ndarray],
+        learning_objective: str = "comprehensive_optimization"
+    ) -> Dict[str, Any]:
+        """Execute adaptive VQ learning with meta-learning integration."""
+        
+        learning_result = {
+            "training_modalities": list(training_data.keys()),
+            "learning_objective": learning_objective,
+            "adaptation_cycles": [],
+            "meta_learning_insights": {},
+            "final_performance": {}
+        }
+        
+        try:
+            # Execute multiple adaptation cycles
+            for cycle in range(5):  # 5 adaptation cycles
+                cycle_result = {}
+                
+                # Train VQ on current data
+                vq_results = await self.multi_modal_vq_optimization(
+                    training_data, f"cycle_{cycle}_optimization"
+                )
+                cycle_result["vq_optimization"] = vq_results
+                
+                # Apply adaptive learning
+                if self.adaptive_controller:
+                    adaptation_result = await self.adaptive_controller.adapt_from_results(
+                        vq_results
+                    )
+                    cycle_result["adaptation"] = adaptation_result
+                
+                # Meta-learning optimization
+                if self.meta_loop_orchestrator:
+                    meta_result = await self._apply_meta_learning_optimization(
+                        vq_results, cycle
+                    )
+                    cycle_result["meta_learning"] = meta_result
+                
+                learning_result["adaptation_cycles"].append(cycle_result)
+            
+            # Generate meta-learning insights
+            if self.meta_loop_orchestrator:
+                insights = await self._generate_meta_learning_insights(
+                    learning_result["adaptation_cycles"]
+                )
+                learning_result["meta_learning_insights"] = insights
+            
+            # end performance evaluation
+            final_performance = await self._evaluate_final_performance(
+                training_data
+            )
+            learning_result["final_performance"] = final_performance
+            
+            return learning_result
+            
+        except Exception as e:
+            logger.error(f"Adaptive VQ learning failed: {e}")
+            learning_result["error"] = str(e)
+            return learning_result
+    
+    def get_ultra_vq_status(self) -> Dict[str, Any]:
+        """Get comprehensive VQ system status."""
+        
+        return {
+            "config": {
+                "technique": self.config.vq_technique.value,
+                "architecture": self.config.architecture.value,
+                "optimization_mode": self.config.optimization_mode.value,
+                "modalities": [m.value for m in self.config.modalities]
+            },
+            "state": {
+                "current_iteration": self.state.current_iteration,
+                "total_optimizations": self.state.total_optimizations,
+                "convergence_status": self.state.convergence_status,
+                "performance_history_size": len(self.state.performance_history)
+            },
+            "engines": {
+                "vq_techniques": len(self.vq_engines),
+                "codebook_manager": self.codebook_manager is not None,
+                "adaptive_controller": self.adaptive_controller is not None,
+                "quantum_optimizer": self.quantum_optimizer is not None
+            },
+            "integrations": {
+                "meta_learning": self.meta_loop_orchestrator is not None,
+                "ml_libraries": ML_LIBRARIES_AVAILABLE,
+                "vq_legacy": VQ_LEGACY_AVAILABLE
+            },
+            "capabilities": {
+                "adaptive_learning": self.config.enable_adaptive_learning,
+                "cross_modal_transfer": self.config.enable_cross_modal_transfer,
+                "quantum_optimization": self.config.enable_quantum_optimization,
+                "real_time_optimization": self.config.enable_real_time_optimization
+            },
+            "performance": self.global_metrics,
+            "health": {
+                "system_status": "healthy",
+                "vq_active": True,
+                "optimization_active": self.config.enable_real_time_optimization
+            }
+        }
+    
+    # ============================================================================
+    # Private Helper Methods
+    # ============================================================================
+    
+    async def _select_optimal_technique(
+        self, 
+        data: np.ndarray, 
+        modality: VQModality
+    ) -> VQTechnique:
+        """Select optimal VQ technique based on data characteristics."""
+        
+        # Analyze data characteristics
+        data_stats = self._analyze_data_characteristics(data)
+        
+        # Use adaptive controller for technique selection
+        if self.adaptive_controller:
+            return await self.adaptive_controller.select_technique(data_stats, modality)
+        
+        # Default to configured technique
+        return self.config.vq_technique
+    
+    def _analyze_data_characteristics(self, data: np.ndarray) -> Dict[str, float]:
+        """Analyze data characteristics for optimal technique selection."""
+        
+        return {
+            "dimensionality": data.shape[-1] if len(data.shape) > 1 else 1,
+            "sparsity": np.mean(data == 0),
+            "variance": np.var(data),
+            "entropy": self._compute_entropy(data),
+            "complexity": self._compute_complexity(data)
+        }
+    
+    def _compute_entropy(self, data: np.ndarray) -> float:
+        """Compute data entropy."""
+        # Simplified entropy computation
+        data_flat = data.flatten()
+        unique, counts = np.unique(data_flat, return_counts=True)
+        probabilities = counts / len(data_flat)
+        return -np.sum(probabilities * np.log2(probabilities + 1e-10))
+    
+    def _compute_complexity(self, data: np.ndarray) -> float:
+        """Compute data complexity measure."""
+        # Simplified complexity based on variance and correlation
+        if len(data.shape) > 1:
+            correlation = np.corrcoef(data.flatten()[:1000], data.flatten()[1000:2000])[0, 1]
+            return np.var(data) * (1 - abs(correlation))
+        else:
+            return np.var(data)
+    
+    async def _apply_adaptive_optimization(
+        self,
+        quantization_result: Dict[str, Any],
+        modality: VQModality
+    ) -> Dict[str, Any]:
+        """Apply adaptive optimization to VQ results."""
+        
+        if not self.adaptive_controller:
+            return {}
+        
+        return await self.adaptive_controller.optimize_result(
+            quantization_result, modality
+        )
+    
+    async def _apply_quantum_enhancement(
+        self,
+        quantization_result: Dict[str, Any],
+        modality: VQModality
+    ) -> Dict[str, Any]:
+        """Apply quantum enhancement to VQ results."""
+        
+        if not self.quantum_optimizer:
+            return {}
+        
+        return await self.quantum_optimizer.enhance_quantization(
+            quantization_result, modality
+        )
+    
+    async def _compute_performance_metrics(
+        self,
+        original_data: np.ndarray,
+        quantization_result: Dict[str, Any],
+        modality: VQModality
+    ) -> VQPerformanceMetrics:
+        """Compute comprehensive performance metrics."""
+        
+        # Reconstruction quality
+        if "reconstruction" in quantization_result:
+            reconstruction = quantization_result["reconstruction"]
+            quality = 1.0 - np.mean((original_data - reconstruction) ** 2) / np.var(original_data)
+        else:
+            quality = 0.0
+        
+        # Compression ratio
+        original_size = original_data.nbytes
+        compressed_size = len(quantization_result.get("indices", [])) * 4  # Assuming int32 indices
+        compression_ratio = compressed_size / original_size if original_size > 0 else 0.0
+        
+        return VQPerformanceMetrics(
+            compression_ratio=compression_ratio,
+            reconstruction_quality=quality,
+            processing_latency=quantization_result.get("processing_time", 0.0),
+            codebook_utilization=quantization_result.get("utilization", 0.0),
+            cross_modal_coherence=0.0,  # Computed separately
+            quantum_efficiency=quantization_result.get("quantum_efficiency", 0.0),
+            adaptive_improvement=quantization_result.get("adaptive_improvement", 0.0),
+            overall_score=(quality + (1.0 - compression_ratio)) / 2.0
+        )
+    
+    def _update_global_metrics(self, vq_result: Dict[str, Any]):
+        """Update global performance metrics."""
+        
+        self.global_metrics["total_vq_operations"] += 1
+        
+        if vq_result["status"] == "completed":
+            self.global_metrics["successful_optimizations"] += 1
+            
+            # Update performance averages
+            metrics = vq_result.get("performance_metrics", {})
+            if hasattr(metrics, 'compression_ratio'):
+                self.global_metrics["average_compression_ratio"] = self._update_running_average(
+                    self.global_metrics["average_compression_ratio"],
+                    metrics.compression_ratio,
+                    self.global_metrics["successful_optimizations"]
+                )
+        else:
+            self.global_metrics["failed_optimizations"] += 1
+    
+    def _update_running_average(self, current_avg: float, new_value: float, count: int) -> float:
+        """Update running average efficiently."""
+        if count == 1:
+            return new_value
+        return current_avg + (new_value - current_avg) / count
+    
+    async def _start_monitoring_loop(self):
+        """Start background monitoring loop."""
+        
+        while True:
+            try:
+                # Collect system metrics
+                system_metrics = await self._collect_system_metrics()
+                
+                # Monitor performance trends
+                await self._monitor_performance_trends()
+                
+                # Check for optimization opportunities
+                await self._check_optimization_opportunities()
+                
+                await asyncio.sleep(30)  # Monitor every 30 seconds
+                
+            except Exception as e:
+                logger.error(f"Monitoring loop error: {e}")
+                await asyncio.sleep(60)
+    
+    async def _start_optimization_loop(self):
+        """Start background optimization loop."""
+        
+        while True:
+            try:
+                # Wait for optimization requests
+                optimization_request = await self.optimization_queue.get()
+                
+                # Process optimization
+                await self._process_optimization_request(optimization_request)
+                
+            except Exception as e:
+                logger.error(f"Optimization loop error: {e}")
+                await asyncio.sleep(1)
+
+# ============================================================================
+# VQ Engine Base Classes
+# ============================================================================
+
+class BaseVQEngine(ABC):
+    """Base class for VQ engines."""
+    
+    def __init__(self, config: UltraVQConfig):
+        self.config = config
+    
+    @abstractmethod
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        """Execute quantization with specific technique."""
+        pass
+
+# ============================================================================
+# Specialized VQ Engines
+# ============================================================================
+
+class AdaptiveVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Adaptive VQ implementation
+        return {"technique": "adaptive", "quantized": data, "indices": [], "reconstruction": data}
+
+class ResidualVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Residual VQ implementation
+        return {"technique": "residual", "quantized": data, "indices": [], "reconstruction": data}
+
+class ProductVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Product VQ implementation
+        return {"technique": "product", "quantized": data, "indices": [], "reconstruction": data}
+
+class BinaryVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Binary VQ implementation
+        return {"technique": "binary", "quantized": data, "indices": [], "reconstruction": data}
+
+class SphericalVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Spherical VQ implementation
+        return {"technique": "spherical", "quantized": data, "indices": [], "reconstruction": data}
+
+class LearnableVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Learnable VQ implementation
+        return {"technique": "learnable", "quantized": data, "indices": [], "reconstruction": data}
+
+class QuantumVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Quantum-inspired VQ implementation
+        return {"technique": "quantum", "quantized": data, "indices": [], "reconstruction": data}
+
+class NeuralVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Neural VQ implementation
+        return {"technique": "neural", "quantized": data, "indices": [], "reconstruction": data}
+
+class UltraHybridVQEngine(BaseVQEngine):
+    async def quantize(self, data: np.ndarray, modality: VQModality) -> Dict[str, Any]:
+        # Ultra-hybrid VQ implementation combining all techniques
+        return {"technique": "ultra_hybrid", "quantized": data, "indices": [], "reconstruction": data}
+
+# ============================================================================
+# Support Classes
+# ============================================================================
+
+class UltraCodebookManager:
+    """Ultra-advanced codebook management."""
+    
+    def __init__(self, codebook_sizes: Dict[str, int], embedding_dims: Dict[str, int], 
+                 enable_adaptive: bool = True, enable_quantum: bool = True):
+        self.codebook_sizes = codebook_sizes
+        self.embedding_dims = embedding_dims
+        self.enable_adaptive = enable_adaptive
+        self.enable_quantum = enable_quantum
+
+class AdaptiveVQController:
+    """Adaptive VQ control system."""
+    
+    def __init__(self, config: UltraVQConfig, performance_targets: Dict[str, float]):
+        self.config = config
+        self.performance_targets = performance_targets
+    
+    async def select_technique(self, data_stats: Dict[str, float], modality: VQModality) -> VQTechnique:
+        # Intelligent technique selection
+        return VQTechnique.ULTRA_HYBRID
+    
+    async def optimize_result(self, result: Dict[str, Any], modality: VQModality) -> Dict[str, Any]:
+        # Result optimization
+        return {"adaptive_improvement": 0.1}
+    
+    async def adapt_from_results(self, results: Dict[str, Any]) -> Dict[str, Any]:
+        # Adaptation from results
+        return {"adaptation_applied": True}
+
+class QuantumVQOptimizer:
+    """Quantum-inspired VQ optimization."""
+    
+    def __init__(self, config: UltraVQConfig, codebook_manager: UltraCodebookManager):
+        self.config = config
+        self.codebook_manager = codebook_manager
+    
+    async def enhance_quantization(self, result: Dict[str, Any], modality: VQModality) -> Dict[str, Any]:
+        # Quantum enhancement
+        return {"quantum_efficiency": 0.15}
+
+# ============================================================================
+# Factory Functions
+# ============================================================================
+
+def create_ultra_vq_system(
+    config: Optional[UltraVQConfig] = None,
+    **kwargs
+) -> UltraVQOrchestrator:
+    """Create ultra-advanced VQ system."""
+    
+    if config is None:
+        config = UltraVQConfig(**kwargs)
+    
+    return UltraVQOrchestrator(config)
+
+def create_ultra_vq_config(
+    vq_technique: VQTechnique = VQTechnique.ULTRA_HYBRID,
+    optimization_mode: VQOptimizationMode = VQOptimizationMode.ULTRA_EFFICIENT,
+    enable_all_features: bool = True,
+    **kwargs
+) -> UltraVQConfig:
+    """Create optimized VQ configuration."""
+    
+    return UltraVQConfig(
+        vq_technique=vq_technique,
+        optimization_mode=optimization_mode,
+        enable_adaptive_learning=enable_all_features,
+        enable_cross_modal_transfer=enable_all_features,
+        enable_quantum_optimization=enable_all_features,
+        enable_real_time_optimization=enable_all_features,
+        enable_meta_learning=enable_all_features and META_LOOP_AVAILABLE,
+        **kwargs
+    )
+
+def demonstrate_ultra_vq():
+    """Demonstrate the ultra VQ system."""
+    
+    logger.info(" ULTRA VQ ORCHESTRATOR DEMONSTRATION")
+    logger.info("=" * 60)
+    
+    # Create configuration
+    config = create_ultra_vq_config(
+        vq_technique=VQTechnique.ULTRA_HYBRID,
+        optimization_mode=VQOptimizationMode.ULTRA_EFFICIENT,
+        enable_all_features=True
+    )
+    
+    logger.info(f" Configuration created:")
+    logger.info(f"   - Technique: {config.vq_technique.value}")
+    logger.info(f"   - Architecture: {config.architecture.value}")
+    logger.info(f"   - Modalities: {len(config.modalities)}")
+    
+    # Create orchestrator
+    orchestrator = create_ultra_vq_system(config)
+    
+    # Get system status
+    status = orchestrator.get_ultra_vq_status()
+    
+    logger.info(f"\n System Status:")
+    logger.info(f"   - VQ techniques: {status['engines']['vq_techniques']}")
+    logger.info(f"   - Adaptive learning: {'' if status['capabilities']['adaptive_learning'] else ''}")
+    logger.info(f"   - Quantum optimization: {'' if status['capabilities']['quantum_optimization'] else ''}")
+    
+    return orchestrator
+
+__all__ = [
+    # Configuration and enums
+    'VQTechnique',
+    'VQModality',
+    'VQOptimizationMode',
+    'VQArchitecture',
+    'UltraVQConfig',
+    'VQPerformanceMetrics',
+    'VQState',
+    
+    # Main orchestrator
+    'UltraVQOrchestrator',
+    
+    # Factory functions
+    'create_ultra_vq_system',
+    'create_ultra_vq_config',
+    'demonstrate_ultra_vq',
+    
+    # Status flags
+    'ML_LIBRARIES_AVAILABLE',
+    'META_LOOP_AVAILABLE',
+    'VQ_LEGACY_AVAILABLE'
+]

--- a/capibara/vq/vim_vq/__init__.py
+++ b/capibara/vq/vim_vq/__init__.py
@@ -1,0 +1,26 @@
+"""
+ViM-VQ: Vector Quantization with Vision in Mind
+
+Implementation of Vector Quantization optimized for vision applications
+with complete TPU support and CapibaraGPT-specific optimizations.
+"""
+
+from .quantizer import (
+    ViMVQConfig,
+    VIM_VQ_BASE,
+    VIM_VQ_SMALL,
+    VIM_VQ_LARGE,
+    ViMVQQuantizer,
+    create_vim_vq_quantizer,
+)
+
+__all__ = [
+    'ViMVQQuantizer',
+    'ViMVQConfig',
+    'create_vim_vq_quantizer',
+    'VIM_VQ_SMALL',
+    'VIM_VQ_BASE',
+    'VIM_VQ_LARGE'
+]
+
+__version__ = '1.0.0'

--- a/capibara/vq/vim_vq/metrics.py
+++ b/capibara/vq/vim_vq/metrics.py
@@ -1,0 +1,115 @@
+"""Metrics of evaluation for ViM-VQ"""
+
+from typing import Dict, Tuple
+import numpy as np
+from capibara.jax import numpy as jnp
+
+try:
+    from core.decorators import profile_execution
+except ImportError:
+    profile_execution = None
+
+
+def compute_mse(original: jnp.ndarray, reconstructed: jnp.ndarray) -> float:
+    """Calculate mean squared error"""
+    return float(jnp.mean((original - reconstructed) ** 2))
+
+def compute_snr(original: jnp.ndarray, reconstructed: jnp.ndarray) -> float:
+    """Calculate signal-to-noise ratio in dB"""
+    mse = compute_mse(original, reconstructed)
+    if mse == 0:
+        return float('inf')
+    power = jnp.mean(original ** 2)
+    return float(10 * jnp.log10(power / mse))
+
+def compute_correlation(original: jnp.ndarray, reconstructed: jnp.ndarray) -> float:
+    """Calculate Pearson correlation"""
+    orig_flat = original.reshape(-1)
+    recon_flat = reconstructed.reshape(-1)
+
+    orig_mean = jnp.mean(orig_flat)
+    recon_mean = jnp.mean(recon_flat)
+
+    numerator = jnp.sum((orig_flat - orig_mean) * (recon_flat - recon_mean))
+    denominator = jnp.sqrt(
+        jnp.sum((orig_flat - orig_mean) ** 2) *
+        jnp.sum((recon_flat - recon_mean) ** 2)
+    )
+
+    if denominator == 0:
+        return 1.0 if numerator == 0 else 0.0
+    return float(numerator / denominator)
+
+def compute_compression_ratio(original_size: int, compressed_size: int) -> float:
+    """Calculate compression ratio"""
+    return original_size / compressed_size
+
+def _evaluate_layer_quantization_impl(
+    original: jnp.ndarray,
+    reconstructed: jnp.ndarray,
+    codebook_size: int,
+    original_dtype
+) -> Dict[str, float]:
+    """Evaluate layer quantization quality"""
+
+    # Sizes for compression ratio
+    original_size = original.size * original_dtype.itemsize
+    compressed_size = (
+        codebook_size * original.shape[-1] * original_dtype.itemsize +  # codebook
+        original.size * np.log2(codebook_size) / 8  # indices
+    )
+
+    return {
+        "mse": compute_mse(original, reconstructed),
+        "snr_db": compute_snr(original, reconstructed),
+        "correlation": compute_correlation(original, reconstructed),
+        "compression_ratio": compute_compression_ratio(original_size, int(compressed_size))
+    }
+
+
+if profile_execution is not None:
+    evaluate_layer_quantization = profile_execution("evaluate_layer_quantization")(_evaluate_layer_quantization_impl)
+else:
+    evaluate_layer_quantization = _evaluate_layer_quantization_impl
+
+
+def evaluate_model_quantization(
+    results: Dict[str, Dict]
+) -> Tuple[Dict[str, float], Dict[str, Dict[str, float]]]:
+    """Evaluate model quantization quality"""
+
+    # Metrics by layer
+    layer_metrics = {}
+
+    # Aggregated metrics
+    total_mse = 0
+    total_snr = 0
+    total_correlation = 0
+    total_compression = 0
+    n_layers = len(results)
+
+    for layer_name, layer_results in results.items():
+        metrics = evaluate_layer_quantization(
+            layer_results["original"],
+            layer_results["reconstructed"],
+            layer_results["codebook"].shape[0],
+            layer_results["original"].dtype
+        )
+
+        layer_metrics[layer_name] = metrics
+
+        # Accumulate metrics
+        total_mse += metrics["mse"]
+        total_snr += metrics["snr_db"]
+        total_correlation += metrics["correlation"]
+        total_compression += metrics["compression_ratio"]
+
+    # Averages
+    avg_metrics = {
+        "avg_mse": total_mse / n_layers,
+        "avg_snr_db": total_snr / n_layers,
+        "avg_correlation": total_correlation / n_layers,
+        "avg_compression_ratio": total_compression / n_layers
+    }
+
+    return avg_metrics, layer_metrics

--- a/capibara/vq/vim_vq/quantizer.py
+++ b/capibara/vq/vim_vq/quantizer.py
@@ -1,0 +1,129 @@
+"""
+ViM-VQ: vector Quantization with Vision in Mind
+implementation optimizada for CapibaraGPT with soporte tpu.
+"""
+
+import jax
+import logging
+import jax.numpy as jnp
+from flax import linen as nn
+from dataclasses import dataclass
+from typing import Dict, Any, Tuple, Optional, List
+import numpy as np
+from functools import partial
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class ViMVQConfig:
+    """setup for ViM-VQ Quantizer"""
+    num_embeddings: int = 8192
+    embedding_dim: int = 512
+    commitment_cost: float = 0.25
+    decay: float = 0.99
+    use_vision_bias: bool = True
+    temperature: float = 0.5
+    
+class ViMVQQuantizer(nn.Module):
+    """Cuantizador ViM-VQ optimizado for aplicaciones de visión"""
+    
+    config: ViMVQConfig
+    
+    def setup(self):
+        self.embeddings = nn.Embed(
+            self.config.num_embeddings,
+            self.config.embedding_dim
+        )
+        
+    def __call__(self, x: jnp.ndarray, training: bool = True) -> Dict[str, jnp.ndarray]:
+        """Forward pass del cuantizador"""
+        # Flatten input
+        input_shape = x.shape
+        flat_input = x.reshape(-1, x.shape[-1])
+        
+        # Compute distances to embeddings
+        distances = jnp.sum((flat_input[..., None, :] - self.embeddings.embedding) ** 2, axis=-1)
+        
+        # Find closest embeddings
+        encoding_indices = jnp.argmin(distances, axis=-1)
+        
+        # Get quantized values
+        quantized = self.embeddings(encoding_indices)
+        quantized = quantized.reshape(input_shape)
+        
+        # Compute losses
+        commitment_loss = jnp.mean((jax.lax.stop_gradient(quantized) - x) ** 2)
+        vq_loss = jnp.mean((quantized - jax.lax.stop_gradient(x)) ** 2)
+        
+        # Straight-through estimator
+        quantized = x + jax.lax.stop_gradient(quantized - x)
+        
+        return {
+            'quantized': quantized,
+            'indices': encoding_indices,
+            'commitment_loss': commitment_loss,
+            'vq_loss': vq_loss,
+            'perplexity': jnp.exp(-jnp.sum(jnp.mean(distances, axis=0) * jnp.log(jnp.mean(distances, axis=0) + 1e-10)))
+        }
+        
+    def quantize_model(self, model_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Cuantiza un model complete"""
+        quantized_params = {}
+        total_params_original = 0
+        total_params_quantized = 0
+        
+        for layer_name, params in model_params.items():
+            if isinstance(params, jnp.ndarray) and params.ndim >= 2:
+                # Apply quantization
+                result = self(params, training=False)
+                quantized_params[layer_name] = result['quantized']
+                
+                total_params_original += params.size
+                total_params_quantized += result['indices'].size * jnp.log2(self.config.num_embeddings) / 8
+            else:
+                quantized_params[layer_name] = params
+                total_params_original += params.size if hasattr(params, 'size') else 0
+                total_params_quantized += params.size if hasattr(params, 'size') else 0
+        
+        compression = total_params_original / max(total_params_quantized, 1)
+        
+        return {
+            'quantized_params': quantized_params,
+            'compression_ratio': compression,
+            'original_size': total_params_original,
+            'quantized_size': total_params_quantized
+        }
+
+def create_vim_vq_quantizer(config: Optional[ViMVQConfig] = None) -> ViMVQQuantizer:
+    """Factory function for create un cuantizador ViM-VQ"""
+    if config is None:
+        config = ViMVQConfig()
+    return ViMVQQuantizer(config=config)
+
+# Configuraciones predefinidas
+VIM_VQ_SMALL = ViMVQConfig(
+    num_embeddings=1024,
+    embedding_dim=256,
+    commitment_cost=0.25,
+    decay=0.99,
+    use_vision_bias=True,
+    temperature=0.5
+)
+
+VIM_VQ_BASE = ViMVQConfig(
+    num_embeddings=8192,
+    embedding_dim=512,
+    commitment_cost=0.25,
+    decay=0.99,
+    use_vision_bias=True,
+    temperature=0.5
+)
+
+VIM_VQ_LARGE = ViMVQConfig(
+    num_embeddings=16384,
+    embedding_dim=1024,
+    commitment_cost=0.25,
+    decay=0.99,
+    use_vision_bias=True,
+    temperature=0.5
+)

--- a/capibara/vq/vim_vq/vim_vq_config.py
+++ b/capibara/vq/vim_vq/vim_vq_config.py
@@ -1,0 +1,126 @@
+"""
+Vim VQ Config - Configuration for Vector Quantization with hardware support.
+
+This module provides configuration for ViM-VQ (Vector-Quantized Vision Model)
+with optimized support for TPU v4-32, TPU v6, and ARM Axion processors.
+
+Key Components:
+    - VimVQConfig: Configuration dataclass for VQ settings
+
+Features:
+    - Sub-vector quantization parameters
+    - Hardware-specific optimizations (TPU, ARM, CPU)
+    - Memory pool configuration
+    - Multimodal support (audio, vision)
+    - Preset configurations for different hardware
+
+Author: Skydesk International Dev Team.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Literal
+
+@dataclass
+class VimVQConfig:
+    """setup for ViM-VQ with soporte tpu v4-32 and ARM Axion"""
+    
+    # Parámetros básicos VQ
+    d: int = 8                     # dimension de sub-vectores
+    k: int = 256                   # size de codebook
+    n_neighbors: int = 4           # Vecinos cercanos for convex combination
+    
+    # Parámetros de optimization
+    max_iters: int = 20           # Iteraciones máximas
+    lr: float = 1e-2              # Learning rate
+    convergence_threshold: float = 1e-6  # Umbral convergencia
+    incremental_threshold: float = 0.99  # Umbral for hard assignment
+    
+    # setup hardware
+    device: Literal["tpu", "arm", "cpu"] = "tpu"
+    tpu_version: Literal["v4-32", "v6"] = "v4-32"
+    use_arm_sve: bool = True      # use SVE/SVE2 en ARM
+    
+    # Optimizaciones memory
+    use_memory_pool: bool = True  # use memory pools optimizados
+    cache_size_mb: int = 512      # size cache for codebook
+    
+    # setup multimodal
+    support_audio: bool = True    # Soporte for features audio
+    support_vision: bool = True   # Soporte for features visuales
+    
+    # tpu específico
+    tpu_batch_size: int = 128
+    use_bfloat16: bool = True
+    tpu_async_copy: bool = True
+    
+    # ARM específico
+    arm_sve_length: Optional[int] = None  # Auto-detectado if None
+    arm_numa_node: int = 0
+    use_huge_pages: bool = True
+    
+    @classmethod
+    def from_preset(cls, preset: Literal["tpu_v4", "tpu_v6", "arm_axion"]) -> "VimVQConfig":
+        """Crea setup since preset predefinido"""
+        if preset == "tpu_v4":
+            return cls(
+                d=8, k=256, device="tpu", tpu_version="v4-32",
+                use_memory_pool=True, cache_size_mb=512
+            )
+        elif preset == "tpu_v6":
+            return cls(
+                d=16, k=512, device="tpu", tpu_version="v6",
+                use_memory_pool=True, cache_size_mb=1024
+            )
+        elif preset == "arm_axion":
+            return cls(
+                d=8, k=128, device="arm", use_arm_sve=True,
+                use_memory_pool=True, cache_size_mb=256
+            )
+        else:
+            raise ValueError(f"Preset desconocido: {preset}")
+
+    @classmethod
+    def for_tpu_v4_32(cls) -> "VimVQConfig":
+        """setup optimizada for tpu v4-32"""
+        return cls(
+            d=8,
+            k=256,
+            n_neighbors=4,
+            device="tpu",
+            use_memory_pool=True,
+            cache_size_mb=2048,
+            tpu_batch_size=256,
+            use_bfloat16=True,
+            tpu_async_copy=True
+        )
+    
+    @classmethod
+    def for_arm_axion(cls) -> "VimVQConfig":
+        """setup optimizada for ARM Axion"""
+        return cls(
+            d=8,
+            k=128,  # Reducido for better rendimiento en ARM
+            n_neighbors=4,
+            device="arm",
+            use_memory_pool=True,
+            cache_size_mb=1024,
+            use_huge_pages=True
+        )
+
+    def validate(self):
+        """Valida la setup"""
+        assert self.d > 0, "d debe ser positivo"
+        assert self.k > 0, "k debe ser positivo"
+        assert self.n_neighbors > 0, "n_neighbors debe ser positivo"
+        assert self.n_neighbors <= self.k, "n_neighbors debe ser <= k"
+        assert self.cache_size_mb > 0, "cache_size_mb debe ser positivo"
+        
+        if self.device == "tpu":
+            assert self.tpu_batch_size > 0, "tpu_batch_size debe ser positivo"
+        elif self.device == "arm":
+            assert self.arm_numa_node >= 0, "arm_numa_node debe ser >= 0"
+
+# Configuraciones predefinidas
+DEFAULT_TPU_V4_CONFIG = VimVQConfig.from_preset("tpu_v4")
+DEFAULT_TPU_V6_CONFIG = VimVQConfig.from_preset("tpu_v6")
+DEFAULT_ARM_CONFIG = VimVQConfig.from_preset("arm_axion") 

--- a/capibara/vq/vim_vq/vim_vq_router.py
+++ b/capibara/vq/vim_vq/vim_vq_router.py
@@ -1,0 +1,208 @@
+"""Router especializado for ViM-VQ with soporte tpu v4-32 and ARM Axion"""
+
+from typing import Dict, Optional, Union, List
+import numpy as np
+
+from capibara.jax import numpy as jnp
+from capibara.jax import random
+from capibara.core.routers.base import BaseRouter
+from capibara.core.router import EnhancedRouter
+
+from ..configs.vim_vq_config import VimVQConfig
+from .quantizer import ViMVQQuantizer
+
+class ViMVQRouter(BaseRouter):
+    """Router especializado for cuantización ViM-VQ"""
+    
+    def __init__(self, 
+                 config: Optional[VimVQConfig] = None,
+                 key: Optional[random.PRNGKey] = None,
+                 parent_router: Optional[EnhancedRouter] = None):
+        """Inicializa router ViM-VQ
+        
+        Args:
+            config: setup ViM-VQ
+            key: JAX random key
+            parent_router: Router padre for integration
+        """
+        super().__init__()
+        
+        self.config = config or VimVQConfig()
+        self.key = key or random.PRNGKey(0)
+        self.parent_router = parent_router
+        
+        # Inicializar quantizer
+        self.quantizer = ViMVQQuantizer(self.config, self.key)
+        
+        # cache for modelos cuantizados
+        self.quantized_models_cache = {}
+        
+    def should_quantize_layer(self, layer_name: str, layer_weights: jnp.ndarray) -> bool:
+        """Determina if una capa debe be cuantizada
+        
+        Args:
+            layer_name: Nombre de la capa
+            layer_weights: Pesos de la capa
+            
+        Returns:
+            bool: True if la capa debe be cuantizada
+        """
+        # not cuantizar capas pequeñas
+        if np.prod(layer_weights.shape) < 1024:
+            return False
+            
+        # not cuantizar capas de embedding
+        if "embed" in layer_name.lower():
+            return False
+            
+        # not cuantizar capas de normalización
+        if any(x in layer_name.lower() for x in ["norm", "batch", "layer"]):
+            return False
+            
+        return True
+        
+    def get_optimal_config(self, 
+                          model_size: int,
+                          device: str = "tpu") -> VimVQConfig:
+        """Obtiene setup óptima basada en size del model
+        
+        Args:
+            model_size: size del model en parámetros
+            device: Dispositivo objetivo ('tpu' or 'arm')
+            
+        Returns:
+            VimVQConfig: setup optimizada
+        """
+        if device == "tpu":
+            # tpu v4-32 optimizations
+            if model_size > 1e9:  # >1B params
+                return VimVQConfig(
+                    d=16,
+                    k=512,
+                    n_neighbors=8,
+                    device="tpu"
+                )
+            else:
+                return VimVQConfig(
+                    d=8,
+                    k=256,
+                    n_neighbors=4,
+                    device="tpu"
+                )
+        else:
+            # ARM optimizations
+            if model_size > 1e9:
+                return VimVQConfig(
+                    d=8,
+                    k=256,
+                    n_neighbors=4,
+                    device="arm",
+                    use_memory_pool=True,
+                    cache_size_mb=2048
+                )
+            else:
+                return VimVQConfig(
+                    d=8,
+                    k=128,
+                    n_neighbors=4,
+                    device="arm",
+                    use_memory_pool=True,
+                    cache_size_mb=1024
+                )
+    
+    def route_model(self,
+                   model_weights: Dict[str, jnp.ndarray],
+                   model_config: Optional[Dict] = None) -> Dict[str, Dict]:
+        """Rutea un model for cuantización
+        
+        Args:
+            model_weights: Pesos del model
+            model_config: setup optional
+            
+        Returns:
+            Dict: Resultados de cuantización by capa
+        """
+        # calculate size del model
+        total_params = sum(np.prod(w.shape) for w in model_weights.values())
+        
+        # determine dispositivo
+        device = "tpu" if self.config.device == "tpu" else "arm"
+        
+        # obtain config óptima
+        if not model_config or "vim_vq" not in model_config:
+            self.config = self.get_optimal_config(total_params, device)
+        
+        # cache key
+        cache_key = f"{total_params}_{device}"
+        
+        # verify cache
+        if cache_key in self.quantized_models_cache:
+            return self.quantized_models_cache[cache_key]
+        
+        # Cuantizar capas seleccionadas
+        results = {}
+        for layer_name, weights in model_weights.items():
+            if self.should_quantize_layer(layer_name, weights):
+                results[layer_name] = self.quantizer.quantize_layer(
+                    weights,
+                    layer_name=layer_name
+                )
+            else:
+                results[layer_name] = {
+                    'quantized_weights': weights,
+                    'compression_ratio': 1.0,
+                    'mse': 0.0
+                }
+        
+        # update cache
+        self.quantized_models_cache[cache_key] = results
+        
+        return results
+    
+    def get_compression_stats(self, results: Dict[str, Dict]) -> Dict:
+        """Calcula estadísticas de compresión
+        
+        Args:
+            results: Resultados de cuantización
+            
+        Returns:
+            Dict: Estadísticas de compresión
+        """
+        total_params = 0
+        total_compressed = 0
+        total_mse = 0
+        layers_quantized = 0
+        
+        for layer_name, layer_results in results.items():
+            params = np.prod(layer_results['quantized_weights'].shape)
+            total_params += params
+            
+            if layer_results['compression_ratio'] > 1.0:
+                total_compressed += params / layer_results['compression_ratio']
+                total_mse += layer_results['mse']
+                layers_quantized += 1
+            else:
+                total_compressed += params
+        
+        return {
+            'total_params': total_params,
+            'compressed_params': total_compressed,
+            'compression_ratio': total_params / total_compressed,
+            'avg_mse': total_mse / layers_quantized if layers_quantized > 0 else 0.0,
+            'layers_quantized': layers_quantized
+        }
+    
+    def integrate_with_parent(self, parent_router: EnhancedRouter):
+        """Integra with router padre
+        
+        Args:
+            parent_router: Router padre for integration
+        """
+        self.parent_router = parent_router
+        
+        # Registrar callback for post-procesamiento
+        if hasattr(parent_router, 'register_post_processor'):
+            parent_router.register_post_processor(
+                'vim_vq',
+                self.route_model
+            )

--- a/capibara/vq/vq_arm_axion.py
+++ b/capibara/vq/vq_arm_axion.py
@@ -1,0 +1,359 @@
+"""
+VQ ARM Axion Optimizer - Vector Quantization optimized for ARM Axion processors.
+
+This module provides optimizations for vector quantization operations on ARM Axion
+processors with SVE2 support. It includes attention optimization, VQ codebook
+operations, and memory-efficient computation strategies.
+
+Key Features:
+    - SVE2 vectorization support (512-bit vectors)
+    - Symmetric/asymmetric quantization (4-bit, 8-bit)
+    - Memory-optimized chunked attention
+    - Kleidi AI integration support
+    - Portable fallback for non-ARM systems
+
+Hardware Support:
+    - ARM Axion (Google Cloud)
+    - ARM Neoverse (AWS Graviton)
+    - Any ARM processor with SVE/SVE2
+    - Fallback support for x86/other architectures
+
+Usage:
+    >>> config = ARMAxionConfig(embedding_dim=4096, num_codebooks=64)
+    >>> optimizer = ARMAxionOptimizer(config)
+    >>> quantized, indices = optimizer.optimize_vq_forward(x, codebook)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# PyTorch imports with graceful fallback
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+    torch = None
+    nn = None
+    F = None
+
+# Check for ARM Axion availability
+ARM_AXION_AVAILABLE = False
+try:
+    import platform
+    machine = platform.machine().lower()
+    ARM_AXION_AVAILABLE = 'arm' in machine or 'aarch64' in machine
+except Exception:
+    pass
+
+
+@dataclass
+class ARMAxionConfig:
+    """Configuration for ARM Axion optimizer.
+
+    Attributes:
+        embedding_dim: Dimension of embeddings for VQ operations.
+        num_codebooks: Number of VQ codebooks.
+        enable_sve2: Enable SVE2 vectorization (512-bit).
+        sve_vector_bits: SVE vector width in bits.
+        enable_quantization: Enable weight quantization.
+        quantization_bits: Quantization bit width (4 or 8).
+        quantization_scheme: 'symmetric' or 'asymmetric'.
+        max_batch_size: Maximum batch size for chunked processing.
+        enable_memory_opt: Enable memory optimization.
+        chunk_size: Chunk size for memory-efficient attention.
+        num_threads: Number of threads for parallel operations.
+        enable_kleidi: Enable Kleidi AI optimizations.
+        enable_cache: Enable caching for repeated computations.
+    """
+    embedding_dim: int = 4096
+    num_codebooks: int = 64
+    enable_sve2: bool = True
+    sve_vector_bits: int = 512
+    enable_quantization: bool = True
+    quantization_bits: int = 8
+    quantization_scheme: str = "symmetric"
+    max_batch_size: int = 32
+    enable_memory_opt: bool = True
+    chunk_size: int = 4096
+    num_threads: int = 8
+    enable_kleidi: bool = True
+    enable_cache: bool = True
+
+
+class ARMAxionOptimizer:
+    """
+    Optimizer for ARM Axion processor operations.
+
+    Provides optimized implementations for attention, linear layers,
+    and vector quantization operations on ARM processors.
+
+    In the absence of ARM-specific kernels, operations fall back to
+    standard PyTorch/NumPy implementations.
+
+    Attributes:
+        config: ARMAxionConfig instance.
+        _initialized: Whether ARM optimizations are active.
+
+    Example:
+        >>> optimizer = ARMAxionOptimizer()
+        >>> output = optimizer.optimize_attention(query, key, value)
+        >>> quantized, indices = optimizer.optimize_vq_forward(x, codebook)
+    """
+
+    def __init__(self, config: Optional[ARMAxionConfig] = None):
+        """
+        Initialize ARM Axion optimizer.
+
+        Args:
+            config: Optional configuration. Uses defaults if not provided.
+        """
+        self.config = config or ARMAxionConfig()
+        self._initialized = False
+        self._initialize_arm_optimizations()
+
+    def _initialize_arm_optimizations(self) -> None:
+        """Initialize ARM-specific optimizations."""
+        if not TORCH_AVAILABLE:
+            logger.warning("PyTorch not available; using NumPy fallback paths")
+            return
+
+        if ARM_AXION_AVAILABLE:
+            logger.info(f"ARM Axion detected - SVE2: {self.config.enable_sve2}")
+            logger.info(f"Vector bits: {self.config.sve_vector_bits}")
+            self._initialized = True
+        else:
+            logger.info("ARM Axion: Running in portable mode (non-ARM system)")
+            self._initialized = True
+
+    def optimize_linear(self, layer: "nn.Linear") -> "nn.Module":
+        """
+        Optimize a linear layer for ARM execution.
+
+        Currently a no-op that returns the original layer.
+        Future implementations may apply quantization or SVE2 optimization.
+
+        Args:
+            layer: PyTorch Linear layer to optimize.
+
+        Returns:
+            Optimized Linear layer (or original if optimization not applicable).
+        """
+        if not TORCH_AVAILABLE:
+            return layer
+
+        if not isinstance(layer, nn.Linear):
+            return layer
+
+        # Placeholder for future ARM-specific optimizations
+        # Could apply: quantization, SVE2 kernels, etc.
+        return layer
+
+    def optimize_attention(
+        self,
+        query: "torch.Tensor",
+        key: "torch.Tensor",
+        value: "torch.Tensor"
+    ) -> "torch.Tensor":
+        """
+        Compute optimized scaled dot-product attention.
+
+        Implements memory-efficient chunked attention when enabled,
+        processing the sequence in chunks to reduce peak memory usage.
+
+        Args:
+            query: Query tensor [batch, heads, seq_q, head_dim].
+            key: Key tensor [batch, heads, seq_k, head_dim].
+            value: Value tensor [batch, heads, seq_k, head_dim].
+
+        Returns:
+            Attention output tensor [batch, heads, seq_q, head_dim].
+
+        Note:
+            Falls back to NumPy for systems without PyTorch.
+        """
+        if not TORCH_AVAILABLE:
+            # NumPy fallback for basic 2D attention
+            q = np.asarray(query)
+            k = np.asarray(key)
+            v = np.asarray(value)
+
+            d_k = q.shape[-1]
+            scores = q @ k.T / math.sqrt(d_k)
+            scores = scores - scores.max(axis=-1, keepdims=True)
+            weights = np.exp(scores)
+            weights = weights / weights.sum(axis=-1, keepdims=True)
+            return weights @ v
+
+        d_k = query.size(-1)
+        scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(d_k)
+
+        # Memory-optimized chunked softmax
+        if self.config.enable_memory_opt and scores.size(-1) > self.config.chunk_size:
+            chunks = torch.split(scores, self.config.chunk_size, dim=-1)
+            softmax_chunks = [F.softmax(chunk, dim=-1) for chunk in chunks]
+            weights = torch.cat(softmax_chunks, dim=-1)
+        else:
+            weights = F.softmax(scores, dim=-1)
+
+        return torch.matmul(weights, value)
+
+    def optimize_vq_forward(
+        self,
+        x: "torch.Tensor",
+        codebook: "torch.Tensor"
+    ) -> Tuple["torch.Tensor", "torch.Tensor"]:
+        """
+        Optimized vector quantization forward pass.
+
+        Finds the nearest codebook entry for each input vector using
+        efficient squared Euclidean distance computation.
+
+        Args:
+            x: Input tensor of shape [..., embedding_dim].
+            codebook: Codebook tensor of shape [num_codes, embedding_dim].
+
+        Returns:
+            Tuple of:
+                - quantized: Quantized vectors, same shape as x.
+                - indices: Codebook indices, shape [...].
+
+        Note:
+            Uses the identity: ||x - c||^2 = ||x||^2 + ||c||^2 - 2*x.c
+            to avoid explicit difference computation.
+        """
+        if not TORCH_AVAILABLE:
+            # NumPy fallback
+            x_flat = np.reshape(x, (-1, x.shape[-1]))
+            cb = np.asarray(codebook)
+
+            # Squared Euclidean distance
+            x2 = (x_flat ** 2).sum(axis=1, keepdims=True)
+            c2 = (cb ** 2).sum(axis=1)[None, :]
+            xc = x_flat @ cb.T
+            dist = x2 + c2 - 2 * xc
+
+            indices = np.argmin(dist, axis=1)
+            quantized = cb[indices].reshape(x.shape)
+            return quantized, indices
+
+        # PyTorch implementation
+        original_shape = x.shape
+        flat_x = x.reshape(-1, x.size(-1))
+
+        # Efficient squared distance computation
+        x2 = (flat_x ** 2).sum(dim=1, keepdim=True)
+        c2 = (codebook ** 2).sum(dim=1)[None, :]
+        xc = torch.matmul(flat_x, codebook.t())
+        dist = x2 + c2 - 2 * xc
+
+        indices = torch.argmin(dist, dim=1)
+        quantized = torch.index_select(codebook, 0, indices)
+        quantized = quantized.reshape(original_shape)
+
+        return quantized, indices
+
+    def get_performance_metrics(self) -> Dict[str, Any]:
+        """
+        Get performance and environment metrics.
+
+        Returns:
+            Dictionary with metrics including:
+                - arm_axion_available: Whether ARM Axion is detected.
+                - sve2_enabled: Whether SVE2 is enabled.
+                - quantization_enabled: Whether quantization is enabled.
+                - num_threads: Number of threads configured.
+                - cpu_usage: Current CPU usage (if psutil available).
+                - memory_usage_mb: Process memory usage (if psutil available).
+        """
+        metrics: Dict[str, Any] = {
+            "arm_axion_available": ARM_AXION_AVAILABLE,
+            "sve2_enabled": bool(self.config.enable_sve2 and ARM_AXION_AVAILABLE),
+            "quantization_enabled": bool(self.config.enable_quantization),
+            "quantization_bits": self.config.quantization_bits,
+            "num_threads": int(self.config.num_threads),
+            "memory_opt_enabled": self.config.enable_memory_opt,
+            "chunk_size": self.config.chunk_size,
+        }
+
+        # Try to get system metrics
+        try:
+            import psutil
+            p = psutil.Process()
+            metrics.update({
+                "cpu_usage": psutil.cpu_percent(interval=0.1),
+                "memory_usage_mb": p.memory_info().rss / 1024 ** 2,
+                "threads_active": p.num_threads(),
+            })
+        except ImportError:
+            pass
+
+        return metrics
+
+
+def create_arm_axion_optimizer(
+    config: Optional[ARMAxionConfig] = None
+) -> ARMAxionOptimizer:
+    """
+    Factory function to create ARM Axion optimizer.
+
+    Args:
+        config: Optional configuration.
+
+    Returns:
+        ARMAxionOptimizer instance.
+    """
+    return ARMAxionOptimizer(config)
+
+
+class VQArmAxion(ARMAxionOptimizer):
+    """Backward-compatible alias for ARM Axion VQ optimizer."""
+    pass
+
+
+# Global optimizer instance
+_global_optimizer: Optional[ARMAxionOptimizer] = None
+
+
+def get_arm_axion_optimizer() -> ARMAxionOptimizer:
+    """Get global ARM Axion optimizer instance."""
+    global _global_optimizer
+    if _global_optimizer is None:
+        _global_optimizer = create_arm_axion_optimizer()
+    return _global_optimizer
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    optimizer = create_arm_axion_optimizer()
+    metrics = optimizer.get_performance_metrics()
+
+    logger.info("ARM Axion Optimizer Test")
+    logger.info(f"  ARM Axion Available: {metrics['arm_axion_available']}")
+    logger.info(f"  SVE2 Enabled: {metrics['sve2_enabled']}")
+    logger.info(f"  Quantization: {metrics['quantization_bits']}-bit")
+
+    if TORCH_AVAILABLE:
+        # Test VQ forward
+        x = torch.randn(4, 16, 256)
+        codebook = torch.randn(512, 256)
+        quantized, indices = optimizer.optimize_vq_forward(x, codebook)
+        logger.info(f"  VQ Test: Input {x.shape} -> Quantized {quantized.shape}")
+
+        # Test attention
+        q = torch.randn(2, 8, 32, 64)
+        k = torch.randn(2, 8, 32, 64)
+        v = torch.randn(2, 8, 32, 64)
+        attn_out = optimizer.optimize_attention(q, k, v)
+        logger.info(f"  Attention Test: Output {attn_out.shape}")

--- a/capibara/vq/vqbit/__init__.py
+++ b/capibara/vq/vqbit/__init__.py
@@ -1,0 +1,594 @@
+"""
+VQBit Module for Capibara-6
+
+Advanced Vector Quantization implementations optimized for different hardware backends:
+- TPU v6e-64 optimized VQ with BF16 and mesh sharding
+- ARM Axion optimized VQ with NEON vectorization
+- Multimodal VQ for cross-modal applications
+- Adaptive VQ with dynamic optimization
+- Integration with MoE and Adaptive systems
+"""
+
+import os
+import sys
+import logging
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+
+# Import TPU v6e VQ system
+try:
+    from .vq_v33_tpu_v6 import (
+        TPUv6eVectorQuantizer,
+        TPUv6eVQConfig,
+        TPUv6eVQSystem,
+        create_tpu_v6e_vq_system,
+        create_tpu_v6e_vq_layer,
+        integrate_with_moe,
+        integrate_with_adaptive
+    )
+    TPU_V6E_VQ_AVAILABLE = True
+except ImportError as e:
+    logging.debug(f"TPU v6e VQ not available: {e}")
+    TPUv6eVectorQuantizer = None
+    TPUv6eVQConfig = None
+    TPUv6eVQSystem = None
+    create_tpu_v6e_vq_system = None
+    create_tpu_v6e_vq_layer = None
+    integrate_with_moe = None
+    integrate_with_adaptive = None
+    TPU_V6E_VQ_AVAILABLE = False
+
+# Import ARM Axion VQ system
+try:
+    from .vq_arm_axion import (
+        ARMAxionConfig,
+        ARMAxionVQOptimizer
+    )
+    ARM_AXION_VQ_AVAILABLE = True
+except ImportError as e:
+    logging.debug(f"ARM Axion VQ not available: {e}")
+    ARMAxionConfig = None
+    ARMAxionVQOptimizer = None
+    ARM_AXION_VQ_AVAILABLE = False
+
+# Import VQbit Layer
+try:
+    from .vqbit_layer import (
+        VQbitLayer,
+        VQbitConfig,
+        create_vqbit_layer,
+        VQBitLayer  # Alias
+    )
+    VQBIT_LAYER_AVAILABLE = True
+except ImportError:
+    VQBIT_LAYER_AVAILABLE = False
+    VQbitLayer = None
+    VQbitConfig = None
+    create_vqbit_layer = None
+    VQBitLayer = None
+
+# Import Adaptive VQ components
+try:
+    from .adaptive_vq import (
+        AdaptiveVectorQuantizer,
+        AdaptiveVQConfig,
+        AdaptationHistory,
+        create_adaptive_vq,
+        create_performance_adaptive_vq,
+        AdaptiveVQ  # Alias
+    )
+    ADAPTIVE_VQ_AVAILABLE = True
+except ImportError:
+    ADAPTIVE_VQ_AVAILABLE = False
+    AdaptiveVectorQuantizer = None
+    AdaptiveVQConfig = None
+    AdaptationHistory = None
+    create_adaptive_vq = None
+    create_performance_adaptive_vq = None
+    AdaptiveVQ = None
+
+# Import Multimodal VQbit components
+try:
+    from .multimodal_vqbit import (
+        VQbitModule,
+        MultimodalVQConfig,
+        create_multimodal_vqbit
+    )
+    MULTIMODAL_VQ_AVAILABLE = True
+except ImportError:
+    MULTIMODAL_VQ_AVAILABLE = False
+    VQbitModule = None
+    MultimodalVQConfig = None
+    create_multimodal_vqbit = None
+
+# Import VQ Monitoring components
+try:
+    from .vq_monitoring import (
+        VQMonitor,
+        MonitoringConfig,
+        MetricsCollector,
+        PerformanceAnalyzer,
+        create_vq_monitor,
+        create_production_monitor,
+        get_global_monitor,
+        set_global_monitor,
+        monitor_vq_operation
+    )
+    VQ_MONITORING_AVAILABLE = True
+except ImportError:
+    VQ_MONITORING_AVAILABLE = False
+    VQMonitor = None
+    MonitoringConfig = None
+    MetricsCollector = None
+    PerformanceAnalyzer = None
+    create_vq_monitor = None
+    create_production_monitor = None
+    get_global_monitor = None
+    set_global_monitor = None
+    monitor_vq_operation = None
+
+# Import Wrapper components
+try:
+    from .wrapper import (
+        AdaptiveWrapper,
+        AdaptiveWrapperConfig,
+        PerformanceTracker,
+        SimpleVQFallback,
+        create_adaptive_wrapper,
+        create_performance_optimized_wrapper
+    )
+    VQ_WRAPPER_AVAILABLE = True
+except ImportError:
+    VQ_WRAPPER_AVAILABLE = False
+    AdaptiveWrapper = None
+    AdaptiveWrapperConfig = None
+    PerformanceTracker = None
+    SimpleVQFallback = None
+    create_adaptive_wrapper = None
+    create_performance_optimized_wrapper = None
+
+# Import JAX Native Integration
+try:
+    from .jax_native_integration import (
+        VQbitNativeIntegration,
+        NativeIntegrationConfig,
+        get_native_integration,
+        create_native_vqbit_layer,
+        create_native_multimodal_vqbit,
+        get_native_backend_info,
+        benchmark_native_backends,
+        integrate_with_tpu_backend
+    )
+    JAX_NATIVE_INTEGRATION_AVAILABLE = True
+except ImportError:
+    JAX_NATIVE_INTEGRATION_AVAILABLE = False
+    VQbitNativeIntegration = None
+    NativeIntegrationConfig = None
+    get_native_integration = None
+    create_native_vqbit_layer = None
+    create_native_multimodal_vqbit = None
+    get_native_backend_info = None
+    benchmark_native_backends = None
+    integrate_with_tpu_backend = None
+
+logger = logging.getLogger(__name__)
+
+def get_project_root():
+    """Get the root path of the project."""
+    return Path(__file__).parent.parent.parent.parent
+
+# Version information
+__version__ = "3.3.0"  # Updated for v3.3 with TPU v6e support
+__author__ = "CapibaraGPT Team"
+
+
+class VQBitSystem:
+    """
+    Unified VQBit system that provides access to all VQ implementations
+    with automatic backend selection and optimization.
+    """
+    
+    def __init__(self):
+        self.available_systems = self._detect_available_systems()
+        self.performance_cache = {}
+        
+        logger.info(f" VQBit System initialized with {len(self.available_systems)} backends")
+        
+    def _detect_available_systems(self) -> Dict[str, bool]:
+        """Detect available VQ systems."""
+        return {
+            'tpu_v6e': TPU_V6E_VQ_AVAILABLE,
+            'arm_axion': ARM_AXION_VQ_AVAILABLE,
+            'vqbit_layer': VQBIT_LAYER_AVAILABLE,
+            'adaptive': ADAPTIVE_VQ_AVAILABLE,
+            'multimodal': MULTIMODAL_VQ_AVAILABLE,
+            'monitoring': VQ_MONITORING_AVAILABLE,
+            'wrapper': VQ_WRAPPER_AVAILABLE,
+            'jax_native_integration': JAX_NATIVE_INTEGRATION_AVAILABLE
+        }
+    
+    def create_vq_for_backend(self, 
+                             backend: str,
+                             config: Optional[Dict[str, Any]] = None) -> Any:
+        """
+        Create VQ system for specific backend.
+        
+        Args:
+            backend: Backend type ('tpu_v6e', 'arm_axion', 'adaptive', etc.)
+            config: Configuration dictionary
+            
+        Returns:
+            VQ system instance
+        """
+        
+        config = config or {}
+        
+        if backend == 'tpu_v6e' and TPU_V6E_VQ_AVAILABLE:
+            vq_config = TPUv6eVQConfig(**config)
+            return create_tpu_v6e_vq_system(vq_config)
+            
+        elif backend == 'arm_axion' and ARM_AXION_VQ_AVAILABLE:
+            arm_config = ARMAxionConfig(**config)
+            return ARMAxionVQOptimizer(arm_config)
+            
+        elif backend == 'native_jax' and JAX_NATIVE_INTEGRATION_AVAILABLE:
+            return create_native_vqbit_layer(
+                codebook_size=config.get('codebook_size', 64),
+                embedding_dim=config.get('embedding_dim', 768),
+                **config
+            )
+            
+        elif backend == 'vqbit_layer' and VQBIT_LAYER_AVAILABLE:
+            vqbit_config = VQbitConfig(
+                codebook_size=config.get('codebook_size', 64),
+                embedding_dim=config.get('embedding_dim', 768),
+                **config
+            )
+            return VQbitLayer(vqbit_config)
+            
+        else:
+            raise ValueError(f"Backend '{backend}' not available or not supported")
+    
+    def get_optimal_backend(self, 
+                           use_case: str = "general",
+                           constraints: Optional[Dict[str, Any]] = None) -> str:
+        """
+        Get optimal backend for use case and constraints.
+        
+        Args:
+            use_case: Use case ('research', 'production', 'memory_constrained')
+            constraints: Hardware/performance constraints
+            
+        Returns:
+            Optimal backend name
+        """
+        
+        constraints = constraints or {}
+        
+        # Research use case - prefer TPU v6e, then native JAX
+        if use_case == 'research':
+            if TPU_V6E_VQ_AVAILABLE:
+                return 'tpu_v6e'
+            elif JAX_NATIVE_INTEGRATION_AVAILABLE:
+                return 'native_jax'
+            
+        # Production use case - prefer ARM Axion, then native implementations
+        elif use_case == 'production':
+            if ARM_AXION_VQ_AVAILABLE:
+                return 'arm_axion'
+            elif VQBIT_LAYER_AVAILABLE:
+                return 'vqbit_layer'
+            
+        # Memory constrained - prefer ARM Axion, then adaptive
+        elif use_case == 'memory_constrained':
+            if ARM_AXION_VQ_AVAILABLE:
+                return 'arm_axion'
+            elif ADAPTIVE_VQ_AVAILABLE:
+                return 'adaptive'
+            
+        # General case - prefer native JAX integration
+        elif JAX_NATIVE_INTEGRATION_AVAILABLE:
+            return 'native_jax'
+            
+        # Fallback to first available system
+        priority_order = ['vqbit_layer', 'adaptive', 'multimodal', 'tpu_v6e', 'arm_axion']
+        
+        for backend in priority_order:
+            if self.available_systems.get(backend):
+                return backend
+        
+        # Final fallback
+        for backend, available in self.available_systems.items():
+            if available:
+                return backend
+                
+        raise RuntimeError("No VQ backends available")
+    
+    def benchmark_backends(self, 
+                          test_configs: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+        """
+        Benchmark available VQ backends.
+        
+        Args:
+            test_configs: List of test configurations
+            
+        Returns:
+            Benchmark results
+        """
+        
+        if test_configs is None:
+            test_configs = [
+                {'num_embeddings': 4096, 'embedding_dim': 512},
+                {'num_embeddings': 8192, 'embedding_dim': 1024},
+                {'num_embeddings': 16384, 'embedding_dim': 2048}
+            ]
+        
+        results = {}
+        
+        for backend, available in self.available_systems.items():
+            if not available:
+                continue
+                
+            try:
+                vq_system = self.create_vq_for_backend(backend, test_configs[0])
+                
+                if hasattr(vq_system, 'benchmark_performance'):
+                    benchmark_result = vq_system.benchmark_performance()
+                    results[backend] = benchmark_result
+                else:
+                    results[backend] = {'status': 'no_benchmark_available'}
+                    
+            except Exception as e:
+                results[backend] = {'error': str(e)}
+                
+        return results
+    
+    def get_system_status(self) -> Dict[str, Any]:
+        """Get comprehensive system status."""
+        
+        return {
+            'version': __version__,
+            'available_systems': self.available_systems,
+            'total_backends': sum(self.available_systems.values()),
+            'recommended_backend': self.get_optimal_backend('general'),
+            'system_info': {
+                'tpu_v6e_features': [
+                    'BF16 precision',
+                    'Mesh sharding',
+                    'Product quantization',
+                    'EMA updates',
+                    'MoE integration'
+                ] if TPU_V6E_VQ_AVAILABLE else None,
+                'arm_axion_features': [
+                    'NEON vectorization',
+                    'Memory optimization',
+                    'Quantization support',
+                    'Multi-threading'
+                ] if ARM_AXION_VQ_AVAILABLE else None
+            }
+        }
+
+
+# Global VQBit system instance
+_vqbit_system = None
+
+def get_vqbit_system() -> VQBitSystem:
+    """Get global VQBit system instance."""
+    global _vqbit_system
+    if _vqbit_system is None:
+        _vqbit_system = VQBitSystem()
+    return _vqbit_system
+
+
+# Convenience functions
+def create_optimal_vq(use_case: str = "general", 
+                     constraints: Optional[Dict[str, Any]] = None,
+                     **kwargs) -> Any:
+    """
+    Create optimal VQ system for use case.
+    
+    Args:
+        use_case: Use case ('research', 'production', 'memory_constrained')
+        constraints: Hardware/performance constraints
+        **kwargs: Additional configuration
+        
+    Returns:
+        Optimal VQ system instance
+    """
+    
+    system = get_vqbit_system()
+    backend = system.get_optimal_backend(use_case, constraints)
+    return system.create_vq_for_backend(backend, kwargs)
+
+
+def get_vq_recommendations(use_case: str,
+                          hardware_info: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """
+    Get VQ recommendations for specific use case and hardware.
+    
+    Args:
+        use_case: Use case description
+        hardware_info: Available hardware information
+        
+    Returns:
+        VQ recommendations
+    """
+    
+    system = get_vqbit_system()
+    
+    recommendations = {
+        'use_case': use_case,
+        'hardware_info': hardware_info,
+        'available_backends': system.available_systems,
+        'recommendations': {}
+    }
+    
+    # Use case specific recommendations
+    if use_case == 'research':
+        if TPU_V6E_VQ_AVAILABLE:
+            recommendations['recommendations'] = {
+                'backend': 'tpu_v6e',
+                'config': {
+                    'num_embeddings': 16384,
+                    'embedding_dim': 2048,
+                    'use_product_quantization': True,
+                    'num_subspaces': 16,
+                    'use_entropy_regularization': True,
+                    'use_diversity_loss': True
+                },
+                'features': ['Maximum performance', 'Advanced features', 'BF16 precision']
+            }
+        else:
+            recommendations['recommendations'] = {
+                'backend': 'fallback',
+                'message': 'TPU v6e not available, consider alternative backends'
+            }
+            
+    elif use_case == 'production':
+        if ARM_AXION_VQ_AVAILABLE:
+            recommendations['recommendations'] = {
+                'backend': 'arm_axion',
+                'config': {
+                    'embedding_dim': 1024,
+                    'num_coofs': 64,
+                    'enable_sve2': True,
+                    'enable_quantization': True
+                },
+                'features': ['High efficiency', 'Low latency', 'Memory optimized']
+            }
+        else:
+            recommendations['recommendations'] = {
+                'backend': 'fallback',
+                'message': 'ARM Axion not available, consider alternative backends'
+            }
+            
+    else:
+        # General recommendations
+        optimal_backend = system.get_optimal_backend(use_case)
+        recommendations['recommendations'] = {
+            'backend': optimal_backend,
+            'config': {'use_defaults': True},
+            'features': ['Automatic optimization', 'Balanced performance']
+        }
+    
+    return recommendations
+
+
+# Module exports
+__all__ = [
+    # Core classes
+    'VQBitSystem',
+    'get_vqbit_system',
+    
+    # VQbit Layer (core implementation)
+    'VQbitLayer',
+    'VQbitConfig', 
+    'create_vqbit_layer',
+    'VQBitLayer',  # Alias
+    
+    # TPU v6e VQ (if available)
+    'TPUv6eVectorQuantizer',
+    'TPUv6eVQConfig',
+    'TPUv6eVQSystem',
+    'create_tpu_v6e_vq_system',
+    'create_tpu_v6e_vq_layer',
+    
+    # ARM Axion VQ (if available)
+    'ARMAxionConfig',
+    'ARMAxionVQOptimizer',
+    
+    # Adaptive VQ components
+    'AdaptiveVectorQuantizer',
+    'AdaptiveVQConfig',
+    'AdaptationHistory',
+    'create_adaptive_vq',
+    'create_performance_adaptive_vq',
+    'AdaptiveVQ',  # Alias
+    
+    # Multimodal VQbit components
+    'VQbitModule',
+    'MultimodalVQConfig',
+    'create_multimodal_vqbit',
+    
+    # VQ Monitoring components
+    'VQMonitor',
+    'MonitoringConfig',
+    'MetricsCollector',
+    'PerformanceAnalyzer',
+    'create_vq_monitor',
+    'create_production_monitor',
+    'get_global_monitor',
+    'set_global_monitor',
+    'monitor_vq_operation',
+    
+    # Wrapper components
+    'AdaptiveWrapper',
+    'AdaptiveWrapperConfig',
+    'PerformanceTracker',
+    'SimpleVQFallback',
+    'create_adaptive_wrapper',
+    'create_performance_optimized_wrapper',
+    
+    # JAX Native Integration
+    'VQbitNativeIntegration',
+    'NativeIntegrationConfig',
+    'get_native_integration',
+    'create_native_vqbit_layer',
+    'create_native_multimodal_vqbit',
+    'get_native_backend_info',
+    'benchmark_native_backends',
+    'integrate_with_tpu_backend',
+    
+    # Convenience functions
+    'create_optimal_vq',
+    'get_vq_recommendations',
+    
+    # Integration functions
+    'integrate_with_moe',
+    'integrate_with_adaptive',
+    
+    # Utility functions
+    'get_project_root',
+    
+    # Status flags
+    'TPU_V6E_VQ_AVAILABLE',
+    'ARM_AXION_VQ_AVAILABLE',
+    'VQBIT_LAYER_AVAILABLE',
+    'ADAPTIVE_VQ_AVAILABLE',
+    'MULTIMODAL_VQ_AVAILABLE',
+    'VQ_MONITORING_AVAILABLE',
+    'VQ_WRAPPER_AVAILABLE',
+    'JAX_NATIVE_INTEGRATION_AVAILABLE'
+]
+
+# Log initialization status
+logger.info(f"VQBit module initialized (v{__version__})")
+logger.info(f"TPU v6e VQ available: {TPU_V6E_VQ_AVAILABLE}")
+logger.info(f"ARM Axion VQ available: {ARM_AXION_VQ_AVAILABLE}")
+logger.info(f"VQbit Layer available: {VQBIT_LAYER_AVAILABLE}")
+logger.info(f"Adaptive VQ available: {ADAPTIVE_VQ_AVAILABLE}")
+logger.info(f"Multimodal VQ available: {MULTIMODAL_VQ_AVAILABLE}")
+logger.info(f"VQ Monitoring available: {VQ_MONITORING_AVAILABLE}")
+logger.info(f"VQ Wrapper available: {VQ_WRAPPER_AVAILABLE}")
+logger.info(f"JAX Native Integration available: {JAX_NATIVE_INTEGRATION_AVAILABLE}")
+
+# Determine system readiness
+available_components = sum([
+    TPU_V6E_VQ_AVAILABLE,
+    ARM_AXION_VQ_AVAILABLE, 
+    VQBIT_LAYER_AVAILABLE,
+    ADAPTIVE_VQ_AVAILABLE,
+    MULTIMODAL_VQ_AVAILABLE,
+    VQ_MONITORING_AVAILABLE,
+    VQ_WRAPPER_AVAILABLE,
+    JAX_NATIVE_INTEGRATION_AVAILABLE
+])
+
+if available_components >= 6:
+    logger.info(" Full VQBit system ready with all components")
+elif available_components >= 4:
+    logger.info(" Most VQBit components available")
+elif available_components >= 2:
+    logger.info(" Basic VQBit system available")
+else:
+logger.debug("Limited VQBit capabilities available")

--- a/capibara/vq/vqbit/adaptive_vq.py
+++ b/capibara/vq/vqbit/adaptive_vq.py
@@ -1,0 +1,753 @@
+"""
+Adaptive VQ Module for Capibara-6
+
+Advanced adaptive vector quantization providing:
+- Dynamic codebook adaptation
+- Performance-based optimization
+- Resource-aware scaling
+- Integration with MoE and routing systems
+- Real-time adaptation to data distribution changes
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union, Callable
+from dataclasses import dataclass, field
+import time
+import math
+from collections import deque, defaultdict
+
+# JAX/Flax imports
+try:
+    import jax
+    import jax.numpy as jnp
+    import flax.linen as nn
+    from flax import struct
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+    jax = None
+    jnp = None
+    nn = None
+
+# PyTorch fallback
+try:
+    import torch
+    import torch.nn as torch_nn
+    import torch.nn.functional as F
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+    torch = None
+    torch_nn = None
+    F = None
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class AdaptiveVQConfig:
+    """Configurestion for Adaptive VQ."""
+    # Core VQ parameters
+    initial_codebook_size: int = 64
+    embedding_dim: int = 768
+    min_codebook_size: int = 16
+    max_codebook_size: int = 256
+    
+    # Adaptation parameters
+    adaptation_rate: float = 0.01
+    growth_threshold: float = 0.95  # Codebook usage threshold for growth
+    shrink_threshold: float = 0.3   # Codebook usage threshold for shrinking
+    adaptation_interval: int = 100   # Steps between adaptations
+    
+    # Performance monitoring
+    performance_window: int = 50
+    target_perplexity: float = 32.0
+    target_compression_ratio: float = 8.0
+    
+    # Resource constraints
+    memory_limit_mb: float = 1000.0
+    latency_target_ms: float = 10.0
+    
+    # Advanced features
+    use_hierarchical_quantization: bool = False
+    use_learned_codebook_init: bool = True
+    enable_dynamic_embedding_dim: bool = False
+    
+    # Integration settings
+    moe_compatible: bool = True
+    routing_compatible: bool = True
+
+
+class AdaptationHistory:
+    """Track adaptation history and decisions."""
+    
+    def __init__(self, max_history: int = 1000):
+        self.max_history = max_history
+        self.adaptations = deque(maxlen=max_history)
+        self.performance_history = deque(maxlen=max_history)
+    
+    def record_adaptation(self, 
+                         old_config: Dict[str, Any], 
+                         new_config: Dict[str, Any], 
+                         reason: str,
+                         performance_before: float,
+                         performance_after: float):
+        """Record an adaptation event."""
+        
+        adaptation_event = {
+            'timestamp': time.time(),
+            'old_config': old_config.copy(),
+            'new_config': new_config.copy(),
+            'reason': reason,
+            'performance_before': performance_before,
+            'performance_after': performance_after,
+            'improvement': performance_after - performance_before
+        }
+        
+        self.adaptations.append(adaptation_event)
+    
+    def get_adaptation_stats(self) -> Dict[str, Any]:
+        """Get adaptation statistics."""
+        
+        if not self.adaptations:
+            return {'total_adaptations': 0}
+        
+        total_adaptations = len(self.adaptations)
+        successful_adaptations = sum(1 for a in self.adaptations if a['improvement'] > 0)
+        
+        reasons = defaultdict(int)
+        for adaptation in self.adaptations:
+            reasons[adaptation['reason']] += 1
+        
+        return {
+            'total_adaptations': total_adaptations,
+            'successful_adaptations': successful_adaptations,
+            'success_rate': successful_adaptations / total_adaptations,
+            'adaptation_reasons': dict(reasons),
+            'recent_adaptations': list(self.adaptations)[-10:]  # Last 10
+        }
+
+
+if JAX_AVAILABLE:
+    class AdaptiveVectorQuantizer(nn.Module):
+        """
+        Adaptive Vector Quantizer - JAX/Flax implementation.
+        
+        Features:
+        - Dynamic codebook size adaptation
+        - Performance-based optimization
+        - Resource-aware scaling
+        - Integration with MoE systems
+        """
+        
+        config: AdaptiveVQConfig
+        
+        def setup(self):
+            """Initialize the adaptive VQ."""
+            
+            # Dynamic codebook - starts with initial size
+            self.current_codebook_size = self.variable(
+                'adaptive_state', 'codebook_size',
+                lambda: jnp.array(self.config.initial_codebook_size, dtype=jnp.int32)
+            )
+            
+            # Main codebook (max size, unused entries are masked)
+            self.codebook = self.param(
+                'codebook',
+                nn.initializers.uniform(scale=1.0),
+                (self.config.max_codebook_size, self.config.embedding_dim)
+            )
+            
+            # Usage statistics for adaptation
+            self.usage_stats = self.variable(
+                'adaptive_state', 'usage_stats',
+                lambda: jnp.zeros(self.config.max_codebook_size)
+            )
+            
+            self.adaptation_step = self.variable(
+                'adaptive_state', 'adaptation_step',
+                lambda: jnp.array(0, dtype=jnp.int32)
+            )
+            
+            # Performance tracking
+            self.performance_history = self.variable(
+                'adaptive_state', 'performance_history',
+                lambda: jnp.zeros(self.config.performance_window)
+            )
+            
+            # Hierarchical quantization if enabled
+            if self.config.use_hierarchical_quantization:
+                self.hierarchical_levels = 3
+                self.level_codebooks = {}
+                for level in range(self.hierarchical_levels):
+                    size = self.config.initial_codebook_size // (2 ** level)
+                    self.level_codebooks[level] = self.param(
+                        f'codebook_level_{level}',
+                        nn.initializers.uniform(scale=1.0),
+                        (size, self.config.embedding_dim)
+                    )
+        
+        def __call__(self, 
+                    inputs: jnp.ndarray, 
+                    training: bool = True,
+                    force_adaptation: bool = False) -> Tuple[jnp.ndarray, jnp.ndarray, Dict[str, Any]]:
+            """
+            Adaptive quantization forward pass.
+            
+            Args:
+                inputs: Input embeddings
+                training: Whether in training mode
+                force_adaptation: Force adaptation check
+                
+            Returns:
+                quantized: Quantized embeddings
+                indices: Codebook indices
+                metrics: Adaptation and performance metrics
+            """
+            
+            input_shape = inputs.shape
+            flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+            
+            # Get current active codebook size
+            active_size = self.current_codebook_size.value
+            active_codebook = self.codebook[:active_size]
+            
+            # Perform quantization
+            if self.config.use_hierarchical_quantization:
+                quantized, indices, base_metrics = self._hierarchical_quantize(flat_inputs, training)
+            else:
+                quantized, indices, base_metrics = self._standard_adaptive_quantize(
+                    flat_inputs, active_codebook, training
+                )
+            
+            # Update adaptation step
+            self.adaptation_step.value += 1
+            
+            # Check for adaptation
+            adaptation_info = {}
+            if training and (force_adaptation or self.adaptation_step.value % self.config.adaptation_interval == 0):
+                adaptation_info = self._check_and_adapt(base_metrics)
+            
+            # Reshape outputs
+            quantized = quantized.reshape(input_shape)
+            indices = indices.reshape(input_shape[:-1])
+            
+            # Combine metrics
+            metrics = {
+                **base_metrics,
+                'adaptation_info': adaptation_info,
+                'current_codebook_size': int(active_size),
+                'adaptation_step': int(self.adaptation_step.value),
+                'adaptive_features': {
+                    'hierarchical': self.config.use_hierarchical_quantization,
+                    'dynamic_size': True,
+                    'performance_tracking': True
+                }
+            }
+            
+            return quantized, indices, metrics
+        
+        def _standard_adaptive_quantize(self, 
+                                      flat_inputs: jnp.ndarray, 
+                                      active_codebook: jnp.ndarray,
+                                      training: bool) -> Tuple[jnp.ndarray, jnp.ndarray, Dict[str, Any]]:
+            """Standard adaptive quantization."""
+            
+            # Compute distances to active codebook
+            distances = jnp.linalg.norm(
+                flat_inputs[:, None, :] - active_codebook[None, :, :],
+                axis=2
+            )
+            
+            # Find nearest entries
+            indices = jnp.argmin(distances, axis=1)
+            quantized = active_codebook[indices]
+            
+            # Update usage statistics
+            if training:
+                one_hot = jax.nn.one_hot(indices, active_codebook.shape[0])
+                usage_update = jnp.sum(one_hot, axis=0)
+                
+                # Update usage stats (only for active portion)
+                current_usage = self.usage_stats.value
+                current_usage = current_usage.at[:active_codebook.shape[0]].add(usage_update)
+                self.usage_stats.value = current_usage
+            
+            # Compute losses
+            commitment_loss = jnp.mean((jax.lax.stop_gradient(quantized) - flat_inputs) ** 2)
+            codebook_loss = jnp.mean((quantized - jax.lax.stop_gradient(flat_inputs)) ** 2)
+            
+            # Straight-through estimator
+            quantized = flat_inputs + jax.lax.stop_gradient(quantized - flat_inputs)
+            
+            # Compute metrics
+            metrics = self._compute_adaptive_metrics(flat_inputs, quantized, indices, 
+                                                   commitment_loss, codebook_loss, active_codebook.shape[0])
+            
+            return quantized, indices, metrics
+        
+        def _hierarchical_quantize(self, 
+                                 flat_inputs: jnp.ndarray, 
+                                 training: bool) -> Tuple[jnp.ndarray, jnp.ndarray, Dict[str, Any]]:
+            """Hierarchical quantization with multiple levels."""
+            
+            # Start with coarsest level
+            current_inputs = flat_inputs
+            total_indices = []
+            total_loss = 0.0
+            
+            for level in range(self.hierarchical_levels):
+                level_codebook = self.level_codebooks[level]
+                
+                # Quantize at current level
+                distances = jnp.linalg.norm(
+                    current_inputs[:, None, :] - level_codebook[None, :, :],
+                    axis=2
+                )
+                
+                level_indices = jnp.argmin(distances, axis=1)
+                level_quantized = level_codebook[level_indices]
+                
+                # Compute residual for next level
+                residual = current_inputs - level_quantized
+                current_inputs = residual
+                
+                total_indices.append(level_indices)
+                total_loss += jnp.mean(residual ** 2)
+            
+            # Reconstruct from all levels
+            reconstructed = jnp.zeros_like(flat_inputs)
+            for level, indices in enumerate(total_indices):
+                level_codebook = self.level_codebooks[level]
+                reconstructed += level_codebook[indices]
+            
+            # Use finest level indices as primary
+            primary_indices = total_indices[-1]
+            
+            metrics = {
+                'hierarchical_loss': total_loss,
+                'num_levels': self.hierarchical_levels,
+                'level_indices': total_indices
+            }
+            
+            return reconstructed, primary_indices, metrics
+        
+        def _compute_adaptive_metrics(self, 
+                                    inputs: jnp.ndarray, 
+                                    quantized: jnp.ndarray,
+                                    indices: jnp.ndarray, 
+                                    commitment_loss: float,
+                                    codebook_loss: float,
+                                    active_codebook_size: int) -> Dict[str, Any]:
+            """Compute metrics with adaptive information."""
+            
+            # Standard metrics
+            mse = jnp.mean((inputs - quantized) ** 2)
+            
+            # Codebook usage (for active portion)
+            unique_indices = len(jnp.unique(indices))
+            codebook_usage = unique_indices / active_codebook_size
+            
+            # Perplexity
+            avg_probs = jnp.mean(jax.nn.one_hot(indices, active_codebook_size), axis=0)
+            perplexity = jnp.exp(-jnp.sum(avg_probs * jnp.log(avg_probs + 1e-10)))
+            
+            # Adaptive-specific metrics
+            usage_distribution = self.usage_stats.value[:active_codebook_size]
+            usage_entropy = -jnp.sum(
+                (usage_distribution / jnp.sum(usage_distribution + 1e-10)) * 
+                jnp.log(usage_distribution / jnp.sum(usage_distribution + 1e-10) + 1e-10)
+            )
+            
+            return {
+                'commitment_loss': commitment_loss,
+                'codebook_loss': codebook_loss,
+                'mse': mse,
+                'codebook_usage': codebook_usage,
+                'perplexity': perplexity,
+                'unique_codes': unique_indices,
+                'usage_entropy': usage_entropy,
+                'active_codebook_size': active_codebook_size,
+                'adaptation_potential': self._compute_adaptation_potential(codebook_usage, perplexity)
+            }
+        
+        def _compute_adaptation_potential(self, usage: float, perplexity: float) -> float:
+            """Compute potential for adaptation based on current metrics."""
+            
+            # High usage suggests need for larger codebook
+            usage_pressure = max(0, usage - self.config.growth_threshold)
+            
+            # Low perplexity suggests underutilized codebook
+            target_perplexity = min(self.config.target_perplexity, self.current_codebook_size.value * 0.8)
+            perplexity_deficit = max(0, target_perplexity - perplexity)
+            
+            # Combine signals
+            adaptation_potential = usage_pressure * 2.0 + perplexity_deficit * 0.1
+            
+            return float(adaptation_potential)
+        
+        def _check_and_adapt(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+            """Check if adaptation is needed and perform it."""
+            
+            current_size = int(self.current_codebook_size.value)
+            usage = metrics['codebook_usage']
+            perplexity = metrics['perplexity']
+            
+            adaptation_info = {
+                'adapted': False,
+                'reason': None,
+                'old_size': current_size,
+                'new_size': current_size
+            }
+            
+            # Check for growth (high usage)
+            if (usage > self.config.growth_threshold and 
+                current_size < self.config.max_codebook_size):
+                
+                new_size = min(self.config.max_codebook_size, current_size * 2)
+                self.current_codebook_size.value = new_size
+                
+                adaptation_info.update({
+                    'adapted': True,
+                    'reason': f'high_usage_{usage:.2f}',
+                    'new_size': new_size
+                })
+                
+                logger.info(f"Adapted codebook size: {current_size} -> {new_size} (high usage: {usage:.2f})")
+            
+            # Check for shrinking (low usage)
+            elif (usage < self.config.shrink_threshold and 
+                  current_size > self.config.min_codebook_size):
+                
+                new_size = max(self.config.min_codebook_size, current_size // 2)
+                self.current_codebook_size.value = new_size
+                
+                adaptation_info.update({
+                    'adapted': True,
+                    'reason': f'low_usage_{usage:.2f}',
+                    'new_size': new_size
+                })
+                
+                logger.info(f"Adapted codebook size: {current_size} -> {new_size} (low usage: {usage:.2f})")
+            
+            return adaptation_info
+
+elif TORCH_AVAILABLE:
+    class AdaptiveVectorQuantizer(torch_nn.Module):
+        """
+        Adaptive Vector Quantizer - PyTorch implementation.
+        """
+        
+        def __init__(self, config: Optional[AdaptiveVQConfig] = None):
+            super().__init__()
+            if config is None:
+                config = AdaptiveVQConfig()
+            self.config = config
+            
+            # Dynamic codebook
+            self.register_buffer('current_codebook_size', 
+                               torch.tensor(self.config.initial_codebook_size, dtype=torch.int32))
+            
+            # Main codebook (max size)
+            self.codebook = torch_nn.Parameter(
+                torch.randn(self.config.max_codebook_size, self.config.embedding_dim)
+            )
+            
+            # Usage statistics
+            self.register_buffer('usage_stats', torch.zeros(self.config.max_codebook_size))
+            self.register_buffer('adaptation_step', torch.tensor(0, dtype=torch.int32))
+            
+            # Adaptation history
+            self.adaptation_history = AdaptationHistory()
+        
+        def forward(self, 
+                   inputs: torch.Tensor, 
+                   training: bool = True,
+                   force_adaptation: bool = False) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+            """Adaptive quantization forward pass."""
+            
+            input_shape = inputs.shape
+            flat_inputs = inputs.view(-1, self.config.embedding_dim)
+            
+            # Get active codebook
+            active_size = int(self.current_codebook_size.item())
+            active_codebook = self.codebook[:active_size]
+            
+            # Perform quantization
+            quantized, indices, metrics = self._adaptive_quantize(flat_inputs, active_codebook, training)
+            
+            # Update adaptation step
+            self.adaptation_step += 1
+            
+            # Check for adaptation
+            adaptation_info = {}
+            if training and (force_adaptation or self.adaptation_step % self.config.adaptation_interval == 0):
+                adaptation_info = self._check_and_adapt(metrics)
+            
+            # Reshape outputs
+            quantized = quantized.view(input_shape)
+            indices = indices.view(input_shape[:-1])
+            
+            # Update metrics
+            metrics.update({
+                'adaptation_info': adaptation_info,
+                'current_codebook_size': active_size,
+                'adaptation_step': int(self.adaptation_step.item())
+            })
+            
+            return quantized, indices, metrics
+        
+        def _adaptive_quantize(self, 
+                             flat_inputs: torch.Tensor, 
+                             active_codebook: torch.Tensor,
+                             training: bool) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+            """Perform adaptive quantization."""
+            
+            # Compute distances
+            distances = torch.norm(
+                flat_inputs.unsqueeze(1) - active_codebook.unsqueeze(0),
+                dim=2
+            )
+            
+            # Find nearest entries
+            indices = torch.argmin(distances, dim=1)
+            quantized = active_codebook[indices]
+            
+            # Update usage statistics
+            if training:
+                with torch.no_grad():
+                    one_hot = F.one_hot(indices, active_codebook.shape[0]).float()
+                    usage_update = torch.sum(one_hot, dim=0)
+                    self.usage_stats[:active_codebook.shape[0]] += usage_update
+            
+            # Compute losses
+            commitment_loss = F.mse_loss(quantized.detach(), flat_inputs)
+            codebook_loss = F.mse_loss(quantized, flat_inputs.detach())
+            
+            # Straight-through estimator
+            quantized = flat_inputs + (quantized - flat_inputs).detach()
+            
+            # Compute metrics
+            metrics = self._compute_adaptive_metrics(flat_inputs, quantized, indices, 
+                                                   commitment_loss, codebook_loss, active_codebook.shape[0])
+            
+            return quantized, indices, metrics
+        
+        def _compute_adaptive_metrics(self, 
+                                    inputs: torch.Tensor, 
+                                    quantized: torch.Tensor,
+                                    indices: torch.Tensor, 
+                                    commitment_loss: torch.Tensor,
+                                    codebook_loss: torch.Tensor,
+                                    active_codebook_size: int) -> Dict[str, Any]:
+            """Compute adaptive metrics."""
+            
+            # Standard metrics
+            mse = F.mse_loss(inputs, quantized)
+            unique_indices = len(torch.unique(indices))
+            codebook_usage = unique_indices / active_codebook_size
+            
+            # Perplexity
+            one_hot = F.one_hot(indices, active_codebook_size).float()
+            avg_probs = torch.mean(one_hot, dim=0)
+            perplexity = torch.exp(-torch.sum(avg_probs * torch.log(avg_probs + 1e-10)))
+            
+            # Usage entropy
+            usage_dist = self.usage_stats[:active_codebook_size]
+            normalized_usage = usage_dist / (torch.sum(usage_dist) + 1e-10)
+            usage_entropy = -torch.sum(normalized_usage * torch.log(normalized_usage + 1e-10))
+            
+            return {
+                'commitment_loss': commitment_loss.item(),
+                'codebook_loss': codebook_loss.item(),
+                'mse': mse.item(),
+                'codebook_usage': codebook_usage.item(),
+                'perplexity': perplexity.item(),
+                'unique_codes': unique_indices,
+                'usage_entropy': usage_entropy.item(),
+                'active_codebook_size': active_codebook_size
+            }
+        
+        def _check_and_adapt(self, metrics: Dict[str, Any]) -> Dict[str, Any]:
+            """Check and perform adaptation."""
+            
+            current_size = int(self.current_codebook_size.item())
+            usage = metrics['codebook_usage']
+            
+            adaptation_info = {
+                'adapted': False,
+                'reason': None,
+                'old_size': current_size,
+                'new_size': current_size
+            }
+            
+            # Growth check
+            if (usage > self.config.growth_threshold and 
+                current_size < self.config.max_codebook_size):
+                
+                new_size = min(self.config.max_codebook_size, current_size * 2)
+                self.current_codebook_size.fill_(new_size)
+                
+                adaptation_info.update({
+                    'adapted': True,
+                    'reason': f'high_usage_{usage:.2f}',
+                    'new_size': new_size
+                })
+            
+            # Shrink check
+            elif (usage < self.config.shrink_threshold and 
+                  current_size > self.config.min_codebook_size):
+                
+                new_size = max(self.config.min_codebook_size, current_size // 2)
+                self.current_codebook_size.fill_(new_size)
+                
+                adaptation_info.update({
+                    'adapted': True,
+                    'reason': f'low_usage_{usage:.2f}',
+                    'new_size': new_size
+                })
+            
+            return adaptation_info
+
+else:
+    # NumPy fallback
+    class AdaptiveVectorQuantizer:
+        """Adaptive Vector Quantizer - NumPy fallback."""
+        
+        def __init__(self, config: Optional[AdaptiveVQConfig] = None):
+            if config is None:
+                config = AdaptiveVQConfig()
+            self.config = config
+            
+            self.current_codebook_size = self.config.initial_codebook_size
+            self.codebook = np.random.randn(self.config.max_codebook_size, self.config.embedding_dim).astype(np.float32)
+            self.usage_stats = np.zeros(self.config.max_codebook_size)
+            self.adaptation_step = 0
+        
+        def __call__(self, inputs: np.ndarray, training: bool = True, **kwargs) -> Tuple[np.ndarray, np.ndarray, Dict[str, Any]]:
+            """Simple adaptive quantization."""
+            
+            input_shape = inputs.shape
+            flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+            
+            # Use active portion of codebook
+            active_codebook = self.codebook[:self.current_codebook_size]
+            
+            # Simple quantization
+            distances = np.linalg.norm(
+                flat_inputs[:, None, :] - active_codebook[None, :, :],
+                axis=2
+            )
+            
+            indices = np.argmin(distances, axis=1)
+            quantized = active_codebook[indices]
+            
+            # Basic metrics
+            unique_codes = len(np.unique(indices))
+            usage = unique_codes / self.current_codebook_size
+            
+            metrics = {
+                'mse': float(np.mean((flat_inputs - quantized) ** 2)),
+                'codebook_usage': usage,
+                'unique_codes': unique_codes,
+                'current_codebook_size': self.current_codebook_size,
+                'backend': 'numpy_fallback'
+            }
+            
+            # Simple adaptation
+            self.adaptation_step += 1
+            if self.adaptation_step % self.config.adaptation_interval == 0:
+                if usage > self.config.growth_threshold and self.current_codebook_size < self.config.max_codebook_size:
+                    self.current_codebook_size = min(self.config.max_codebook_size, self.current_codebook_size * 2)
+                elif usage < self.config.shrink_threshold and self.current_codebook_size > self.config.min_codebook_size:
+                    self.current_codebook_size = max(self.config.min_codebook_size, self.current_codebook_size // 2)
+            
+            # Reshape back
+            quantized = quantized.reshape(input_shape)
+            indices = indices.reshape(input_shape[:-1])
+            
+            return quantized, indices, metrics
+
+
+# Factory functions
+def create_adaptive_vq(initial_codebook_size: int = 64,
+                      embedding_dim: int = 768,
+                      adaptation_rate: float = 0.01,
+                      use_hierarchical: bool = False,
+                      **kwargs) -> Union[AdaptiveVectorQuantizer, AdaptiveVectorQuantizer]:
+    """
+    Create an adaptive VQ with specified configuration.
+    
+    Args:
+        initial_codebook_size: Starting codebook size
+        embedding_dim: Embedding dimension
+        adaptation_rate: Rate of adaptation
+        use_hierarchical: Enable hierarchical quantization
+        **kwargs: Additional configuration
+        
+    Returns:
+        AdaptiveVectorQuantizer instance
+    """
+    
+    config = AdaptiveVQConfig(
+        initial_codebook_size=initial_codebook_size,
+        embedding_dim=embedding_dim,
+        adaptation_rate=adaptation_rate,
+        use_hierarchical_quantization=use_hierarchical,
+        **kwargs
+    )
+    
+    return AdaptiveVectorQuantizer(config)
+
+
+def create_performance_adaptive_vq(target_performance: float = 0.9,
+                                  memory_limit_mb: float = 500.0,
+                                  latency_target_ms: float = 5.0) -> Union[AdaptiveVectorQuantizer, AdaptiveVectorQuantizer]:
+    """
+    Create performance-optimized adaptive VQ.
+    
+    Args:
+        target_performance: Target performance score
+        memory_limit_mb: Memory limit in MB
+        latency_target_ms: Target latency in milliseconds
+        
+    Returns:
+        Performance-optimized AdaptiveVectorQuantizer
+    """
+    
+    # Estimate optimal parameters based on constraints
+    if memory_limit_mb < 100:
+        initial_size = 16
+        max_size = 32
+    elif memory_limit_mb < 500:
+        initial_size = 32
+        max_size = 64
+    else:
+        initial_size = 64
+        max_size = 128
+    
+    config = AdaptiveVQConfig(
+        initial_codebook_size=initial_size,
+        max_codebook_size=max_size,
+        memory_limit_mb=memory_limit_mb,
+        latency_target_ms=latency_target_ms,
+        growth_threshold=0.9 if target_performance > 0.8 else 0.8,
+        adaptation_interval=50 if target_performance > 0.9 else 100
+    )
+    
+    return AdaptiveVectorQuantizer(config)
+
+
+# Alias for compatibility
+AdaptiveVQ = AdaptiveVectorQuantizer
+
+logger.info(f"Adaptive VQ initialized - JAX: {JAX_AVAILABLE}, PyTorch: {TORCH_AVAILABLE}")
+
+def main():
+    # Main function for this module.
+    logger.info("Module adaptive_vq.py starting")
+    return True
+
+if __name__ == "__main__":
+    main()

--- a/capibara/vq/vqbit/jax_native_integration.py
+++ b/capibara/vq/vqbit/jax_native_integration.py
@@ -1,0 +1,725 @@
+"""
+VQbit JAX Native Integration for Capibara-6
+
+Integration between VQbit implementations and native JAX infrastructure:
+- Connection with capibara.jax.numpy
+- Native TPU v4/v6 optimizations
+- Specialized kernels for VQbit
+- Automatic fallbacks to numpy
+- Integration with existing TPU backend
+"""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Import native JAX infrastructure
+try:
+    import capibara.jax as cjax
+    import capibara.jax.numpy as cjnp
+    CAPIBARA_JAX_AVAILABLE = True
+    logger.info("Capibara JAX infrastructure available")
+except ImportError:
+    CAPIBARA_JAX_AVAILABLE = False
+    logger.warning("Capibara JAX infrastructure not available")
+    cjax = None
+    cjnp = None
+
+# Import standard libraries as fallback
+try:
+    import numpy as np
+    NUMPY_AVAILABLE = True
+except ImportError:
+    NUMPY_AVAILABLE = False
+    np = None
+
+# Import VQbit implementations
+try:
+    from .vqbit_layer import VQbitLayer, VQbitConfig
+    from .multimodal_vqbit import VQbitModule, MultimodalVQConfig
+    from .adaptive_vq import AdaptiveVectorQuantizer, AdaptiveVQConfig
+    VQBIT_IMPLEMENTATIONS_AVAILABLE = True
+except ImportError:
+    VQBIT_IMPLEMENTATIONS_AVAILABLE = False
+
+@dataclass
+class NativeIntegrationConfig:
+    """Configuration for native JAX integration."""
+    prefer_capibara_jax: bool = True
+    enable_tpu_kernels: bool = True
+    enable_fallback_numpy: bool = True
+    log_backend_selection: bool = True
+    cache_compiled_functions: bool = True
+
+
+class VQbitNativeIntegration:
+    """
+    Native integration between VQbit and capibara.jax
+
+    Features:
+    - Automatic detection of optimal backend
+    - Use of specialized TPU kernels when available
+    - Automatic fallback to numpy
+    - Integration with monitoring system
+    - Backend-specific optimizations
+    """
+    
+    def __init__(self, config: Optional[NativeIntegrationConfig] = None):
+        if config is None:
+            config = NativeIntegrationConfig()
+        self.config = config
+        
+        # Detect available backends
+        self.available_backends = self._detect_backends()
+        self.selected_backend = self._select_optimal_backend()
+        
+        # Cache for compiled functions
+        self.function_cache = {} if config.cache_compiled_functions else None
+        
+        if config.log_backend_selection:
+            logger.info(f"VQbit Native Integration initialized with {self.selected_backend} backend")
+            logger.info(f"Available backends: {list(self.available_backends.keys())}")
+    
+    def _detect_backends(self) -> Dict[str, bool]:
+        """Detect available computation backends."""
+        backends = {
+            'capibara_jax': CAPIBARA_JAX_AVAILABLE,
+            'numpy': NUMPY_AVAILABLE,
+            'vqbit_implementations': VQBIT_IMPLEMENTATIONS_AVAILABLE
+        }
+        
+        # Check for TPU availability through capibara.jax
+        if CAPIBARA_JAX_AVAILABLE:
+            try:
+                # Try to access TPU backend (with safe import)
+                from capibara.jax.tpu_v4.backend import TpuV4AdaptiveOps
+                backends['tpu_v4_kernels'] = True
+            except (ImportError, AttributeError, TypeError) as e:
+                logger.debug(f"TPU v4 kernels not available: {e}")
+                backends['tpu_v4_kernels'] = False
+        else:
+            backends['tpu_v4_kernels'] = False
+        
+        return backends
+    
+    def _select_optimal_backend(self) -> str:
+        """Select optimal backend based on availability."""
+        
+        # Priority order for backend selection
+        if self.config.prefer_capibara_jax and self.available_backends.get('capibara_jax'):
+            if self.available_backends.get('tpu_v4_kernels'):
+                return 'capibara_jax_tpu'
+            else:
+                return 'capibara_jax'
+        
+        elif self.available_backends.get('vqbit_implementations'):
+            return 'vqbit_native'
+        
+        elif self.available_backends.get('numpy'):
+            return 'numpy_fallback'
+        
+        else:
+            return 'minimal_fallback'
+    
+    def create_native_vqbit_layer(self, 
+                                 codebook_size: int = 64,
+                                 embedding_dim: int = 768,
+                                 use_tpu_optimizations: bool = True,
+                                 **kwargs) -> Any:
+        """
+        Create VQbit layer using native infrastructure.
+        
+        Args:
+            codebook_size: Number of codebook entries
+            embedding_dim: Embedding dimension
+            use_tpu_optimizations: Enable TPU optimizations
+            **kwargs: Additional configuration
+            
+        Returns:
+            Native VQbit layer instance
+        """
+        
+        if self.selected_backend == 'capibara_jax_tpu':
+            return self._create_capibara_jax_tpu_vqbit(codebook_size, embedding_dim, **kwargs)
+        
+        elif self.selected_backend == 'capibara_jax':
+            return self._create_capibara_jax_vqbit(codebook_size, embedding_dim, **kwargs)
+        
+        elif self.selected_backend == 'vqbit_native':
+            return self._create_vqbit_native(codebook_size, embedding_dim, **kwargs)
+        
+        elif self.selected_backend == 'numpy_fallback':
+            return self._create_numpy_fallback_vqbit(codebook_size, embedding_dim, **kwargs)
+        
+        else:
+            return self._create_minimal_fallback_vqbit(codebook_size, embedding_dim, **kwargs)
+    
+    def _create_capibara_jax_tpu_vqbit(self, codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates VQbit layer using Capibara JAX with TPU kernels."""
+        
+        try:
+            from capibara.jax.tpu_v4.backend import TpuV4AdaptiveOps
+            
+            # Create TPU-optimized VQbit wrapper
+            class CapibaraJAXTPUVQbit:
+                def __init__(self, codebook_size: int, embedding_dim: int):
+                    self.codebook_size = codebook_size
+                    self.embedding_dim = embedding_dim
+                    self.tpu_ops = TpuV4AdaptiveOps()
+                    
+                    # Initialize codebook using capibara.jax.numpy
+                    self.codebook = cjnp.array(
+                        np.random.randn(codebook_size, embedding_dim) if NUMPY_AVAILABLE 
+                        else [[0.0] * embedding_dim for _ in range(codebook_size)]
+                    )
+                
+                def __call__(self, inputs, training=True, **kwargs):
+                    """VQbit quantization using TPU kernels."""
+                    
+                    # Use TPU-optimized VQbit quantization
+                    quantized, indices = self.tpu_ops.vqbit_quantize(
+                        inputs, self.codebook, modality=kwargs.get('modality', 'default')
+                    )
+                    
+                    # Compute basic metrics
+                    metrics = self._compute_metrics(inputs, quantized, indices)
+                    
+                    return quantized, indices, metrics
+                
+                def _compute_metrics(self, inputs, quantized, indices):
+                    """Compute quantization metrics."""
+                    try:
+                        # Basic metrics using capibara.jax.numpy
+                        mse = cjnp.mean((inputs - quantized) ** 2)
+                        unique_codes = len(cjnp.array(list(set(indices.flatten()))))
+                        usage = unique_codes / self.codebook_size
+                        
+                        return {
+                            'mse': float(mse),
+                            'codebook_usage': float(usage),
+                            'unique_codes': unique_codes,
+                            'backend': 'capibara_jax_tpu',
+                            'compression_ratio': 32.0 / 6.0  # Assuming 64 codes = 6 bits
+                        }
+                    except Exception as e:
+                        logger.warning(f"Metrics computation failed: {e}")
+                        return {'backend': 'capibara_jax_tpu', 'error': str(e)}
+            
+            return CapibaraJAXTPUVQbit(codebook_size, embedding_dim)
+            
+        except Exception as e:
+            logger.warning(f"Capibara JAX TPU VQbit creation failed: {e}")
+            return self._create_capibara_jax_vqbit(codebook_size, embedding_dim, **kwargs)
+    
+    def _create_capibara_jax_vqbit(self, codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates VQbit layer using Capibara JAX (no TPU kernels)."""
+        
+        try:
+            # VQbit implementation using capibara.jax.numpy
+            class CapibaraJAXVQbit:
+                def __init__(self, codebook_size: int, embedding_dim: int):
+                    self.codebook_size = codebook_size
+                    self.embedding_dim = embedding_dim
+                    
+                    # Initialize codebook
+                    if NUMPY_AVAILABLE:
+                        codebook_data = np.random.randn(codebook_size, embedding_dim).astype(np.float32)
+                        # Normalize codebook entries
+                        norms = np.linalg.norm(codebook_data, axis=1, keepdims=True)
+                        codebook_data = codebook_data / (norms + 1e-8)
+                    else:
+                        # Minimal fallback
+                        codebook_data = [[0.1] * embedding_dim for _ in range(codebook_size)]
+                    
+                    self.codebook = cjnp.array(codebook_data)
+                
+                def __call__(self, inputs, training=True, **kwargs):
+                    """VQbit quantization using capibara.jax.numpy."""
+                    
+                    try:
+                        input_shape = inputs.shape
+                        flat_inputs = cjnp.reshape(inputs, (-1, self.embedding_dim))
+                        
+                        # Compute distances using capibara.jax operations
+                        # Distance computation: ||x - c||^2 = ||x||^2 + ||c||^2 - 2<x,c>
+                        input_norms = cjnp.sum(flat_inputs ** 2, axis=1, keepdims=True)
+                        codebook_norms = cjnp.sum(self.codebook ** 2, axis=1, keepdims=True).T
+                        dot_products = cjnp.matmul(flat_inputs, self.codebook.T)
+                        
+                        distances = input_norms + codebook_norms - 2 * dot_products
+                        
+                        # Find nearest codebook entries
+                        indices = cjnp.argmin(distances, axis=1)
+                        
+                        # Get quantized values
+                        quantized_flat = self.codebook[indices]
+                        quantized = cjnp.reshape(quantized_flat, input_shape)
+                        indices_reshaped = cjnp.reshape(indices, input_shape[:-1])
+                        
+                        # Compute metrics
+                        metrics = self._compute_metrics(flat_inputs, quantized_flat, indices)
+                        
+                        return quantized, indices_reshaped, metrics
+                        
+                    except Exception as e:
+                        logger.error(f"Capibara JAX VQbit forward failed: {e}")
+                        # Return inputs unchanged as fallback
+                        return inputs, cjnp.zeros(inputs.shape[:-1]), {'error': str(e)}
+                
+                def _compute_metrics(self, inputs, quantized, indices):
+                    """Compute metrics using capibara.jax.numpy."""
+                    try:
+                        mse = cjnp.mean((inputs - quantized) ** 2)
+                        
+                        # Count unique indices (simplified)
+                        unique_codes = len(set(indices.flatten().tolist()))
+                        usage = unique_codes / self.codebook_size
+                        
+                        return {
+                            'mse': float(mse),
+                            'codebook_usage': float(usage),
+                            'unique_codes': unique_codes,
+                            'backend': 'capibara_jax',
+                            'compression_ratio': 32.0 / max(1, np.log2(self.codebook_size))
+                        }
+                    except Exception as e:
+                        return {'backend': 'capibara_jax', 'error': str(e)}
+            
+            return CapibaraJAXVQbit(codebook_size, embedding_dim)
+            
+        except Exception as e:
+            logger.warning(f"Capibara JAX VQbit creation failed: {e}")
+            return self._create_vqbit_native(codebook_size, embedding_dim, **kwargs)
+    
+    def _create_vqbit_native(self, codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates VQbit using native VQbit implementations."""
+        
+        if not VQBIT_IMPLEMENTATIONS_AVAILABLE:
+            return self._create_numpy_fallback_vqbit(codebook_size, embedding_dim, **kwargs)
+        
+        try:
+            from .vqbit_layer import create_vqbit_layer
+            
+            return create_vqbit_layer(
+                codebook_size=codebook_size,
+                embedding_dim=embedding_dim,
+                use_tpu_optimizations=True,
+                **kwargs
+            )
+            
+        except Exception as e:
+            logger.warning(f"Native VQbit creation failed: {e}")
+            return self._create_numpy_fallback_vqbit(codebook_size, embedding_dim, **kwargs)
+    
+    def _create_numpy_fallback_vqbit(self, codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates VQbit using pure numpy fallback."""
+        
+        if not NUMPY_AVAILABLE:
+            return self._create_minimal_fallback_vqbit(codebook_size, embedding_dim, **kwargs)
+        
+        class NumpyVQbit:
+            def __init__(self, codebook_size: int, embedding_dim: int):
+                self.codebook_size = codebook_size
+                self.embedding_dim = embedding_dim
+                
+                # Initialize normalized codebook
+                self.codebook = np.random.randn(codebook_size, embedding_dim).astype(np.float32)
+                norms = np.linalg.norm(self.codebook, axis=1, keepdims=True)
+                self.codebook = self.codebook / (norms + 1e-8)
+            
+            def __call__(self, inputs, training=True, **kwargs):
+                """Pure numpy VQbit quantization."""
+                
+                input_shape = inputs.shape
+                flat_inputs = inputs.reshape(-1, self.embedding_dim)
+                
+                # Compute distances
+                distances = np.linalg.norm(
+                    flat_inputs[:, None, :] - self.codebook[None, :, :],
+                    axis=2
+                )
+                
+                # Find nearest codes
+                indices = np.argmin(distances, axis=1)
+                quantized_flat = self.codebook[indices]
+                
+                # Reshape back
+                quantized = quantized_flat.reshape(input_shape)
+                indices_reshaped = indices.reshape(input_shape[:-1])
+                
+                # Basic metrics
+                mse = np.mean((flat_inputs - quantized_flat) ** 2)
+                unique_codes = len(np.unique(indices))
+                usage = unique_codes / self.codebook_size
+                
+                metrics = {
+                    'mse': float(mse),
+                    'codebook_usage': float(usage),
+                    'unique_codes': unique_codes,
+                    'backend': 'numpy_fallback',
+                    'compression_ratio': 32.0 / max(1, np.log2(self.codebook_size))
+                }
+                
+                return quantized, indices_reshaped, metrics
+        
+        return NumpyVQbit(codebook_size, embedding_dim)
+    
+    def _create_minimal_fallback_vqbit(self, codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates minimal VQbit fallback (no external dependencies)."""
+        
+        class MinimalVQbit:
+            def __init__(self, codebook_size: int, embedding_dim: int):
+                self.codebook_size = codebook_size
+                self.embedding_dim = embedding_dim
+                
+                # Minimal codebook initialization
+                self.codebook = [
+                    [0.1 * (i % 10 - 5) for _ in range(embedding_dim)]
+                    for i in range(codebook_size)
+                ]
+            
+            def __call__(self, inputs, training=True, **kwargs):
+                """Minimal VQbit implementation."""
+                
+                # Simple quantization (just return inputs with dummy indices)
+                if hasattr(inputs, 'shape'):
+                    indices_shape = inputs.shape[:-1]
+                    indices = [[0 for _ in range(indices_shape[-1])] 
+                              for _ in range(indices_shape[0])] if len(indices_shape) > 1 else [0] * indices_shape[0]
+                else:
+                    indices = [0]
+                
+                metrics = {
+                    'mse': 0.0,
+                    'codebook_usage': 1.0,
+                    'unique_codes': 1,
+                    'backend': 'minimal_fallback',
+                    'compression_ratio': 1.0
+                }
+                
+                return inputs, indices, metrics
+        
+        return MinimalVQbit(codebook_size, embedding_dim)
+    
+    def create_multimodal_native_vqbit(self,
+                                      modalities: List[str] = None,
+                                      codebook_size: int = 64,
+                                      embedding_dim: int = 768,
+                                      **kwargs) -> Any:
+        """Creates multimodal VQbit using native infrastructure."""
+        
+        if modalities is None:
+            modalities = ['text', 'image', 'audio']
+        
+        if self.selected_backend.startswith('capibara_jax'):
+            return self._create_capibara_jax_multimodal(modalities, codebook_size, embedding_dim, **kwargs)
+        else:
+            return self._create_fallback_multimodal(modalities, codebook_size, embedding_dim, **kwargs)
+    
+    def _create_capibara_jax_multimodal(self, modalities: List[str], codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates multimodal VQbit using Capibara JAX."""
+        
+        class CapibaraJAXMultimodalVQbit:
+            def __init__(self, modalities: List[str], codebook_size: int, embedding_dim: int):
+                self.modalities = modalities
+                self.codebook_size = codebook_size
+                self.embedding_dim = embedding_dim
+                
+                # Create shared codebook using capibara.jax.numpy
+                if NUMPY_AVAILABLE:
+                    codebook_data = np.random.randn(codebook_size, embedding_dim).astype(np.float32)
+                else:
+                    codebook_data = [[0.1] * embedding_dim for _ in range(codebook_size)]
+                
+                self.codebook = cjnp.array(codebook_data)
+                
+                # Modal adaptation matrices
+                self.modal_adapters = {}
+                for modality in modalities:
+                    if NUMPY_AVAILABLE:
+                        adapter_data = np.eye(embedding_dim).astype(np.float32)
+                    else:
+                        adapter_data = [[1.0 if i == j else 0.0 for j in range(embedding_dim)] 
+                                       for i in range(embedding_dim)]
+                    self.modal_adapters[modality] = cjnp.array(adapter_data)
+            
+            def __call__(self, inputs, modality=None, training=True, **kwargs):
+                """Multimodal VQbit processing."""
+                
+                if isinstance(inputs, dict):
+                    # Process multiple modalities
+                    results = {}
+                    all_quantized = []
+                    
+                    for mod, modal_input in inputs.items():
+                        if mod in self.modalities:
+                            result = self._process_modality(modal_input, mod)
+                            results[mod] = result
+                            all_quantized.append(result['quantized'])
+                    
+                    # Simple fusion (average)
+                    if all_quantized:
+                        if CAPIBARA_JAX_AVAILABLE:
+                            fused = cjnp.mean(cjnp.stack(all_quantized), axis=0)
+                        else:
+                            fused = all_quantized[0]  # Just use first as fallback
+                    else:
+                        fused = inputs
+                    
+                    return {
+                        'quantized': fused,
+                        'modal_results': results,
+                        'metrics': {'total_modalities': len(results), 'backend': 'capibara_jax_multimodal'}
+                    }
+                else:
+                    # Single modality
+                    if modality is None:
+                        modality = self.modalities[0]
+                    return self._process_modality(inputs, modality)
+            
+            def _process_modality(self, inputs, modality):
+                """Process single modality."""
+                try:
+                    # Apply modal adaptation
+                    if modality in self.modal_adapters:
+                        adapted = cjnp.matmul(inputs, self.modal_adapters[modality])
+                    else:
+                        adapted = inputs
+                    
+                    # Simple quantization
+                    input_shape = adapted.shape
+                    flat_adapted = cjnp.reshape(adapted, (-1, self.embedding_dim))
+                    
+                    # Find nearest codebook entries
+                    distances = cjnp.sum((flat_adapted[:, None, :] - self.codebook[None, :, :]) ** 2, axis=2)
+                    indices = cjnp.argmin(distances, axis=1)
+                    quantized_flat = self.codebook[indices]
+                    
+                    quantized = cjnp.reshape(quantized_flat, input_shape)
+                    indices_reshaped = cjnp.reshape(indices, input_shape[:-1])
+                    
+                    # Basic metrics
+                    mse = cjnp.mean((flat_adapted - quantized_flat) ** 2)
+                    
+                    return {
+                        'quantized': quantized,
+                        'indices': indices_reshaped,
+                        'metrics': {
+                            'mse': float(mse),
+                            'modality': modality,
+                            'backend': 'capibara_jax'
+                        }
+                    }
+                    
+                except Exception as e:
+                    logger.error(f"Capibara JAX modality processing failed: {e}")
+                    return {
+                        'quantized': inputs,
+                        'indices': cjnp.zeros(inputs.shape[:-1]),
+                        'metrics': {'error': str(e), 'modality': modality}
+                    }
+        
+        return CapibaraJAXMultimodalVQbit(modalities, codebook_size, embedding_dim)
+    
+    def _create_fallback_multimodal(self, modalities: List[str], codebook_size: int, embedding_dim: int, **kwargs) -> Any:
+        """Creates fallback multimodal VQbit."""
+        
+        if VQBIT_IMPLEMENTATIONS_AVAILABLE:
+            try:
+                from .multimodal_vqbit import create_multimodal_vqbit
+                return create_multimodal_vqbit(
+                    modalities=modalities,
+                    codebook_size=codebook_size,
+                    embedding_dim=embedding_dim,
+                    **kwargs
+                )
+            except Exception as e:
+                logger.warning(f"Native multimodal VQbit creation failed: {e}")
+        
+        # Ultimate fallback
+        return self._create_minimal_fallback_vqbit(codebook_size, embedding_dim, **kwargs)
+    
+    def get_backend_info(self) -> Dict[str, Any]:
+        """Get information about the selected backend."""
+        
+        return {
+            'selected_backend': self.selected_backend,
+            'available_backends': self.available_backends,
+            'capibara_jax_available': CAPIBARA_JAX_AVAILABLE,
+            'numpy_available': NUMPY_AVAILABLE,
+            'vqbit_implementations_available': VQBIT_IMPLEMENTATIONS_AVAILABLE,
+            'config': {
+                'prefer_capibara_jax': self.config.prefer_capibara_jax,
+                'enable_tpu_kernels': self.config.enable_tpu_kernels,
+                'enable_fallback_numpy': self.config.enable_fallback_numpy
+            }
+        }
+    
+    def benchmark_backends(self) -> Dict[str, Any]:
+        """Benchmark available backends."""
+        
+        if not NUMPY_AVAILABLE:
+            return {'error': 'numpy_not_available_for_benchmarking'}
+        
+        # Create test data
+        test_input = np.random.randn(4, 16, 128).astype(np.float32)
+        
+        results = {}
+        
+        # Test each available backend
+        backends_to_test = ['capibara_jax_tpu', 'capibara_jax', 'vqbit_native', 'numpy_fallback']
+        
+        for backend in backends_to_test:
+            if backend == 'capibara_jax_tpu' and not self.available_backends.get('tpu_v4_kernels'):
+                continue
+            if backend == 'capibara_jax' and not self.available_backends.get('capibara_jax'):
+                continue
+            if backend == 'vqbit_native' and not self.available_backends.get('vqbit_implementations'):
+                continue
+            
+            try:
+                # Temporarily switch backend
+                original_backend = self.selected_backend
+                self.selected_backend = backend
+                
+                # Create VQbit instance
+                vqbit = self.create_native_vqbit_layer(codebook_size=32, embedding_dim=128)
+                
+                # Benchmark
+                start_time = time.time()
+                quantized, indices, metrics = vqbit(test_input, training=True)
+                end_time = time.time()
+                
+                results[backend] = {
+                    'operation_time_ms': (end_time - start_time) * 1000,
+                    'metrics': metrics,
+                    'success': True
+                }
+                
+                # Restore original backend
+                self.selected_backend = original_backend
+                
+            except Exception as e:
+                results[backend] = {
+                    'error': str(e),
+                    'success': False
+                }
+        
+        return results
+
+
+# Global native integration instance
+_native_integration = None
+
+def get_native_integration() -> VQbitNativeIntegration:
+    """Get global native integration instance."""
+    global _native_integration
+    if _native_integration is None:
+        _native_integration = VQbitNativeIntegration()
+    return _native_integration
+
+def create_native_vqbit_layer(codebook_size: int = 64,
+                             embedding_dim: int = 768,
+                             **kwargs) -> Any:
+    """
+    Create VQbit layer using native infrastructure.
+    
+    Args:
+        codebook_size: Number of codebook entries
+        embedding_dim: Embedding dimension
+        **kwargs: Additional configuration
+        
+    Returns:
+        Native VQbit layer instance
+    """
+    integration = get_native_integration()
+    return integration.create_native_vqbit_layer(codebook_size, embedding_dim, **kwargs)
+
+def create_native_multimodal_vqbit(modalities: List[str] = None,
+                                  codebook_size: int = 64,
+                                  embedding_dim: int = 768,
+                                  **kwargs) -> Any:
+    """
+    Create multimodal VQbit using native infrastructure.
+    
+    Args:
+        modalities: List of modalities to support
+        codebook_size: Number of codebook entries
+        embedding_dim: Embedding dimension
+        **kwargs: Additional configuration
+        
+    Returns:
+        Native multimodal VQbit instance
+    """
+    integration = get_native_integration()
+    return integration.create_multimodal_native_vqbit(modalities, codebook_size, embedding_dim, **kwargs)
+
+def get_native_backend_info() -> Dict[str, Any]:
+    """Get information about native backend selection."""
+    integration = get_native_integration()
+    return integration.get_backend_info()
+
+def benchmark_native_backends() -> Dict[str, Any]:
+    """Benchmark all available native backends."""
+    integration = get_native_integration()
+    return integration.benchmark_backends()
+
+# Integration with existing TPU backend
+def integrate_with_tpu_backend():
+    """Integrate VQbit with existing TPU backend."""
+    
+    try:
+        from capibara.jax.tpu_v4.backend import TpuV4AdaptiveOps
+        
+        # Enhance TPU backend with native VQbit
+        original_vqbit_quantize = TpuV4AdaptiveOps.vqbit_quantize
+        
+        def enhanced_vqbit_quantize(self, input_tensor, codebook, modality="default"):
+            """Enhanced VQbit quantization using native implementations."""
+            
+            try:
+                # Try to use native VQbit implementation
+                integration = get_native_integration()
+                vqbit_layer = integration.create_native_vqbit_layer(
+                    codebook_size=codebook.shape[0] if hasattr(codebook, 'shape') else 64,
+                    embedding_dim=input_tensor.shape[-1]
+                )
+                
+                quantized, indices, metrics = vqbit_layer(input_tensor, training=True)
+                
+                # Log integration success
+                logger.debug(f"Native VQbit integration successful: {metrics.get('backend', 'unknown')}")
+                
+                return quantized, indices
+                
+            except Exception as e:
+                logger.warning(f"Native VQbit integration failed, using original: {e}")
+                return original_vqbit_quantize(self, input_tensor, codebook, modality)
+        
+        # Replace method
+        TpuV4AdaptiveOps.vqbit_quantize = enhanced_vqbit_quantize
+        
+        logger.info(" VQbit native integration with TPU backend successful")
+        return True
+        
+    except Exception as e:
+        logger.warning(f"TPU backend integration failed: {e}")
+        return False
+
+# Auto-integrate on import (safely)
+try:
+    # Only try integration if we have the necessary components
+    if CAPIBARA_JAX_AVAILABLE and VQBIT_IMPLEMENTATIONS_AVAILABLE:
+        if integrate_with_tpu_backend():
+            logger.info(" VQbit native integration activated")
+        else:
+            logger.info(" VQbit running in standalone mode")
+    else:
+        logger.info(" VQbit native integration available but not auto-activated")
+except Exception as e:
+    logger.debug(f"Auto-integration skipped: {e}")
+
+logger.info("VQbit JAX Native Integration initialized")

--- a/capibara/vq/vqbit/mnemosyne_semio.py
+++ b/capibara/vq/vqbit/mnemosyne_semio.py
@@ -1,0 +1,206 @@
+"""MnemosyneSemioModule – v2.0
+================================
+• Detección de contexto with sistema de pesos + regex optional
+• Idioma autodetectado (inglés/español)
+• Devuelve analysis semiótico clásico, cuántico or híbrido
+• Caché interna for prompts repetidos
+• integration básica with embeddings cuánticos
+"""
+
+from __future__ import annotations
+
+import os
+import functools
+import langdetect
+from capibara.jax.numpy import jnp
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# Enumeraciones and resultados
+# -----------------------------------------------------------------------------
+
+from enum import Enum
+
+class AnalysisType(Enum):
+    CLASSICAL = "classical"
+    ADAPTIVE = "adaptive"
+    HYBRID = "hybrid"
+
+@dataclass
+class AnalysisResult:
+    status: str
+    analysis_type: AnalysisType
+    confidence: float
+    interpretation: str
+    suggested_actions: List[str]
+
+# -----------------------------------------------------------------------------
+# Palabras key base
+# -----------------------------------------------------------------------------
+
+_ADAPTIVE_KW = {"solitón", "vórtice", "campo no lineal", "estructura topológica", "cuántico", "vortex", "soliton"}
+_CLASSIC_KW = {
+    "obra de arte", "pintura", "escultura", "videoarte", "fotografía", "arte clásico",
+    "iconografía", "symbol", "symbolic", "classic art", "renaissance", "baroque", "romanticism",
+}
+
+# -----------------------------------------------------------------------------
+# Módulo principal
+# -----------------------------------------------------------------------------
+
+@dataclass
+class MnemosyneSemioModule:
+    context_keywords: Set[str] = field(default_factory=lambda: _ADAPTIVE_KW | _CLASSIC_KW)
+    corpus: Optional[Dict[str, str]] = None
+    _active: bool = False
+
+    def __post_init__(self):
+        self._build_keyword_system()
+        self._init_art_corpus()
+        self.adaptive_threshold = 0.6
+        self.hybrid_threshold = 0.4
+
+    def _detect_language(self, text: str) -> str:
+        try:
+            return langdetect.detect(text)
+        except Exception:
+            return "unknown"
+
+    def activate(self, text: str) -> Tuple[bool, List[str]]:
+        low = text.lower()
+        matched = [kw for kw in self.context_keywords if re.search(rf"\\b{re.escape(kw)}\\b", low)]
+        self._active = bool(matched)
+        logger.debug("Mnemosyne activated=%s keywords=%s", self._active, matched)
+        return self._active, matched
+
+    @functools.lru_cache(maxsize=256)
+    def contextual_analysis(self, text: str) -> Dict[str, str]:
+        active, matched = self.activate(text)
+        if not active:
+            return {"status": "inactive", "reason": "context not matched"}
+
+        q = any(kw in _ADAPTIVE_KW for kw in matched)
+        analysis_type = "adaptive" if q else "classical"
+        interp = (
+            "Interpretación cuántica: El prompt menciona dinámica topológica/solitónica; "
+            "profundizar en mecánica cuántica no lineal."
+            if q else
+            "Interpretación clásica: El prompt sugiere un análisis iconográfico de obra artística; "
+            "examinar simbolismo histórico y contexto cultural."
+        )
+        return {
+            "status": "active",
+            "analysis_type": analysis_type,
+            "matched_keywords": matched,
+            "interpretation": interp,
+        }
+
+    def load_corpus(self, corpus: Dict[str, str]):
+        self.corpus = corpus
+
+    def _build_keyword_system(self):
+        self.keyword_weights = {
+            "obra de arte": 0.8, "pintura": 0.7, "escultura": 0.7,
+            "renacimiento": 0.9, "barroco": 0.9,
+            "videoarte": 0.6, "instalación": 0.6, "performance": 0.6,
+            "solitón": 1.0, "vórtice cuántico": 1.0,
+            "campo no lineal": 0.9, "estructura topológica": 0.8,
+            "arte cuántico": 1.0, "visualización científica": 0.7
+        }
+        self.keyword_groups = {
+            AnalysisType.CLASSICAL: ["obra de arte", "pintura", "escultura", "renacimiento", "barroco", "videoarte"],
+            AnalysisType.ADAPTIVE: ["solitón", "vórtice cuántico", "campo no lineal", "estructura topológica"]
+        }
+
+    def _init_art_corpus(self):
+        self.art_corpus = {
+            "classical": {
+                "symbols": ["flor", "cráneo", "reloj", "espejo"],
+                "themes": ["vanitas", "memento mori", "alegoría"]
+            },
+            "adaptive": {
+                "symbols": ["onda", "partícula", "entrelazamiento"],
+                "themes": ["dualidad", "superposición", "decoherencia"]
+            }
+        }
+
+    def analyze_query(self, query: str) -> AnalysisResult:
+        clean_query = self._preprocess_text(query)
+        adaptive_score = self._calculate_context_score(clean_query, AnalysisType.ADAPTIVE)
+        classical_score = self._calculate_context_score(clean_query, AnalysisType.CLASSICAL)
+        analysis_type, confidence = self._determine_analysis_type(adaptive_score, classical_score)
+        interpretation = self._generate_interpretation(clean_query, analysis_type)
+        actions = self._suggest_actions(analysis_type)
+        return AnalysisResult("active", analysis_type, confidence, interpretation, actions)
+
+    def _preprocess_text(self, text: str) -> str:
+        return re.sub(r"[^\\w\\s]", "", text.lower())
+
+    def _calculate_context_score(self, text: str, context_type: AnalysisType) -> float:
+        total = 0.0
+        for keyword in self.keyword_groups.get(context_type, []):
+            if keyword in text:
+                total += self.keyword_weights.get(keyword, 0.0)
+        return total / len(self.keyword_groups[context_type]) if self.keyword_groups[context_type] else 0.0
+
+    def _determine_analysis_type(self, adaptive_score: float, classical_score: float) -> Tuple[AnalysisType, float]:
+        if adaptive_score >= self.adaptive_threshold:
+            return AnalysisType.ADAPTIVE, adaptive_score
+        elif adaptive_score >= self.hybrid_threshold and classical_score > 0.3:
+            return AnalysisType.HYBRID, (adaptive_score + classical_score) / 2
+        elif classical_score > 0.5:
+            return AnalysisType.CLASSICAL, classical_score
+        else:
+            return AnalysisType.CLASSICAL, 0.0
+
+    def _generate_interpretation(self, text: str, analysis_type: AnalysisType) -> str:
+        base = {
+            AnalysisType.CLASSICAL: "Análisis semiótico clásico: El texto sugiere una aproximación tradicional al arte, con posibles elementos de {themes}. Buscar símbolos como {symbols}.",
+            AnalysisType.ADAPTIVE: "Lectura cuántico-artística: El contenido apunta a fenómenos cuánticos como {themes}. Considerar representaciones de {symbols} desde perspectiva no clásica.",
+            AnalysisType.HYBRID: "Interpretación híbrida: Combina elementos artísticos tradicionales ({classical_themes}) con conceptos cuánticos ({adaptive_themes}). Analizar interacción entre {classical_symbols} y {adaptive_symbols}."
+        }
+        if analysis_type == AnalysisType.HYBRID:
+            return base[analysis_type].format(
+                classical_themes=", ".join(self.art_corpus["classical"]["themes"][:2]),
+                adaptive_themes=", ".join(self.art_corpus["adaptive"]["themes"][:2]),
+                classical_symbols=", ".join(self.art_corpus["classical"]["symbols"][:2]),
+                adaptive_symbols=", ".join(self.art_corpus["adaptive"]["symbols"][:2])
+            )
+        else:
+            corpus = self.art_corpus["adaptive" if analysis_type == AnalysisType.ADAPTIVE else "classical"]
+            return base[analysis_type].format(
+                themes=", ".join(corpus["themes"][:2]),
+                symbols=", ".join(corpus["symbols"][:2])
+            )
+
+    def _suggest_actions(self, analysis_type: AnalysisType) -> List[str]:
+        return {
+            AnalysisType.CLASSICAL: [
+                "Realizar análisis iconográfico detallado",
+                "Buscar referencias históricas del periodo",
+                "Identificar símbolos tradicionales"
+            ],
+            AnalysisType.ADAPTIVE: [
+                "Mapear conceptos a representaciones cuánticas",
+                "Analizar patrones de interferencia simbólica",
+                "Buscar analogías con sistemas no lineales"
+            ],
+            AnalysisType.HYBRID: [
+                "Comparar con obras de arte científico-históricas",
+                "Identificar puntos de convergencia conceptual",
+                "Analizar dimensiones clásicas y cuánticas simultáneamente"
+            ]
+        }.get(analysis_type, [])
+
+    def integrate_with_adaptive(self, adaptive_embedding: jnp.ndarray) -> Dict:
+        return {
+            "status": "integrated",
+            "embedding_shape": adaptive_embedding.shape,
+            "analysis": "Adaptive-semiotic fusion completed",
+            "fusion_coherence": 0.94,
+            "semantic_alignment": 0.89,
+            "adaptive_weight": 0.85
+        }

--- a/capibara/vq/vqbit/multimodal_vqbit.py
+++ b/capibara/vq/vqbit/multimodal_vqbit.py
@@ -1,0 +1,779 @@
+"""
+Multimodal VQbit Module for Capibara-6
+
+Advanced multimodal vector quantization supporting:
+- Cross-modal quantization (text, image, audio)
+- Shared codebook learning across modalities
+- Modal-specific adaptations
+- Fusion strategies for multimodal representations
+- Cache-aware processing for adaptive systems
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass
+import math
+
+# JAX/Flax imports (preferred for TPU)
+try:
+    import jax
+    import jax.numpy as jnp
+    import flax.linen as nn
+    from flax import struct
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+    jax = None
+    jnp = None
+    nn = None
+
+# PyTorch fallback
+try:
+    import torch
+    import torch.nn as torch_nn
+    import torch.nn.functional as F
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+    torch = None
+    torch_nn = None
+    F = None
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class MultimodalVQConfig:
+    """Configurestion for Multimodal VQbit."""
+    # Core VQ parameters
+    codebook_size: int = 64
+    embedding_dim: int = 768
+    commitment_weight: float = 0.25
+    
+    # Multimodal settings
+    modalities: List[str] = None  # ['text', 'image', 'audio']
+    shared_codebook: bool = True
+    modal_adaptation: bool = True
+    fusion_strategy: str = "concat"  # concat, add, attention
+    
+    # Cache settings for adaptive compatibility
+    adaptive_compatible: bool = False
+    cache_size_ratio: float = 0.4
+    tile_size: int = 256
+    enable_prefetch: bool = True
+    
+    # EMA settings
+    use_ema: bool = True
+    ema_decay: float = 0.999
+    ema_epsilon: float = 1e-5
+    
+    def __post_init__(self):
+        if self.modalities is None:
+            self.modalities = ['text', 'image', 'audio']
+
+
+if JAX_AVAILABLE:
+    class VQbitModule(nn.Module):
+        """
+        Multimodal VQbit Module - JAX/Flax implementation.
+        
+        Features:
+        - Multimodal vector quantization
+        - Shared or separate codebooks per modality
+        - Modal adaptation layers
+        - Fusion strategies for cross-modal representations
+        - Cache-aware processing for adaptive systems
+        """
+        
+        config: MultimodalVQConfig
+        
+        def setup(self):
+            """Initialize the multimodal VQbit module."""
+            num_modalities = len(self.config.modalities)
+            
+            # Modal adaptation layers
+            if self.config.modal_adaptation:
+                self.modal_adapters = {}
+                for modality in self.config.modalities:
+                    self.modal_adapters[modality] = nn.Dense(
+                        self.config.embedding_dim,
+                        name=f"adapter_{modality}"
+                    )
+            
+            # Codebook initialization
+            if self.config.shared_codebook:
+                # Single shared codebook
+                self.codebook = self.param(
+                    'shared_codebook',
+                    nn.initializers.uniform(scale=1.0),
+                    (self.config.codebook_size, self.config.embedding_dim)
+                )
+            else:
+                # Separate codebooks per modality
+                self.codebooks = {}
+                for modality in self.config.modalities:
+                    self.codebooks[modality] = self.param(
+                        f'codebook_{modality}',
+                        nn.initializers.uniform(scale=1.0),
+                        (self.config.codebook_size, self.config.embedding_dim)
+                    )
+            
+            # Fusion layer
+            if self.config.fusion_strategy == "attention":
+                self.fusion_attention = nn.MultiHeadDotProductAttention(
+                    num_heads=8,
+                    qkv_features=self.config.embedding_dim
+                )
+            elif self.config.fusion_strategy == "concat":
+                self.fusion_projection = nn.Dense(self.config.embedding_dim)
+            
+            # EMA variables if enabled
+            if self.config.use_ema:
+                if self.config.shared_codebook:
+                    self.ema_cluster_size = self.variable(
+                        'ema_stats', 'cluster_size',
+                        lambda: jnp.zeros(self.config.codebook_size)
+                    )
+                    self.ema_embedding_avg = self.variable(
+                        'ema_stats', 'embedding_avg',
+                        lambda: jnp.zeros((self.config.codebook_size, self.config.embedding_dim))
+                    )
+                else:
+                    self.ema_stats = {}
+                    for modality in self.config.modalities:
+                        self.ema_stats[modality] = {
+                            'cluster_size': self.variable(
+                                'ema_stats', f'cluster_size_{modality}',
+                                lambda: jnp.zeros(self.config.codebook_size)
+                            ),
+                            'embedding_avg': self.variable(
+                                'ema_stats', f'embedding_avg_{modality}',
+                                lambda: jnp.zeros((self.config.codebook_size, self.config.embedding_dim))
+                            )
+                        }
+        
+        def __call__(self, 
+                    inputs: Union[jnp.ndarray, Dict[str, jnp.ndarray]], 
+                    modality: Optional[str] = None,
+                    training: bool = True,
+                    **kwargs) -> Dict[str, Any]:
+            """
+            Forward pass of multimodal VQbit module.
+            
+            Args:
+                inputs: Input embeddings (single array or dict of modality arrays)
+                modality: Modality name if single input
+                training: Whether in training mode
+                **kwargs: Additional arguments (for adaptive compatibility)
+                
+            Returns:
+                Dictionary with quantized outputs, indices, and metrics
+            """
+            
+            if isinstance(inputs, dict):
+                # Multiple modalities
+                return self._process_multimodal(inputs, training)
+            else:
+                # Single modality
+                if modality is None:
+                    modality = self.config.modalities[0]  # Default to first modality
+                return self._process_single_modality(inputs, modality, training)
+        
+        def _process_single_modality(self, 
+                                   inputs: jnp.ndarray, 
+                                   modality: str, 
+                                   training: bool) -> Dict[str, Any]:
+            """Process single modality input."""
+            
+            # Modal adaptation
+            if self.config.modal_adaptation and modality in self.modal_adapters:
+                adapted_inputs = self.modal_adapters[modality](inputs)
+            else:
+                adapted_inputs = inputs
+            
+            # Get appropriate codebook
+            if self.config.shared_codebook:
+                codebook = self.codebook
+            else:
+                codebook = self.codebooks[modality]
+            
+            # Quantize
+            input_shape = adapted_inputs.shape
+            flat_inputs = adapted_inputs.reshape(-1, self.config.embedding_dim)
+            
+            # Compute distances and quantize
+            distances = jnp.linalg.norm(
+                flat_inputs[:, None, :] - codebook[None, :, :],
+                axis=2
+            )
+            
+            indices = jnp.argmin(distances, axis=1)
+            quantized = codebook[indices]
+            
+            # Compute losses
+            commitment_loss = jnp.mean((jax.lax.stop_gradient(quantized) - flat_inputs) ** 2)
+            codebook_loss = jnp.mean((quantized - jax.lax.stop_gradient(flat_inputs)) ** 2)
+            
+            # Straight-through estimator
+            quantized = flat_inputs + jax.lax.stop_gradient(quantized - flat_inputs)
+            
+            # Reshape back
+            quantized = quantized.reshape(input_shape)
+            indices = indices.reshape(input_shape[:-1])
+            
+            # Compute metrics
+            metrics = self._compute_metrics(flat_inputs, quantized.reshape(-1, self.config.embedding_dim), 
+                                          indices.reshape(-1), commitment_loss, codebook_loss, modality)
+            
+            return {
+                'quantized': quantized,
+                'indices': indices,
+                'metrics': metrics,
+                'modality': modality,
+                'cache_info': self._get_cache_info() if self.config.adaptive_compatible else {}
+            }
+        
+        def _process_multimodal(self, 
+                              inputs: Dict[str, jnp.ndarray], 
+                              training: bool) -> Dict[str, Any]:
+            """Process multiple modalities and fuse results."""
+            
+            modal_results = {}
+            all_quantized = []
+            all_metrics = {}
+            
+            # Process each modality
+            for modality, modal_input in inputs.items():
+                if modality in self.config.modalities:
+                    result = self._process_single_modality(modal_input, modality, training)
+                    modal_results[modality] = result
+                    all_quantized.append(result['quantized'])
+                    all_metrics[f"{modality}_metrics"] = result['metrics']
+            
+            # Fuse modalities
+            if len(all_quantized) > 1:
+                fused_quantized = self._fuse_modalities(all_quantized)
+            else:
+                fused_quantized = all_quantized[0] if all_quantized else jnp.zeros((1, self.config.embedding_dim))
+            
+            # Compute global metrics
+            global_metrics = self._compute_global_metrics(modal_results)
+            all_metrics['global'] = global_metrics
+            
+            return {
+                'quantized': fused_quantized,
+                'modal_results': modal_results,
+                'metrics': all_metrics,
+                'cache_info': self._get_cache_info() if self.config.adaptive_compatible else {}
+            }
+        
+        def _fuse_modalities(self, quantized_list: List[jnp.ndarray]) -> jnp.ndarray:
+            """Fuse quantized representations from multiple modalities."""
+            
+            if self.config.fusion_strategy == "concat":
+                # Concatenate and project
+                concatenated = jnp.concatenate(quantized_list, axis=-1)
+                if hasattr(self, 'fusion_projection'):
+                    return self.fusion_projection(concatenated)
+                else:
+                    # Simple average if no projection
+                    return jnp.mean(jnp.stack(quantized_list), axis=0)
+                    
+            elif self.config.fusion_strategy == "add":
+                # Element-wise addition
+                return jnp.sum(jnp.stack(quantized_list), axis=0)
+                
+            elif self.config.fusion_strategy == "attention":
+                # Attention-based fusion
+                stacked = jnp.stack(quantized_list, axis=1)  # [batch, num_modalities, dim]
+                if hasattr(self, 'fusion_attention'):
+                    fused = self.fusion_attention(stacked, stacked)
+                    return jnp.mean(fused, axis=1)  # Average over modalities
+                else:
+                    return jnp.mean(stacked, axis=1)
+            
+            else:
+                # Default: average
+                return jnp.mean(jnp.stack(quantized_list), axis=0)
+        
+        def _compute_metrics(self, inputs: jnp.ndarray, quantized: jnp.ndarray,
+                           indices: jnp.ndarray, commitment_loss: float,
+                           codebook_loss: float, modality: str) -> Dict[str, Any]:
+            """Compute quantization metrics for a modality."""
+            
+            # Basic metrics
+            mse = jnp.mean((inputs - quantized) ** 2)
+            
+            # Codebook usage
+            unique_indices = len(jnp.unique(indices))
+            codebook_usage = unique_indices / self.config.codebook_size
+            
+            # Perplexity
+            avg_probs = jnp.mean(jax.nn.one_hot(indices, self.config.codebook_size), axis=0)
+            perplexity = jnp.exp(-jnp.sum(avg_probs * jnp.log(avg_probs + 1e-10)))
+            
+            # Compression ratio
+            original_bits = inputs.size * 32  # float32
+            quantized_bits = indices.size * math.ceil(math.log2(self.config.codebook_size))
+            compression_ratio = original_bits / quantized_bits
+            
+            return {
+                'modality': modality,
+                'commitment_loss': commitment_loss,
+                'codebook_loss': codebook_loss,
+                'mse': mse,
+                'codebook_usage': codebook_usage,
+                'perplexity': perplexity,
+                'compression_ratio': compression_ratio,
+                'unique_codes': unique_indices
+            }
+        
+        def _compute_global_metrics(self, modal_results: Dict[str, Any]) -> Dict[str, Any]:
+            """Compute global metrics across all modalities."""
+            
+            if not modal_results:
+                return {'total_modalities': 0}
+            
+            # Average metrics across modalities
+            total_commitment = 0.0
+            total_codebook = 0.0
+            total_mse = 0.0
+            total_usage = 0.0
+            total_perplexity = 0.0
+            
+            for result in modal_results.values():
+                metrics = result['metrics']
+                total_commitment += metrics['commitment_loss']
+                total_codebook += metrics['codebook_loss']
+                total_mse += metrics['mse']
+                total_usage += metrics['codebook_usage']
+                total_perplexity += metrics['perplexity']
+            
+            num_modalities = len(modal_results)
+            
+            return {
+                'total_modalities': num_modalities,
+                'avg_commitment_loss': total_commitment / num_modalities,
+                'avg_codebook_loss': total_codebook / num_modalities,
+                'avg_mse': total_mse / num_modalities,
+                'avg_codebook_usage': total_usage / num_modalities,
+                'avg_perplexity': total_perplexity / num_modalities,
+                'fusion_strategy': self.config.fusion_strategy
+            }
+        
+        def _get_cache_info(self) -> Dict[str, Any]:
+            """Get cache information for adaptive compatibility."""
+            return {
+                'cache_size_ratio': self.config.cache_size_ratio,
+                'tile_size': self.config.tile_size,
+                'prefetch_enabled': self.config.enable_prefetch,
+                'adaptive_compatible': self.config.adaptive_compatible
+            }
+
+elif TORCH_AVAILABLE:
+    class VQbitModule(torch_nn.Module):
+        """
+        Multimodal VQbit Module - PyTorch implementation.
+        """
+        
+        def __init__(self, config: Optional[MultimodalVQConfig] = None, **kwargs):
+            super().__init__()
+            if config is None:
+                # Extract config parameters from kwargs
+                config_dict = {}
+                for key in ['codebook_size', 'embedding_dim', 'commitment_weight', 
+                           'modalities', 'shared_codebook', 'modal_adaptation',
+                           'fusion_strategy', 'adaptive_compatible', 'cache_size_ratio',
+                           'tile_size', 'enable_prefetch']:
+                    if key in kwargs:
+                        config_dict[key] = kwargs.pop(key)
+                config = MultimodalVQConfig(**config_dict)
+            self.config = config
+            
+            # Modal adaptation layers
+            if self.config.modal_adaptation:
+                self.modal_adapters = torch_nn.ModuleDict()
+                for modality in self.config.modalities:
+                    self.modal_adapters[modality] = torch_nn.Linear(
+                        self.config.embedding_dim, self.config.embedding_dim
+                    )
+            
+            # Codebook initialization
+            if self.config.shared_codebook:
+                self.codebook = torch_nn.Parameter(
+                    torch.randn(self.config.codebook_size, self.config.embedding_dim)
+                )
+            else:
+                self.codebooks = torch_nn.ParameterDict()
+                for modality in self.config.modalities:
+                    self.codebooks[modality] = torch_nn.Parameter(
+                        torch.randn(self.config.codebook_size, self.config.embedding_dim)
+                    )
+            
+            # Fusion layer
+            if self.config.fusion_strategy == "attention":
+                self.fusion_attention = torch_nn.MultiheadAttention(
+                    self.config.embedding_dim, num_heads=8, batch_first=True
+                )
+            elif self.config.fusion_strategy == "concat":
+                fusion_input_dim = len(self.config.modalities) * self.config.embedding_dim
+                self.fusion_projection = torch_nn.Linear(fusion_input_dim, self.config.embedding_dim)
+            
+            # EMA buffers
+            if self.config.use_ema:
+                if self.config.shared_codebook:
+                    self.register_buffer('ema_cluster_size', torch.zeros(self.config.codebook_size))
+                    self.register_buffer('ema_embedding_avg', torch.zeros(self.config.codebook_size, self.config.embedding_dim))
+                else:
+                    for modality in self.config.modalities:
+                        self.register_buffer(f'ema_cluster_size_{modality}', torch.zeros(self.config.codebook_size))
+                        self.register_buffer(f'ema_embedding_avg_{modality}', torch.zeros(self.config.codebook_size, self.config.embedding_dim))
+        
+        def forward(self, 
+                   inputs: Union[torch.Tensor, Dict[str, torch.Tensor]], 
+                   modality: Optional[str] = None,
+                   training: bool = True,
+                   **kwargs) -> Dict[str, Any]:
+            """Forward pass of multimodal VQbit module."""
+            
+            if isinstance(inputs, dict):
+                return self._process_multimodal(inputs, training)
+            else:
+                if modality is None:
+                    modality = self.config.modalities[0]
+                return self._process_single_modality(inputs, modality, training)
+        
+        def _process_single_modality(self, 
+                                   inputs: torch.Tensor, 
+                                   modality: str, 
+                                   training: bool) -> Dict[str, Any]:
+            """Process single modality input."""
+            
+            # Modal adaptation
+            if self.config.modal_adaptation and modality in self.modal_adapters:
+                adapted_inputs = self.modal_adapters[modality](inputs)
+            else:
+                adapted_inputs = inputs
+            
+            # Get appropriate codebook
+            if self.config.shared_codebook:
+                codebook = self.codebook
+            else:
+                codebook = self.codebooks[modality]
+            
+            # Quantize
+            input_shape = adapted_inputs.shape
+            flat_inputs = adapted_inputs.view(-1, self.config.embedding_dim)
+            
+            # Compute distances and quantize
+            distances = torch.norm(
+                flat_inputs.unsqueeze(1) - codebook.unsqueeze(0),
+                dim=2
+            )
+            
+            indices = torch.argmin(distances, dim=1)
+            quantized = codebook[indices]
+            
+            # Compute losses
+            commitment_loss = F.mse_loss(quantized.detach(), flat_inputs)
+            codebook_loss = F.mse_loss(quantized, flat_inputs.detach())
+            
+            # Straight-through estimator
+            quantized = flat_inputs + (quantized - flat_inputs).detach()
+            
+            # Reshape back
+            quantized = quantized.view(input_shape)
+            indices = indices.view(input_shape[:-1])
+            
+            # Compute metrics
+            metrics = self._compute_metrics(flat_inputs, quantized.view(-1, self.config.embedding_dim), 
+                                          indices.view(-1), commitment_loss, codebook_loss, modality)
+            
+            return {
+                'quantized': quantized,
+                'indices': indices,
+                'metrics': metrics,
+                'modality': modality,
+                'cache_info': self._get_cache_info() if self.config.adaptive_compatible else {}
+            }
+        
+        def _process_multimodal(self, 
+                              inputs: Dict[str, torch.Tensor], 
+                              training: bool) -> Dict[str, Any]:
+            """Process multiple modalities and fuse results."""
+            
+            modal_results = {}
+            all_quantized = []
+            all_metrics = {}
+            
+            # Process each modality
+            for modality, modal_input in inputs.items():
+                if modality in self.config.modalities:
+                    result = self._process_single_modality(modal_input, modality, training)
+                    modal_results[modality] = result
+                    all_quantized.append(result['quantized'])
+                    all_metrics[f"{modality}_metrics"] = result['metrics']
+            
+            # Fuse modalities
+            if len(all_quantized) > 1:
+                fused_quantized = self._fuse_modalities(all_quantized)
+            else:
+                fused_quantized = all_quantized[0] if all_quantized else torch.zeros(1, self.config.embedding_dim)
+            
+            # Compute global metrics
+            global_metrics = self._compute_global_metrics(modal_results)
+            all_metrics['global'] = global_metrics
+            
+            return {
+                'quantized': fused_quantized,
+                'modal_results': modal_results,
+                'metrics': all_metrics,
+                'cache_info': self._get_cache_info() if self.config.adaptive_compatible else {}
+            }
+        
+        def _fuse_modalities(self, quantized_list: List[torch.Tensor]) -> torch.Tensor:
+            """Fuse quantized representations from multiple modalities."""
+            
+            if self.config.fusion_strategy == "concat":
+                # Concatenate and project
+                concatenated = torch.cat(quantized_list, dim=-1)
+                if hasattr(self, 'fusion_projection'):
+                    return self.fusion_projection(concatenated)
+                else:
+                    return torch.mean(torch.stack(quantized_list), dim=0)
+                    
+            elif self.config.fusion_strategy == "add":
+                return torch.sum(torch.stack(quantized_list), dim=0)
+                
+            elif self.config.fusion_strategy == "attention":
+                stacked = torch.stack(quantized_list, dim=1)  # [batch, num_modalities, dim]
+                if hasattr(self, 'fusion_attention'):
+                    fused, _ = self.fusion_attention(stacked, stacked, stacked)
+                    return torch.mean(fused, dim=1)
+                else:
+                    return torch.mean(stacked, dim=1)
+            
+            else:
+                return torch.mean(torch.stack(quantized_list), dim=0)
+        
+        def _compute_metrics(self, inputs: torch.Tensor, quantized: torch.Tensor,
+                           indices: torch.Tensor, commitment_loss: torch.Tensor,
+                           codebook_loss: torch.Tensor, modality: str) -> Dict[str, Any]:
+            """Compute quantization metrics for a modality."""
+            
+            # Basic metrics
+            mse = F.mse_loss(inputs, quantized)
+            
+            # Codebook usage
+            unique_indices = len(torch.unique(indices))
+            codebook_usage = unique_indices / self.config.codebook_size
+            
+            # Perplexity
+            one_hot = F.one_hot(indices, self.config.codebook_size).float()
+            avg_probs = torch.mean(one_hot, dim=0)
+            perplexity = torch.exp(-torch.sum(avg_probs * torch.log(avg_probs + 1e-10)))
+            
+            return {
+                'modality': modality,
+                'commitment_loss': commitment_loss.item(),
+                'codebook_loss': codebook_loss.item(),
+                'mse': mse.item(),
+                'codebook_usage': codebook_usage.item(),
+                'perplexity': perplexity.item(),
+                'unique_codes': unique_indices
+            }
+        
+        def _compute_global_metrics(self, modal_results: Dict[str, Any]) -> Dict[str, Any]:
+            """Compute global metrics across all modalities."""
+            
+            if not modal_results:
+                return {'total_modalities': 0}
+            
+            total_commitment = 0.0
+            total_codebook = 0.0
+            total_mse = 0.0
+            total_usage = 0.0
+            total_perplexity = 0.0
+            
+            for result in modal_results.values():
+                metrics = result['metrics']
+                total_commitment += metrics['commitment_loss']
+                total_codebook += metrics['codebook_loss']
+                total_mse += metrics['mse']
+                total_usage += metrics['codebook_usage']
+                total_perplexity += metrics['perplexity']
+            
+            num_modalities = len(modal_results)
+            
+            return {
+                'total_modalities': num_modalities,
+                'avg_commitment_loss': total_commitment / num_modalities,
+                'avg_codebook_loss': total_codebook / num_modalities,
+                'avg_mse': total_mse / num_modalities,
+                'avg_codebook_usage': total_usage / num_modalities,
+                'avg_perplexity': total_perplexity / num_modalities,
+                'fusion_strategy': self.config.fusion_strategy
+            }
+        
+        def _get_cache_info(self) -> Dict[str, Any]:
+            """Get cache information for adaptive compatibility."""
+            return {
+                'cache_size_ratio': self.config.cache_size_ratio,
+                'tile_size': self.config.tile_size,
+                'prefetch_enabled': self.config.enable_prefetch,
+                'adaptive_compatible': self.config.adaptive_compatible
+            }
+
+else:
+    # Fallback implementation using NumPy
+    class VQbitModule:
+        """
+        Multimodal VQbit Module - NumPy fallback implementation.
+        """
+        
+        def __init__(self, config: Optional[MultimodalVQConfig] = None, **kwargs):
+            if config is None:
+                config_dict = {}
+                for key in ['codebook_size', 'embedding_dim', 'commitment_weight', 
+                           'modalities', 'shared_codebook', 'modal_adaptation',
+                           'fusion_strategy', 'adaptive_compatible', 'cache_size_ratio',
+                           'tile_size', 'enable_prefetch']:
+                    if key in kwargs:
+                        config_dict[key] = kwargs.pop(key)
+                config = MultimodalVQConfig(**config_dict)
+            self.config = config
+            
+            # Initialize codebooks
+            if self.config.shared_codebook:
+                self.codebook = np.random.randn(self.config.codebook_size, self.config.embedding_dim).astype(np.float32)
+            else:
+                self.codebooks = {}
+                for modality in self.config.modalities:
+                    self.codebooks[modality] = np.random.randn(
+                        self.config.codebook_size, self.config.embedding_dim
+                    ).astype(np.float32)
+        
+        def __call__(self, 
+                    inputs: Union[np.ndarray, Dict[str, np.ndarray]], 
+                    modality: Optional[str] = None,
+                    training: bool = True,
+                    **kwargs) -> Dict[str, Any]:
+            """Forward pass (simplified NumPy implementation)."""
+            
+            if isinstance(inputs, dict):
+                # Simple multimodal processing
+                results = {}
+                for mod, inp in inputs.items():
+                    if mod in self.config.modalities:
+                        results[mod] = self._process_single(inp, mod)
+                
+                # Simple fusion (average)
+                if results:
+                    all_quantized = [r['quantized'] for r in results.values()]
+                    fused = np.mean(np.stack(all_quantized), axis=0)
+                else:
+                    fused = np.zeros((1, self.config.embedding_dim))
+                
+                return {
+                    'quantized': fused,
+                    'modal_results': results,
+                    'metrics': {'total_modalities': len(results)},
+                    'cache_info': self._get_cache_info() if self.config.adaptive_compatible else {}
+                }
+            else:
+                if modality is None:
+                    modality = self.config.modalities[0]
+                return self._process_single(inputs, modality)
+        
+        def _process_single(self, inputs: np.ndarray, modality: str) -> Dict[str, Any]:
+            """Process single modality (simplified)."""
+            
+            # Get codebook
+            if self.config.shared_codebook:
+                codebook = self.codebook
+            else:
+                codebook = self.codebooks.get(modality, self.codebook if hasattr(self, 'codebook') else np.random.randn(self.config.codebook_size, self.config.embedding_dim))
+            
+            # Simple quantization
+            input_shape = inputs.shape
+            flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+            
+            distances = np.linalg.norm(
+                flat_inputs[:, None, :] - codebook[None, :, :],
+                axis=2
+            )
+            
+            indices = np.argmin(distances, axis=1)
+            quantized = codebook[indices].reshape(input_shape)
+            indices = indices.reshape(input_shape[:-1])
+            
+            # Basic metrics
+            unique_codes = len(np.unique(indices))
+            
+            return {
+                'quantized': quantized,
+                'indices': indices,
+                'metrics': {
+                    'modality': modality,
+                    'unique_codes': unique_codes,
+                    'codebook_usage': unique_codes / self.config.codebook_size
+                },
+                'cache_info': self._get_cache_info() if self.config.adaptive_compatible else {}
+            }
+        
+        def _get_cache_info(self) -> Dict[str, Any]:
+            """Get cache information for adaptive compatibility."""
+            return {
+                'cache_size_ratio': self.config.cache_size_ratio,
+                'tile_size': self.config.tile_size,
+                'prefetch_enabled': self.config.enable_prefetch,
+                'adaptive_compatible': self.config.adaptive_compatible
+            }
+
+
+# Factory functions
+def create_multimodal_vqbit(modalities: List[str] = None,
+                           codebook_size: int = 64,
+                           embedding_dim: int = 768,
+                           shared_codebook: bool = True,
+                           fusion_strategy: str = "concat",
+                           **kwargs) -> VQbitModule:
+    """
+    Create a multimodal VQbit module.
+    
+    Args:
+        modalities: List of supported modalities
+        codebook_size: Number of codebook entries
+        embedding_dim: Dimension of embeddings
+        shared_codebook: Whether to use shared codebook across modalities
+        fusion_strategy: Strategy for fusing modalities
+        **kwargs: Additional configuration
+        
+    Returns:
+        VQbitModule instance
+    """
+    if modalities is None:
+        modalities = ['text', 'image', 'audio']
+    
+    config = MultimodalVQConfig(
+        modalities=modalities,
+        codebook_size=codebook_size,
+        embedding_dim=embedding_dim,
+        shared_codebook=shared_codebook,
+        fusion_strategy=fusion_strategy,
+        **kwargs
+    )
+    
+    return VQbitModule(config)
+
+
+logger.info(f"Multimodal VQbit initialized - JAX: {JAX_AVAILABLE}, PyTorch: {TORCH_AVAILABLE}")
+
+def main():
+    # Main function for this module.
+    logger.info("Module multimodal_vqbit.py starting")
+    return True
+
+if __name__ == "__main__":
+    main()

--- a/capibara/vq/vqbit/vq_arm_axion.py
+++ b/capibara/vq/vqbit/vq_arm_axion.py
@@ -1,0 +1,210 @@
+"""
+CapibaraGPT v3.3 - Optimizaciones ARM Axion
+implementation optimizada for procesadores ARM Axion with 64 códigos VQ
+"""
+
+import os
+import logging
+import numpy as np
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, Tuple
+
+try:
+    import torch
+    import torch_arm
+    from torch_arm.sve import SVELinearFunction
+    from torch_arm.quantization import QuantizedLinear
+    ARM_AXION_AVAILABLE = True
+except ImportError:
+    ARM_AXION_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class ARMAxionConfig:
+    """setup for optimizaciones ARM Axion."""
+    
+    # VQ settings
+    embedding_dim: int = 4096
+    num_codes: int = 64  # Optimizado for ARM
+    
+    # SVE2 settings
+    enable_sve2: bool = True
+    sve_vector_bits: int = 512
+    
+    # Quantization
+    enable_quantization: bool = True
+    quantization_bits: int = 8
+    quantization_scheme: str = "symmetric"
+    
+    # Memory settings
+    max_batch_size: int = 32
+    enable_memory_opt: bool = True
+    chunk_size: int = 4096
+    
+    # Performance
+    num_threads: int = 8
+    enable_kleidi: bool = True
+    enable_cache: bool = True
+
+class ARMAxionOptimizer:
+    """Optimizador específico for ARM Axion."""
+    
+    def __init__(self, config: Optional[ARMAxionConfig] = None):
+        self.config = config or ARMAxionConfig()
+        self._initialize_arm_optimizations()
+        
+    def _initialize_arm_optimizations(self):
+        """Inicializar optimizaciones ARM."""
+        if not ARM_AXION_AVAILABLE:
+            logger.warning(" ARM Axion optimizations not available")
+            return
+            
+        try:
+            # configure SVE2
+            if self.config.enable_sve2:
+                torch_arm.config.set_vector_bits(self.config.sve_vector_bits)
+                logger.info(f" SVE2 enabled with {self.config.sve_vector_bits} bits")
+            
+            # configure threads
+            torch_arm.config.set_num_threads(self.config.num_threads)
+            
+            # Inicializar Kleidi if está available
+            if self.config.enable_kleidi:
+                try:
+                    from capibara.core.kleidi import KleidiOptimizer
+                except Exception as e:
+                    self.config.enable_kleidi = False
+                    logger.warning(" Kleidi optimization unavailable: %s", e)
+                else:
+                    self.kleidi = KleidiOptimizer()
+                    logger.info(" Kleidi optimization enabled")
+            
+            logger.info(" ARM Axion optimizations initialized")
+            
+        except Exception as e:
+            logger.error(f" Error initializing ARM optimizations: {e}")
+    
+    def optimize_linear(self, layer: torch.nn.Linear) -> torch.nn.Module:
+        """optimize capa lineal for ARM."""
+        if not ARM_AXION_AVAILABLE:
+            return layer
+            
+        try:
+            # apply SVE2
+            if self.config.enable_sve2:
+                layer = SVELinearFunction.apply(layer)
+            
+            # apply cuantización
+            if self.config.enable_quantization:
+                layer = QuantizedLinear(
+                    layer,
+                    bits=self.config.quantization_bits,
+                    scheme=self.config.quantization_scheme
+                )
+            
+            return layer
+            
+        except Exception as e:
+            logger.warning(f"Failed to optimize linear layer: {e}")
+            return layer
+    
+    def optimize_attention(self, query: torch.Tensor, key: torch.Tensor, 
+                         value: torch.Tensor) -> torch.Tensor:
+        """optimize atención for ARM."""
+        if not ARM_AXION_AVAILABLE:
+            return torch.matmul(
+                torch.softmax(torch.matmul(query, key.transpose(-2, -1)), dim=-1),
+                value
+            )
+        
+        try:
+            # use Kleidi if está available
+            if self.config.enable_kleidi and hasattr(self, 'kleidi'):
+                return self.kleidi.optimized_attention(query, key, value)
+            
+            # implementation optimizada manual
+            scores = torch_arm.matmul(query, key.transpose(-2, -1))
+            scores = scores / np.sqrt(query.size(-1))
+            
+            # optimize softmax
+            if self.config.enable_memory_opt:
+                # process en chunks for ahorrar memory
+                chunks = torch.chunk(scores, self.config.chunk_size, dim=-1)
+                weights = [torch_arm.softmax(chunk, dim=-1) for chunk in chunks]
+                weights = torch.cat(weights, dim=-1)
+            else:
+                weights = torch_arm.softmax(scores, dim=-1)
+            
+            return torch_arm.matmul(weights, value)
+            
+        except Exception as e:
+            logger.warning(f"Failed to optimize attention: {e}")
+            return torch.matmul(
+                torch.softmax(torch.matmul(query, key.transpose(-2, -1)), dim=-1),
+                value
+            )
+    
+    def optimize_vq_forward(self, x: torch.Tensor, codebook: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass optimizado for VQ."""
+        if not ARM_AXION_AVAILABLE:
+            return self._vq_forward_cpu(x, codebook)
+        
+        try:
+            # Reshape input
+            flat_x = x.reshape(-1, x.size(-1))
+            
+            # calculate distancias usando SVE2
+            distances = -torch_arm.cdist(flat_x, codebook)
+            
+            # find códigos more cercanos
+            encoding_indices = torch_arm.argmax(distances, dim=1)
+            
+            # Cuantizar
+            quantized = torch.index_select(codebook, 0, encoding_indices)
+            quantized = quantized.view_as(x)
+            
+            return quantized, encoding_indices
+            
+        except Exception as e:
+            logger.warning(f"Failed to optimize VQ forward: {e}")
+            return self._vq_forward_cpu(x, codebook)
+    
+    def _vq_forward_cpu(self, x: torch.Tensor, codebook: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """implementation cpu fallback for VQ."""
+        flat_x = x.reshape(-1, x.size(-1))
+        distances = torch.cdist(flat_x, codebook)
+        encoding_indices = torch.argmin(distances, dim=1)
+        quantized = torch.index_select(codebook, 0, encoding_indices)
+        return quantized.view_as(x), encoding_indices
+    
+    def get_performance_metrics(self) -> Dict[str, Any]:
+        """obtain métricas de rendimiento."""
+        metrics = {
+            "arm_axion_available": ARM_AXION_AVAILABLE,
+            "sve2_enabled": self.config.enable_sve2 if ARM_AXION_AVAILABLE else False,
+            "quantization_enabled": self.config.enable_quantization if ARM_AXION_AVAILABLE else False,
+            "kleidi_enabled": hasattr(self, 'kleidi') if ARM_AXION_AVAILABLE else False,
+            "num_threads": self.config.num_threads if ARM_AXION_AVAILABLE else 1
+        }
+        
+        if ARM_AXION_AVAILABLE:
+            try:
+                import psutil
+                metrics.update({
+                    "cpu_usage": psutil.cpu_percent(interval=1),
+                    "memory_usage": psutil.Process().memory_info().rss / 1024**2,  # MB
+                    "threads_active": psutil.Process().num_threads()
+                })
+            except:
+                pass
+        
+        return metrics
+
+def create_arm_axion_optimizer(config: Optional[ARMAxionConfig] = None) -> ARMAxionOptimizer:
+    """create optimizador ARM Axion."""
+    return ARMAxionOptimizer(config) 
+
+
+# Backwards-compatible alias expected by vqbit __init__
+ARMAxionVQOptimizer = ARMAxionOptimizer

--- a/capibara/vq/vqbit/vq_monitoring.py
+++ b/capibara/vq/vqbit/vq_monitoring.py
@@ -1,0 +1,774 @@
+"""
+VQ Monitoring Module for Capibara-6
+
+Comprehensive monitoring and analytics for VQ systems:
+- Real-time performance tracking
+- Resource utilization monitoring
+- Codebook health analysis
+- Adaptation decision logging
+- Performance regression detection
+- Integration with observability systems
+"""
+
+import logging
+import time
+import json
+import threading
+from typing import Any, Dict, List, Optional, Tuple, Union, Callable
+from dataclasses import dataclass, field, asdict
+from collections import deque, defaultdict
+from pathlib import Path
+import statistics
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class MonitoringConfig:
+    """Configurestion for VQ monitoring."""
+    # Monitoring settings
+    enable_real_time_monitoring: bool = True
+    metrics_collection_interval: float = 1.0  # seconds
+    performance_window_size: int = 100
+    
+    # Storage settings
+    enable_persistent_logging: bool = True
+    log_directory: str = "./vq_monitoring_logs"
+    max_log_files: int = 10
+    log_rotation_size_mb: float = 50.0
+    
+    # Alert settings
+    enable_alerts: bool = True
+    performance_threshold: float = 0.8
+    memory_threshold: float = 0.9
+    latency_threshold_ms: float = 100.0
+    
+    # Analysis settings
+    enable_trend_analysis: bool = True
+    trend_analysis_window: int = 1000
+    anomaly_detection_sensitivity: float = 2.0  # Standard deviations
+    
+    # Integration settings
+    enable_prometheus_export: bool = False
+    prometheus_port: int = 8090
+    enable_tensorboard_logging: bool = False
+    tensorboard_log_dir: str = "./vq_tensorboard_logs"
+
+
+class MetricsCollector:
+    """Collect and aggregate VQ metrics."""
+    
+    def __init__(self, config: MonitoringConfig):
+        self.config = config
+        self.metrics_buffer = deque(maxlen=config.performance_window_size)
+        self.lock = threading.Lock()
+        self.start_time = time.time()
+        
+        # Aggregated statistics
+        self.aggregated_stats = defaultdict(list)
+        self.performance_trends = {}
+        
+    def record_metrics(self, metrics: Dict[str, Any], source: str = "unknown"):
+        """Record metrics from a VQ operation."""
+        
+        timestamp = time.time()
+        
+        # Create metrics entry
+        metrics_entry = {
+            'timestamp': timestamp,
+            'source': source,
+            'metrics': metrics.copy(),
+            'elapsed_since_start': timestamp - self.start_time
+        }
+        
+        with self.lock:
+            self.metrics_buffer.append(metrics_entry)
+            
+            # Update aggregated statistics
+            for key, value in metrics.items():
+                if isinstance(value, (int, float)):
+                    self.aggregated_stats[key].append(value)
+                    
+                    # Keep only recent values
+                    if len(self.aggregated_stats[key]) > self.config.performance_window_size:
+                        self.aggregated_stats[key].pop(0)
+    
+    def get_current_stats(self) -> Dict[str, Any]:
+        """Get current aggregated statistics."""
+        
+        with self.lock:
+            if not self.metrics_buffer:
+                return {'status': 'no_data'}
+            
+            stats = {
+                'total_samples': len(self.metrics_buffer),
+                'time_range': {
+                    'start': self.metrics_buffer[0]['timestamp'],
+                    'end': self.metrics_buffer[-1]['timestamp'],
+                    'duration_seconds': self.metrics_buffer[-1]['timestamp'] - self.metrics_buffer[0]['timestamp']
+                },
+                'metrics_summary': {}
+            }
+            
+            # Compute summary statistics for each metric
+            for metric_name, values in self.aggregated_stats.items():
+                if values:
+                    stats['metrics_summary'][metric_name] = {
+                        'mean': statistics.mean(values),
+                        'median': statistics.median(values),
+                        'std': statistics.stdev(values) if len(values) > 1 else 0.0,
+                        'min': min(values),
+                        'max': max(values),
+                        'count': len(values)
+                    }
+            
+            return stats
+    
+    def get_recent_metrics(self, count: int = 10) -> List[Dict[str, Any]]:
+        """Get recent metrics entries."""
+        
+        with self.lock:
+            return list(self.metrics_buffer)[-count:]
+    
+    def detect_anomalies(self) -> List[Dict[str, Any]]:
+        """Detect performance anomalies."""
+        
+        anomalies = []
+        
+        with self.lock:
+            for metric_name, values in self.aggregated_stats.items():
+                if len(values) < 10:  # Need sufficient data
+                    continue
+                
+                mean_val = statistics.mean(values)
+                std_val = statistics.stdev(values) if len(values) > 1 else 0.0
+                
+                if std_val == 0:
+                    continue
+                
+                # Check recent values for anomalies
+                recent_values = values[-10:]
+                for i, value in enumerate(recent_values):
+                    z_score = abs(value - mean_val) / std_val
+                    
+                    if z_score > self.config.anomaly_detection_sensitivity:
+                        anomalies.append({
+                            'metric': metric_name,
+                            'value': value,
+                            'expected_range': (mean_val - 2*std_val, mean_val + 2*std_val),
+                            'z_score': z_score,
+                            'timestamp': time.time() - (len(recent_values) - i),
+                            'severity': 'high' if z_score > 3.0 else 'medium'
+                        })
+        
+        return anomalies
+
+
+class PerformanceAnalyzer:
+    """Analyze VQ performance trends and patterns."""
+    
+    def __init__(self, config: MonitoringConfig):
+        self.config = config
+        self.analysis_history = deque(maxlen=config.trend_analysis_window)
+        
+    def analyze_performance_trend(self, metrics_collector: MetricsCollector) -> Dict[str, Any]:
+        """Analyze performance trends."""
+        
+        stats = metrics_collector.get_current_stats()
+        
+        if 'metrics_summary' not in stats:
+            return {'status': 'insufficient_data'}
+        
+        trends = {}
+        
+        # Analyze each metric
+        for metric_name, summary in stats['metrics_summary'].items():
+            if summary['count'] < 20:  # Need sufficient data
+                continue
+            
+            # Get recent vs older values
+            values = metrics_collector.aggregated_stats[metric_name]
+            if len(values) < 20:
+                continue
+            
+            recent_mean = statistics.mean(values[-10:])
+            older_mean = statistics.mean(values[-20:-10])
+            
+            # Determine trend
+            if recent_mean > older_mean * 1.05:
+                trend = "improving"
+            elif recent_mean < older_mean * 0.95:
+                trend = "degrading"
+            else:
+                trend = "stable"
+            
+            # Calculate trend strength
+            trend_strength = abs(recent_mean - older_mean) / older_mean if older_mean != 0 else 0
+            
+            trends[metric_name] = {
+                'trend': trend,
+                'strength': trend_strength,
+                'recent_mean': recent_mean,
+                'older_mean': older_mean,
+                'change_percent': ((recent_mean - older_mean) / older_mean * 100) if older_mean != 0 else 0
+            }
+        
+        return {
+            'timestamp': time.time(),
+            'trends': trends,
+            'overall_health': self._compute_overall_health(trends),
+            'recommendations': self._generate_recommendations(trends)
+        }
+    
+    def _compute_overall_health(self, trends: Dict[str, Any]) -> Dict[str, Any]:
+        """Compute overall system health score."""
+        
+        if not trends:
+            return {'score': 0.0, 'status': 'unknown'}
+        
+        # Weight different metrics
+        metric_weights = {
+            'mse': 0.3,
+            'codebook_usage': 0.2,
+            'perplexity': 0.2,
+            'commitment_loss': 0.15,
+            'codebook_loss': 0.15
+        }
+        
+        health_score = 0.0
+        total_weight = 0.0
+        
+        for metric_name, trend_info in trends.items():
+            weight = metric_weights.get(metric_name, 0.1)
+            
+            # Score based on trend
+            if trend_info['trend'] == 'improving':
+                metric_score = 1.0
+            elif trend_info['trend'] == 'stable':
+                metric_score = 0.8
+            else:  # degrading
+                metric_score = 0.4
+            
+            # Adjust by trend strength
+            metric_score *= (1.0 - min(0.5, trend_info['strength']))
+            
+            health_score += metric_score * weight
+            total_weight += weight
+        
+        final_score = health_score / total_weight if total_weight > 0 else 0.0
+        
+        # Determine status
+        if final_score > 0.8:
+            status = 'excellent'
+        elif final_score > 0.6:
+            status = 'good'
+        elif final_score > 0.4:
+            status = 'fair'
+        else:
+            status = 'poor'
+        
+        return {
+            'score': final_score,
+            'status': status,
+            'contributing_metrics': len(trends)
+        }
+    
+    def _generate_recommendations(self, trends: Dict[str, Any]) -> List[str]:
+        """Generates optimization recommendations based on trends."""
+        
+        recommendations = []
+        
+        for metric_name, trend_info in trends.items():
+            if trend_info['trend'] == 'degrading' and trend_info['strength'] > 0.1:
+                
+                if metric_name == 'mse' and trend_info['change_percent'] > 10:
+                    recommendations.append(
+                        f"MSE increasing ({trend_info['change_percent']:.1f}%) - consider increasing codebook size or adjusting learning rate"
+                    )
+                
+                elif metric_name == 'codebook_usage' and trend_info['recent_mean'] < 0.5:
+                    recommendations.append(
+                        f"Low codebook usage ({trend_info['recent_mean']:.2f}) - consider reducing codebook size"
+                    )
+                
+                elif metric_name == 'perplexity' and trend_info['change_percent'] < -20:
+                    recommendations.append(
+                        f"Perplexity decreasing significantly - codebook may be underutilized"
+                    )
+                
+                elif metric_name in ['commitment_loss', 'codebook_loss'] and trend_info['change_percent'] > 20:
+                    recommendations.append(
+                        f"{metric_name} increasing - check training stability and learning rates"
+                    )
+        
+        # General recommendations
+        if not recommendations:
+            recommendations.append("Performance is stable - no immediate optimizations needed")
+        
+        return recommendations
+
+
+class VQMonitor:
+    """
+    Comprehensive VQ monitoring system.
+    
+    Features:
+    - Real-time metrics collection
+    - Performance trend analysis
+    - Anomaly detection
+    - Resource monitoring
+    - Automated alerting
+    """
+    
+    def __init__(self, config: Optional[MonitoringConfig] = None):
+        if config is None:
+            config = MonitoringConfig()
+        self.config = config
+        
+        # Core components
+        self.metrics_collector = MetricsCollector(config)
+        self.performance_analyzer = PerformanceAnalyzer(config)
+        
+        # Monitoring state
+        self.monitoring_active = False
+        self.monitoring_thread = None
+        self.alert_callbacks = []
+        
+        # Logging setup
+        if config.enable_persistent_logging:
+            self.log_directory = Path(config.log_directory)
+            self.log_directory.mkdir(exist_ok=True)
+            self.current_log_file = None
+            self._setup_logging()
+        
+        logger.info("VQ Monitor initialized")
+    
+    def start_monitoring(self):
+        """Start real-time monitoring."""
+        
+        if self.monitoring_active:
+            logger.warning("Monitoring already active")
+            return
+        
+        self.monitoring_active = True
+        
+        if self.config.enable_real_time_monitoring:
+            self.monitoring_thread = threading.Thread(
+                target=self._monitoring_loop,
+                daemon=True
+            )
+            self.monitoring_thread.start()
+            logger.info("Real-time monitoring started")
+    
+    def stop_monitoring(self):
+        """Stop real-time monitoring."""
+        
+        self.monitoring_active = False
+        
+        if self.monitoring_thread:
+            self.monitoring_thread.join(timeout=5.0)
+            self.monitoring_thread = None
+        
+        logger.info("Monitoring stopped")
+    
+    def record_vq_operation(self, 
+                           vq_instance: Any,
+                           inputs: Any,
+                           outputs: Tuple[Any, Any, Dict[str, Any]],
+                           operation_time: float,
+                           memory_usage: Optional[float] = None):
+        """
+        Record a VQ operation for monitoring.
+        
+        Args:
+            vq_instance: VQ instance that performed the operation
+            inputs: Input data
+            outputs: VQ outputs (quantized, indices, metrics)
+            operation_time: Time taken for operation
+            memory_usage: Memory usage in MB
+        """
+        
+        quantized, indices, vq_metrics = outputs
+        
+        # Enhance metrics with monitoring information
+        enhanced_metrics = vq_metrics.copy()
+        enhanced_metrics.update({
+            'operation_time_ms': operation_time * 1000,
+            'memory_usage_mb': memory_usage,
+            'input_shape': getattr(inputs, 'shape', None),
+            'output_shape': getattr(quantized, 'shape', None),
+            'vq_type': type(vq_instance).__name__,
+            'timestamp': time.time()
+        })
+        
+        # Record metrics
+        self.metrics_collector.record_metrics(enhanced_metrics, source=type(vq_instance).__name__)
+        
+        # Check for alerts
+        if self.config.enable_alerts:
+            self._check_alerts(enhanced_metrics)
+        
+        # Log to file if enabled
+        if self.config.enable_persistent_logging:
+            self._log_to_file(enhanced_metrics)
+    
+    def get_monitoring_report(self) -> Dict[str, Any]:
+        """Generates comprehensive monitoring report."""
+        
+        # Get current statistics
+        current_stats = self.metrics_collector.get_current_stats()
+        
+        # Perform trend analysis
+        trend_analysis = self.performance_analyzer.analyze_performance_trend(self.metrics_collector)
+        
+        # Detect anomalies
+        anomalies = self.metrics_collector.detect_anomalies()
+        
+        # Resource utilization
+        resource_stats = self._get_resource_stats()
+        
+        report = {
+            'report_timestamp': time.time(),
+            'monitoring_duration_hours': (time.time() - self.start_time) / 3600,
+            'current_statistics': current_stats,
+            'trend_analysis': trend_analysis,
+            'anomalies': anomalies,
+            'resource_utilization': resource_stats,
+            'system_health': trend_analysis.get('overall_health', {}),
+            'recommendations': trend_analysis.get('recommendations', []),
+            'alert_summary': self._get_alert_summary()
+        }
+        
+        return report
+    
+    def get_performance_dashboard(self) -> Dict[str, Any]:
+        """Get data for performance dashboard."""
+        
+        recent_metrics = self.metrics_collector.get_recent_metrics(50)
+        
+        if not recent_metrics:
+            return {'status': 'no_data'}
+        
+        # Extract time series data
+        time_series = {}
+        for entry in recent_metrics:
+            timestamp = entry['timestamp']
+            for metric_name, value in entry['metrics'].items():
+                if isinstance(value, (int, float)):
+                    if metric_name not in time_series:
+                        time_series[metric_name] = {'timestamps': [], 'values': []}
+                    time_series[metric_name]['timestamps'].append(timestamp)
+                    time_series[metric_name]['values'].append(value)
+        
+        # Current status
+        latest_entry = recent_metrics[-1]
+        current_status = {
+            'timestamp': latest_entry['timestamp'],
+            'vq_type': latest_entry['source'],
+            'key_metrics': {
+                'mse': latest_entry['metrics'].get('mse', 0),
+                'codebook_usage': latest_entry['metrics'].get('codebook_usage', 0),
+                'perplexity': latest_entry['metrics'].get('perplexity', 0),
+                'operation_time_ms': latest_entry['metrics'].get('operation_time_ms', 0)
+            }
+        }
+        
+        return {
+            'current_status': current_status,
+            'time_series': time_series,
+            'monitoring_active': self.monitoring_active,
+            'total_operations': len(recent_metrics)
+        }
+    
+    def _monitoring_loop(self):
+        """Main monitoring loop for real-time analysis."""
+        
+        while self.monitoring_active:
+            try:
+                # Perform periodic analysis
+                if len(self.metrics_collector.metrics_buffer) > 10:
+                    # Check for performance regressions
+                    self._check_performance_regression()
+                    
+                    # Update trend analysis
+                    if self.config.enable_trend_analysis:
+                        self.performance_analyzer.analyze_performance_trend(self.metrics_collector)
+                
+                time.sleep(self.config.metrics_collection_interval)
+                
+            except Exception as e:
+                logger.error(f"Error in monitoring loop: {e}")
+                time.sleep(5.0)  # Wait before retrying
+    
+    def _check_alerts(self, metrics: Dict[str, Any]):
+        """Check if any alerts should be triggered."""
+        
+        alerts = []
+        
+        # Performance alerts
+        if 'mse' in metrics and metrics['mse'] > 1.0:  # High reconstruction error
+            alerts.append({
+                'type': 'performance',
+                'severity': 'warning',
+                'message': f"High MSE detected: {metrics['mse']:.4f}",
+                'metric': 'mse',
+                'value': metrics['mse']
+            })
+        
+        # Memory alerts
+        if 'memory_usage_mb' in metrics and metrics['memory_usage_mb']:
+            if metrics['memory_usage_mb'] > self.config.memory_threshold * 1000:  # Convert to MB
+                alerts.append({
+                    'type': 'resource',
+                    'severity': 'critical',
+                    'message': f"High memory usage: {metrics['memory_usage_mb']:.1f}MB",
+                    'metric': 'memory_usage_mb',
+                    'value': metrics['memory_usage_mb']
+                })
+        
+        # Latency alerts
+        if 'operation_time_ms' in metrics:
+            if metrics['operation_time_ms'] > self.config.latency_threshold_ms:
+                alerts.append({
+                    'type': 'performance',
+                    'severity': 'warning',
+                    'message': f"High latency: {metrics['operation_time_ms']:.1f}ms",
+                    'metric': 'operation_time_ms',
+                    'value': metrics['operation_time_ms']
+                })
+        
+        # Codebook utilization alerts
+        if 'codebook_usage' in metrics:
+            usage = metrics['codebook_usage']
+            if usage < 0.1:
+                alerts.append({
+                    'type': 'efficiency',
+                    'severity': 'info',
+                    'message': f"Low codebook utilization: {usage:.1%}",
+                    'metric': 'codebook_usage',
+                    'value': usage
+                })
+            elif usage > 0.95:
+                alerts.append({
+                    'type': 'capacity',
+                    'severity': 'warning',
+                    'message': f"High codebook utilization: {usage:.1%} - consider increasing size",
+                    'metric': 'codebook_usage',
+                    'value': usage
+                })
+        
+        # Trigger alert callbacks
+        for alert in alerts:
+            self._trigger_alert(alert)
+    
+    def _trigger_alert(self, alert: Dict[str, Any]):
+        """Trigger alert callbacks."""
+        
+        alert['timestamp'] = time.time()
+        
+        # Log alert
+        severity_emoji = {
+            'info': '️',
+            'warning': '️',
+            'critical': ''
+        }
+        
+        emoji = severity_emoji.get(alert['severity'], '')
+        logger.warning(f"{emoji} VQ Alert [{alert['severity'].upper()}]: {alert['message']}")
+        
+        # Call registered callbacks
+        for callback in self.alert_callbacks:
+            try:
+                callback(alert)
+            except Exception as e:
+                logger.error(f"Error in alert callback: {e}")
+    
+    def _check_performance_regression(self):
+        """Check for performance regressions."""
+        
+        # Simple regression detection based on recent vs historical performance
+        recent_metrics = self.metrics_collector.get_recent_metrics(20)
+        
+        if len(recent_metrics) < 20:
+            return
+        
+        # Check MSE trend
+        recent_mse = [m['metrics'].get('mse', 0) for m in recent_metrics[-10:]]
+        older_mse = [m['metrics'].get('mse', 0) for m in recent_metrics[-20:-10]]
+        
+        if recent_mse and older_mse:
+            recent_avg = statistics.mean(recent_mse)
+            older_avg = statistics.mean(older_mse)
+            
+            # Significant regression
+            if recent_avg > older_avg * 1.2:
+                self._trigger_alert({
+                    'type': 'regression',
+                    'severity': 'warning',
+                    'message': f"Performance regression detected: MSE increased {((recent_avg/older_avg - 1) * 100):.1f}%",
+                    'metric': 'mse_regression',
+                    'value': recent_avg / older_avg
+                })
+    
+    def _get_resource_stats(self) -> Dict[str, Any]:
+        """Get current resource utilization statistics."""
+        
+        try:
+            import psutil
+            
+            # Memory usage
+            memory = psutil.virtual_memory()
+            
+            # CPU usage
+            cpu_percent = psutil.cpu_percent(interval=1)
+            
+            return {
+                'memory': {
+                    'total_gb': memory.total / (1024**3),
+                    'available_gb': memory.available / (1024**3),
+                    'used_percent': memory.percent
+                },
+                'cpu': {
+                    'usage_percent': cpu_percent,
+                    'count': psutil.cpu_count()
+                },
+                'timestamp': time.time()
+            }
+        
+        except ImportError:
+            return {
+                'status': 'psutil_not_available',
+                'timestamp': time.time()
+            }
+    
+    def _setup_logging(self):
+        """Setup persistent logging."""
+        
+        log_filename = f"vq_monitoring_{int(time.time())}.jsonl"
+        self.current_log_file = self.log_directory / log_filename
+        
+        logger.info(f"VQ monitoring logs: {self.current_log_file}")
+    
+    def _log_to_file(self, metrics: Dict[str, Any]):
+        """Log metrics to file."""
+        
+        if not self.current_log_file:
+            return
+        
+        try:
+            log_entry = {
+                'timestamp': time.time(),
+                'metrics': metrics
+            }
+            
+            with open(self.current_log_file, 'a') as f:
+                f.write(json.dumps(log_entry) + '\n')
+                
+        except Exception as e:
+            logger.error(f"Error logging to file: {e}")
+    
+    def _get_alert_summary(self) -> Dict[str, Any]:
+        """Get summary of recent alerts."""
+        
+        # This would typically integrate with an alerting system
+        return {
+            'total_alerts_today': 0,
+            'critical_alerts': 0,
+            'warning_alerts': 0,
+            'info_alerts': 0,
+            'last_alert_time': None
+        }
+    
+    def add_alert_callback(self, callback: Callable[[Dict[str, Any]], None]):
+        """Add callback for alert notifications."""
+        self.alert_callbacks.append(callback)
+    
+    def export_metrics(self, format: str = "json") -> Union[str, Dict[str, Any]]:
+        """Export collected metrics in specified format."""
+        
+        report = self.get_monitoring_report()
+        
+        if format == "json":
+            return json.dumps(report, indent=2, default=str)
+        elif format == "dict":
+            return report
+        else:
+            raise ValueError(f"Unsupported export format: {format}")
+
+
+# Factory functions
+def create_vq_monitor(enable_real_time: bool = True,
+                     enable_logging: bool = True,
+                     enable_alerts: bool = True,
+                     **kwargs) -> VQMonitor:
+    """
+    Create a VQ monitor with specified configuration.
+    
+    Args:
+        enable_real_time: Enable real-time monitoring
+        enable_logging: Enable persistent logging
+        enable_alerts: Enable alerting
+        **kwargs: Additional configuration
+        
+    Returns:
+        VQMonitor instance
+    """
+    
+    config = MonitoringConfig(
+        enable_real_time_monitoring=enable_real_time,
+        enable_persistent_logging=enable_logging,
+        enable_alerts=enable_alerts,
+        **kwargs
+    )
+    
+    return VQMonitor(config)
+
+
+def create_production_monitor() -> VQMonitor:
+    """Creates production-ready VQ monitor with optimized settings."""
+    
+    config = MonitoringConfig(
+        enable_real_time_monitoring=True,
+        enable_persistent_logging=True,
+        enable_alerts=True,
+        performance_threshold=0.9,
+        memory_threshold=0.8,
+        latency_threshold_ms=50.0,
+        metrics_collection_interval=0.5,
+        enable_trend_analysis=True,
+        anomaly_detection_sensitivity=2.5
+    )
+    
+    return VQMonitor(config)
+
+
+# Global monitor instance
+_global_monitor = None
+
+def get_global_monitor() -> Optional[VQMonitor]:
+    """Get global VQ monitor instance."""
+    return _global_monitor
+
+def set_global_monitor(monitor: VQMonitor):
+    """Set global VQ monitor instance."""
+    global _global_monitor
+    _global_monitor = monitor
+
+def monitor_vq_operation(vq_instance: Any, 
+                        inputs: Any, 
+                        outputs: Tuple[Any, Any, Dict[str, Any]],
+                        operation_time: float):
+    """Convenience function to monitor VQ operation using global monitor."""
+    
+    if _global_monitor:
+        _global_monitor.record_vq_operation(vq_instance, inputs, outputs, operation_time)
+
+
+logger.info("VQ Monitoring system initialized")
+
+def main():
+    # Main function for this module.
+    logger.info("Module vq_monitoring.py starting")
+    return True
+
+if __name__ == "__main__":
+    main()

--- a/capibara/vq/vqbit/vq_v33_tpu_v6.py
+++ b/capibara/vq/vqbit/vq_v33_tpu_v6.py
@@ -1,0 +1,722 @@
+"""
+VQ v3.3 TPU v6e-64 Optimized Implementation for Capibara-6
+
+Advanced Vector Quantization implementation specifically optimized for TPU v6e-64:
+- BF16 precision for optimal TPU performance
+- Mesh sharding for 8x8 TPU pod utilization
+- Product quantization for memory efficiency
+- Advanced codebook management with EMA updates
+- Integration with Dynamic MoE and Adaptive systems
+- Real-time performance monitoring and optimization
+"""
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple, Union, Callable
+from dataclasses import dataclass, field
+from functools import partial
+
+import numpy as np
+
+# JAX/Flax for TPU v6e
+try:
+    import jax
+    import jax.numpy as jnp
+    import flax.linen as nn
+    from flax import struct
+    from flax.training import train_state
+    from jax import random, pmap, pjit
+    from jax.sharding import Mesh, PartitionSpec as P
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+    raise ImportError("JAX/Flax not available; TPU v6e VQ requires JAX/Flax.")
+
+# Import VQ systems
+try:
+    from ..enhanced_vq_system_v2 import EnhancedVQConfig
+    ENHANCED_VQ_AVAILABLE = True
+except ImportError:
+    ENHANCED_VQ_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TPUv6eVQConfig:
+    """Configurestion for TPU v6e-64 optimized VQ."""
+    
+    # Core VQ parameters optimized for TPU v6e
+    num_embeddings: int = 16384  # Optimized for TPU memory
+    embedding_dim: int = 2048    # BF16-friendly dimension
+    commitment_cost: float = 0.25
+    
+    # TPU v6e specific settings
+    use_bfloat16: bool = True
+    mesh_shape: Tuple[int, int] = (8, 8)  # TPU v6e-64 pod
+    
+    # Product quantization for memory efficiency
+    use_product_quantization: bool = True
+    num_subspaces: int = 16
+    subspace_dim: int = 128  # embedding_dim // num_subspaces
+    
+    # EMA updates optimized for TPU
+    use_ema: bool = True
+    ema_decay: float = 0.999
+    ema_epsilon: float = 1e-5
+    
+    # Advanced features
+    use_entropy_regularization: bool = True
+    entropy_weight: float = 0.01
+    use_diversity_loss: bool = True
+    diversity_weight: float = 0.1
+    
+    # TPU compilation settings
+    enable_jit: bool = True
+    enable_pjit: bool = True
+    enable_gradient_checkpointing: bool = True
+    
+    # Performance monitoring
+    enable_performance_monitoring: bool = True
+    log_frequency: int = 100
+    
+    # Integration settings
+    enable_moe_integration: bool = True
+    enable_adaptive_integration: bool = True
+
+
+class TPUv6eVectorQuantizer(nn.Module):
+    """
+    TPU v6e-64 optimized Vector Quantizer with advanced features.
+    
+    Features:
+    - BF16 precision for optimal TPU performance
+    - Product quantization for memory efficiency
+    - Mesh sharding for distributed computation
+    - EMA updates with TPU-optimized implementation
+    - Integration with MoE and Adaptive systems
+    """
+    
+    config: TPUv6eVQConfig
+    
+    def setup(self):
+        """Initialize VQ components."""
+        
+        if self.config.use_product_quantization:
+            # Product quantization setup
+            self.num_subspaces = self.config.num_subspaces
+            self.subspace_dim = self.config.embedding_dim // self.num_subspaces
+            
+            # Create codebooks for each subspace
+            self.codebooks = []
+            for i in range(self.num_subspaces):
+                codebook = self.param(
+                    f'codebook_{i}',
+                    nn.initializers.variance_scaling(
+                        scale=1.0, mode='fan_in', distribution='uniform'
+                    ),
+                    (self.config.num_embeddings, self.subspace_dim),
+                    jnp.bfloat16 if self.config.use_bfloat16 else jnp.float32
+                )
+                self.codebooks.append(codebook)
+        else:
+            # Standard VQ codebook
+            self.codebook = self.param(
+                'codebook',
+                nn.initializers.variance_scaling(
+                    scale=1.0, mode='fan_in', distribution='uniform'
+                ),
+                (self.config.num_embeddings, self.config.embedding_dim),
+                jnp.bfloat16 if self.config.use_bfloat16 else jnp.float32
+            )
+            
+        # EMA variables for codebook updates
+        if self.config.use_ema:
+            if self.config.use_product_quantization:
+                self.ema_cluster_sizes = []
+                self.ema_embeddings = []
+                for i in range(self.num_subspaces):
+                    ema_cluster_size = self.variable(
+                        'ema_stats', f'cluster_size_{i}',
+                        lambda: jnp.zeros(self.config.num_embeddings, dtype=jnp.float32)
+                    )
+                    ema_embedding = self.variable(
+                        'ema_stats', f'embedding_{i}',
+                        lambda: jnp.zeros(
+                            (self.config.num_embeddings, self.subspace_dim),
+                            dtype=jnp.float32
+                        )
+                    )
+                    self.ema_cluster_sizes.append(ema_cluster_size)
+                    self.ema_embeddings.append(ema_embedding)
+            else:
+                self.ema_cluster_size = self.variable(
+                    'ema_stats', 'cluster_size',
+                    lambda: jnp.zeros(self.config.num_embeddings, dtype=jnp.float32)
+                )
+                self.ema_embedding = self.variable(
+                    'ema_stats', 'embedding',
+                    lambda: jnp.zeros(
+                        (self.config.num_embeddings, self.config.embedding_dim),
+                        dtype=jnp.float32
+                    )
+                )
+    
+    def __call__(self, inputs: jnp.ndarray, training: bool = True) -> Dict[str, jnp.ndarray]:
+        """
+        Forward pass of TPU v6e optimized VQ.
+        
+        Args:
+            inputs: Input tensor [batch, ..., embedding_dim]
+            training: Whether in training mode
+            
+        Returns:
+            Dictionary with quantized outputs and metrics
+        """
+        
+        # Ensure BF16 precision for TPU optimization
+        if self.config.use_bfloat16:
+            inputs = inputs.astype(jnp.bfloat16)
+            
+        input_shape = inputs.shape
+        flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+        
+        if self.config.use_product_quantization:
+            return self._product_quantize(flat_inputs, input_shape, training)
+        else:
+            return self._standard_quantize(flat_inputs, input_shape, training)
+    
+    def _product_quantize(self,
+                         flat_inputs: jnp.ndarray,
+                         input_shape: Tuple[int, ...],
+                         training: bool) -> Dict[str, jnp.ndarray]:
+        """Product quantization implementation (vectorized)."""
+
+        # Stack all codebooks: [num_subspaces, num_embeddings, subspace_dim]
+        stacked_codebooks = jnp.stack(self.codebooks, axis=0)
+
+        # Reshape inputs: [batch, num_subspaces, subspace_dim]
+        batch_size = flat_inputs.shape[0]
+        all_inputs = flat_inputs.reshape(batch_size, self.num_subspaces, self.subspace_dim)
+
+        # Compute distances for all subspaces at once (vectorized)
+        # all_inputs:          [batch, num_subspaces, subspace_dim]
+        # stacked_codebooks:   [num_subspaces, num_embeddings, subspace_dim]
+        distances = jnp.sum(
+            (all_inputs[:, :, None, :] - stacked_codebooks[None, :, :, :]) ** 2,
+            axis=-1
+        )  # [batch, num_subspaces, num_embeddings]
+
+        # Get closest codebook entries (vectorized)
+        combined_indices = jnp.argmin(distances, axis=-1)  # [batch, num_subspaces]
+
+        # Gather quantized values (vectorized)
+        subspace_idx = jnp.arange(self.num_subspaces)[None, :]
+        all_quantized = stacked_codebooks[subspace_idx, combined_indices]  # [batch, num_subspaces, subspace_dim]
+
+        # Straight-through estimator (vectorized)
+        all_quantized = all_inputs + jax.lax.stop_gradient(all_quantized - all_inputs)
+
+        # Commitment loss (vectorized)
+        total_commitment = jnp.mean((jax.lax.stop_gradient(all_quantized) - all_inputs) ** 2)
+
+        # EMA updates during training (sequential for mutable state)
+        if training and self.config.use_ema:
+            for i in range(self.num_subspaces):
+                self._update_ema_subspace(i, all_inputs[:, i], combined_indices[:, i])
+
+        # Reshape back
+        quantized = all_quantized.reshape(batch_size, -1).reshape(input_shape)
+
+        # For compatibility with entropy/diversity loss, create lists
+        indices_list = [combined_indices[:, i] for i in range(self.num_subspaces)]
+        quantized_subspaces = [all_quantized[:, i] for i in range(self.num_subspaces)]
+
+        # Total loss
+        total_loss = total_commitment * self.config.commitment_cost
+        
+        # Add entropy regularization
+        if self.config.use_entropy_regularization:
+            entropy_loss = self._compute_entropy_loss(indices_list)
+            total_loss += entropy_loss * self.config.entropy_weight
+            
+        # Add diversity loss
+        if self.config.use_diversity_loss:
+            diversity_loss = self._compute_diversity_loss(quantized_subspaces)
+            total_loss += diversity_loss * self.config.diversity_weight
+        
+        return {
+            'quantized': quantized,
+            'indices': combined_indices,
+            'loss': total_loss,
+            'commitment_loss': sum(losses),
+            'perplexity': self._compute_perplexity(indices_list),
+            'codebook_utilization': self._compute_codebook_utilization(indices_list)
+        }
+    
+    def _standard_quantize(self,
+                          flat_inputs: jnp.ndarray,
+                          input_shape: Tuple[int, ...],
+                          training: bool) -> Dict[str, jnp.ndarray]:
+        """Standard VQ implementation."""
+        
+        # Compute distances to codebook
+        distances = jnp.sum(
+            (flat_inputs[..., None, :] - self.codebook[None, :, :]) ** 2,
+            axis=-1
+        )
+        
+        # Get closest codebook entries
+        indices = jnp.argmin(distances, axis=-1)
+        quantized = self.codebook[indices]
+        
+        # Straight-through estimator
+        quantized = flat_inputs + jax.lax.stop_gradient(quantized - flat_inputs)
+        quantized = quantized.reshape(input_shape)
+        
+        # Commitment loss
+        commitment_loss = jnp.mean(
+            (jax.lax.stop_gradient(quantized) - inputs.reshape(input_shape)) ** 2
+        )
+        
+        total_loss = commitment_loss * self.config.commitment_cost
+        
+        # EMA updates during training
+        if training and self.config.use_ema:
+            self._update_ema_standard(flat_inputs, indices)
+        
+        return {
+            'quantized': quantized,
+            'indices': indices,
+            'loss': total_loss,
+            'commitment_loss': commitment_loss,
+            'perplexity': self._compute_perplexity([indices]),
+            'codebook_utilization': self._compute_codebook_utilization([indices])
+        }
+    
+    def _update_ema_subspace(self, subspace_idx: int, inputs: jnp.ndarray, indices: jnp.ndarray):
+        """Update EMA statistics for product quantization subspace."""
+        
+        # One-hot encoding of indices
+        encodings = jax.nn.one_hot(indices, self.config.num_embeddings, dtype=jnp.float32)
+        
+        # Update cluster sizes
+        cluster_size = jnp.sum(encodings, axis=0)
+        self.ema_cluster_sizes[subspace_idx].value = (
+            self.config.ema_decay * self.ema_cluster_sizes[subspace_idx].value +
+            (1 - self.config.ema_decay) * cluster_size
+        )
+        
+        # Update embeddings
+        dw = jnp.dot(encodings.T, inputs)
+        self.ema_embeddings[subspace_idx].value = (
+            self.config.ema_decay * self.ema_embeddings[subspace_idx].value +
+            (1 - self.config.ema_decay) * dw
+        )
+        
+        # Update codebook
+        n = jnp.sum(self.ema_cluster_sizes[subspace_idx].value)
+        cluster_size = (
+            (self.ema_cluster_sizes[subspace_idx].value + self.config.ema_epsilon) /
+            (n + self.config.num_embeddings * self.config.ema_epsilon) * n
+        )
+        
+        normalized_embeddings = (
+            self.ema_embeddings[subspace_idx].value / cluster_size[..., None]
+        )
+        
+        # Update the codebook parameter
+        self.codebooks[subspace_idx] = normalized_embeddings.astype(
+            jnp.bfloat16 if self.config.use_bfloat16 else jnp.float32
+        )
+    
+    def _update_ema_standard(self, inputs: jnp.ndarray, indices: jnp.ndarray):
+        """Update EMA statistics for standard VQ."""
+        
+        # One-hot encoding of indices
+        encodings = jax.nn.one_hot(indices, self.config.num_embeddings, dtype=jnp.float32)
+        
+        # Update cluster sizes
+        cluster_size = jnp.sum(encodings, axis=0)
+        self.ema_cluster_size.value = (
+            self.config.ema_decay * self.ema_cluster_size.value +
+            (1 - self.config.ema_decay) * cluster_size
+        )
+        
+        # Update embeddings
+        dw = jnp.dot(encodings.T, inputs)
+        self.ema_embedding.value = (
+            self.config.ema_decay * self.ema_embedding.value +
+            (1 - self.config.ema_decay) * dw
+        )
+        
+        # Update codebook
+        n = jnp.sum(self.ema_cluster_size.value)
+        cluster_size = (
+            (self.ema_cluster_size.value + self.config.ema_epsilon) /
+            (n + self.config.num_embeddings * self.config.ema_epsilon) * n
+        )
+        
+        normalized_embeddings = self.ema_embedding.value / cluster_size[..., None]
+        
+        # Update the codebook parameter
+        self.codebook = normalized_embeddings.astype(
+            jnp.bfloat16 if self.config.use_bfloat16 else jnp.float32
+        )
+    
+    def _compute_entropy_loss(self, indices_list: List[jnp.ndarray]) -> jnp.ndarray:
+        """Compute entropy regularization loss."""
+        
+        total_entropy = 0.0
+        
+        for indices in indices_list:
+            # Compute usage probabilities
+            usage_counts = jnp.bincount(indices, length=self.config.num_embeddings)
+            usage_probs = usage_counts / jnp.sum(usage_counts)
+            
+            # Compute entropy
+            entropy = -jnp.sum(usage_probs * jnp.log(usage_probs + 1e-8))
+            total_entropy += entropy
+            
+        return -total_entropy / len(indices_list)  # Negative for maximization
+    
+    def _compute_diversity_loss(self, quantized_subspaces: List[jnp.ndarray]) -> jnp.ndarray:
+        """Compute diversity loss to encourage codebook utilization."""
+        
+        total_diversity = 0.0
+        
+        for quantized in quantized_subspaces:
+            # Compute pairwise distances between quantized vectors
+            distances = jnp.sum(
+                (quantized[:, None, :] - quantized[None, :, :]) ** 2,
+                axis=-1
+            )
+            
+            # Encourage diversity by minimizing negative distances
+            diversity = -jnp.mean(distances)
+            total_diversity += diversity
+            
+        return total_diversity / len(quantized_subspaces)
+    
+    def _compute_perplexity(self, indices_list: List[jnp.ndarray]) -> jnp.ndarray:
+        """Compute perplexity metric."""
+        
+        total_perplexity = 0.0
+        
+        for indices in indices_list:
+            # Compute usage probabilities
+            usage_counts = jnp.bincount(indices, length=self.config.num_embeddings)
+            usage_probs = usage_counts / jnp.sum(usage_counts)
+            
+            # Compute perplexity
+            entropy = -jnp.sum(usage_probs * jnp.log(usage_probs + 1e-8))
+            perplexity = jnp.exp(entropy)
+            total_perplexity += perplexity
+            
+        return total_perplexity / len(indices_list)
+    
+    def _compute_codebook_utilization(self, indices_list: List[jnp.ndarray]) -> jnp.ndarray:
+        """Compute codebook utilization rate."""
+        
+        total_utilization = 0.0
+        
+        for indices in indices_list:
+            unique_indices = jnp.unique(indices)
+            utilization = len(unique_indices) / self.config.num_embeddings
+            total_utilization += utilization
+            
+        return total_utilization / len(indices_list)
+
+
+class TPUv6eVQSystem:
+    """
+    Complete TPU v6e-64 VQ system with mesh sharding and performance optimization.
+    """
+    
+    def __init__(self, config: TPUv6eVQConfig):
+        self.config = config
+        
+        # Initialize TPU mesh
+        if JAX_AVAILABLE:
+            self._initialize_tpu_mesh()
+        else:
+            raise RuntimeError("JAX not available for TPU v6e VQ system")
+            
+        # Performance metrics
+        self.performance_metrics = {
+            'quantization_latency': [],
+            'throughput_tokens_per_second': [],
+            'memory_usage_gb': [],
+            'codebook_utilization': [],
+            'perplexity_history': []
+        }
+        
+        logger.info(" TPU v6e-64 VQ system initialized")
+    
+    def _initialize_tpu_mesh(self):
+        """Initialize TPU v6e mesh for distributed computation."""
+        
+        # Get TPU devices
+        devices = jax.devices()
+        if not devices or devices[0].platform != 'tpu':
+            logger.warning("TPU devices not found, using available devices")
+            
+        # Create mesh for TPU v6e-64 (8x8 configuration)
+        num_devices = len(devices)
+        if num_devices >= 64:
+            mesh_shape = (8, 8)
+        elif num_devices >= 32:
+            mesh_shape = (4, 8)
+        elif num_devices >= 8:
+            mesh_shape = (2, 4)
+        else:
+            mesh_shape = (1, min(num_devices, 4))
+            
+        devices_array = np.array(devices[:mesh_shape[0] * mesh_shape[1]]).reshape(mesh_shape)
+        self.mesh = Mesh(devices_array, ('batch', 'model'))
+        
+        logger.info(f" TPU mesh initialized: {mesh_shape} with {len(devices)} devices")
+    
+    def create_vq_layer(self, **kwargs) -> TPUv6eVectorQuantizer:
+        """Creates TPU v6e optimized VQ layer."""
+        
+        # Merge config with kwargs
+        config_dict = self.config.__dict__.copy()
+        config_dict.update(kwargs)
+        config = TPUv6eVQConfig(**config_dict)
+        
+        return TPUv6eVectorQuantizer(config=config)
+    
+    def compile_for_tpu(self, vq_layer: TPUv6eVectorQuantizer) -> Callable:
+        """Compile VQ layer for TPU v6e with optimal sharding."""
+        
+        def vq_forward(params, inputs, training=True):
+            return vq_layer.apply(params, inputs, training=training)
+        
+        # Define sharding specifications
+        input_spec = P('batch', None)  # Shard batch dimension
+        param_spec = P(None, 'model')  # Shard model dimension for codebooks
+        output_spec = P('batch', None)  # Shard batch dimension for outputs
+        
+        # Compile with pjit for optimal TPU performance
+        compiled_fn = pjit(
+            vq_forward,
+            in_shardings=(param_spec, input_spec, None),
+            out_shardings=output_spec,
+            donate_argnums=(0,)  # Donate parameters for memory efficiency
+        )
+        
+        return compiled_fn
+    
+    def benchmark_performance(self, 
+                             vq_layer: TPUv6eVectorQuantizer,
+                             batch_sizes: List[int] = None,
+                             sequence_lengths: List[int] = None) -> Dict[str, Any]:
+        """Benchmark TPU v6e VQ performance."""
+        
+        if batch_sizes is None:
+            batch_sizes = [1, 4, 8, 16, 32]
+        if sequence_lengths is None:
+            sequence_lengths = [512, 1024, 2048, 4096]
+            
+        # Initialize VQ parameters
+        key = random.PRNGKey(42)
+        dummy_input = jnp.ones((1, 1, self.config.embedding_dim))
+        params = vq_layer.init(key, dummy_input)
+        
+        # Compile VQ function
+        compiled_vq = self.compile_for_tpu(vq_layer)
+        
+        benchmark_results = {
+            'batch_sizes': batch_sizes,
+            'sequence_lengths': sequence_lengths,
+            'results': {}
+        }
+        
+        for batch_size in batch_sizes:
+            for seq_len in sequence_lengths:
+                # Create test input
+                test_input = random.normal(
+                    key, 
+                    (batch_size, seq_len, self.config.embedding_dim)
+                ).astype(jnp.bfloat16 if self.config.use_bfloat16 else jnp.float32)
+                
+                # Warmup
+                for _ in range(3):
+                    _ = compiled_vq(params, test_input, training=False)
+                
+                # Benchmark
+                start_time = time.time()
+                num_runs = 10
+                
+                for _ in range(num_runs):
+                    result = compiled_vq(params, test_input, training=False)
+                    result['quantized'].block_until_ready()  # Ensure computation completes
+                
+                end_time = time.time()
+                
+                # Calculate metrics
+                total_time = end_time - start_time
+                avg_time = total_time / num_runs
+                tokens_per_second = (batch_size * seq_len) / avg_time
+                
+                benchmark_results['results'][(batch_size, seq_len)] = {
+                    'avg_latency_ms': avg_time * 1000,
+                    'tokens_per_second': tokens_per_second,
+                    'perplexity': float(result['perplexity']),
+                    'codebook_utilization': float(result['codebook_utilization'])
+                }
+                
+                logger.info(f"Benchmark B={batch_size}, S={seq_len}: "
+                           f"{avg_time*1000:.2f}ms, {tokens_per_second:.0f} tok/s")
+        
+        return benchmark_results
+    
+    def get_performance_metrics(self) -> Dict[str, Any]:
+        """Get comprehensive performance metrics."""
+        
+        return {
+            'config': {
+                'num_embeddings': self.config.num_embeddings,
+                'embedding_dim': self.config.embedding_dim,
+                'use_product_quantization': self.config.use_product_quantization,
+                'num_subspaces': self.config.num_subspaces if self.config.use_product_quantization else None,
+                'use_bfloat16': self.config.use_bfloat16,
+                'mesh_shape': self.config.mesh_shape
+            },
+            'performance_metrics': self.performance_metrics,
+            'system_info': {
+                'jax_available': JAX_AVAILABLE,
+                'devices': [str(d) for d in jax.devices()] if JAX_AVAILABLE else [],
+                'mesh_initialized': hasattr(self, 'mesh')
+            }
+        }
+
+
+# Factory functions
+def create_tpu_v6e_vq_system(config: Optional[TPUv6eVQConfig] = None) -> TPUv6eVQSystem:
+    """Creates TPU v6e-64 optimized VQ system."""
+    
+    if config is None:
+        config = TPUv6eVQConfig()
+        
+    return TPUv6eVQSystem(config)
+
+
+def create_tpu_v6e_vq_layer(**kwargs) -> TPUv6eVectorQuantizer:
+    """Creates TPU v6e-64 optimized VQ layer with custom configuration."""
+    
+    config = TPUv6eVQConfig(**kwargs)
+    return TPUv6eVectorQuantizer(config=config)
+
+
+# Integration functions
+def integrate_with_moe(vq_system: TPUv6eVQSystem, 
+                      moe_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Integrate TPU v6e VQ with MoE system."""
+    
+    # Optimize VQ configuration for MoE
+    num_experts = moe_config.get('num_experts', 32)
+    expert_capacity = moe_config.get('expert_capacity', 128)
+    
+    # Calculate optimal VQ parameters for MoE
+    optimal_embeddings = min(16384, num_experts * expert_capacity * 2)
+    
+    integration_config = {
+        'num_embeddings': optimal_embeddings,
+        'use_product_quantization': True,
+        'num_subspaces': min(32, num_experts),
+        'enable_moe_integration': True
+    }
+    
+    return integration_config
+
+
+def integrate_with_adaptive(vq_system: TPUv6eVQSystem,
+                           adaptive_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Integrate TPU v6e VQ with Adaptive computation system."""
+    
+    # Optimize VQ configuration for adaptive computation
+    compute_budget = adaptive_config.get('compute_budget', 1.0)
+    
+    if compute_budget < 0.7:
+        # Low compute budget - optimize for efficiency
+        integration_config = {
+            'num_embeddings': 8192,
+            'embedding_dim': 1024,
+            'use_product_quantization': True,
+            'num_subspaces': 8
+        }
+    else:
+        # High compute budget - optimize for quality
+        integration_config = {
+            'num_embeddings': 16384,
+            'embedding_dim': 2048,
+            'use_product_quantization': True,
+            'num_subspaces': 16,
+            'use_entropy_regularization': True,
+            'use_diversity_loss': True
+        }
+    
+    integration_config['enable_adaptive_integration'] = True
+    return integration_config
+
+
+def main():
+    """Main function demonstrating TPU v6e VQ system."""
+    
+    logger.info(" TPU v6e-64 VQ system starting")
+    
+    if not JAX_AVAILABLE:
+        logger.warning(" JAX not available - TPU v6e VQ system requires JAX")
+        return False
+    
+    try:
+        # Create TPU v6e VQ system
+        config = TPUv6eVQConfig(
+            num_embeddings=8192,
+            embedding_dim=1024,
+            use_product_quantization=True,
+            num_subspaces=16,
+            use_bfloat16=True
+        )
+        
+        vq_system = create_tpu_v6e_vq_system(config)
+        
+        # Create VQ layer
+        vq_layer = vq_system.create_vq_layer()
+        
+        # Show system info
+        metrics = vq_system.get_performance_metrics()
+        logger.info(" TPU v6e VQ System Info:")
+        logger.info(f"   Embeddings: {metrics['config']['num_embeddings']}")
+        logger.info(f"   Dimension: {metrics['config']['embedding_dim']}")
+        logger.info(f"   Product Quantization: {metrics['config']['use_product_quantization']}")
+        logger.info(f"   Subspaces: {metrics['config']['num_subspaces']}")
+        logger.info(f"   BF16: {metrics['config']['use_bfloat16']}")
+        logger.info(f"   Devices: {len(metrics['system_info']['devices'])}")
+        
+        # Test MoE integration
+        moe_config = {'num_experts': 32, 'expert_capacity': 128}
+        moe_integration = integrate_with_moe(vq_system, moe_config)
+        logger.info(f"\n MoE Integration:")
+        logger.info(f"   Optimal embeddings: {moe_integration['num_embeddings']}")
+        logger.info(f"   Subspaces: {moe_integration['num_subspaces']}")
+        
+        # Test Adaptive integration
+        adaptive_config = {'compute_budget': 1.2}
+        adaptive_integration = integrate_with_adaptive(vq_system, adaptive_config)
+        logger.info(f"\n Adaptive Integration:")
+        logger.info(f"   Embeddings: {adaptive_integration['num_embeddings']}")
+        logger.info(f"   Dimension: {adaptive_integration['embedding_dim']}")
+        
+        logger.info("\n TPU v6e-64 VQ system demo completed!")
+        return True
+        
+    except Exception as e:
+        logger.error(f" Demo failed: {e}")
+        return False
+
+
+if __name__ == "__main__":
+    main()

--- a/capibara/vq/vqbit/vqbit_layer.py
+++ b/capibara/vq/vqbit/vqbit_layer.py
@@ -1,0 +1,534 @@
+"""
+VQbit Layer Implementation for Capibara-6
+
+Core Vector Quantization layer with support for:
+- JAX/Flax implementation for TPU optimization
+- PyTorch fallback for CPU/GPU
+- Adaptive codebook management
+- Performance monitoring
+- Integration with MoE and Adaptive systems
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass
+import math
+
+# JAX/Flax imports (preferred for TPU)
+try:
+    import jax
+    import jax.numpy as jnp
+    import flax.linen as nn
+    from flax import struct
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+    jax = None
+    jnp = None
+    nn = None
+
+# PyTorch fallback
+try:
+    import torch
+    import torch.nn as torch_nn
+    import torch.nn.functional as F
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+    torch = None
+    torch_nn = None
+    F = None
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class VQbitConfig:
+    """Configurestion for VQbit Layer."""
+    codebook_size: int = 64
+    embedding_dim: int = 768
+    commitment_weight: float = 0.25
+    use_tpu_optimizations: bool = True
+    diversity_regularization: bool = True
+    use_ema: bool = True
+    ema_decay: float = 0.999
+    ema_epsilon: float = 1e-5
+    use_product_quantization: bool = False
+    num_subspaces: int = 8
+
+
+if JAX_AVAILABLE:
+    class VQbitLayer(nn.Module):
+        """
+        VQbit Layer - JAX/Flax implementation for TPU optimization.
+        
+        Features:
+        - Vector quantization with learnable codebook
+        - EMA updates for stable training
+        - Commitment loss and diversity regularization
+        - TPU-optimized operations
+        - Product quantization support
+        """
+        
+        config: VQbitConfig
+        
+        def setup(self):
+            """Initialize the VQbit layer."""
+            # Initialize codebook
+            if self.config.use_product_quantization:
+                # Product quantization: split embedding into subspaces
+                subspace_dim = self.config.embedding_dim // self.config.num_subspaces
+                codebook_shape = (self.config.num_subspaces, self.config.codebook_size, subspace_dim)
+            else:
+                codebook_shape = (self.config.codebook_size, self.config.embedding_dim)
+                
+            self.codebook = self.param(
+                'codebook',
+                nn.initializers.uniform(scale=1.0),
+                codebook_shape
+            )
+            
+            if self.config.use_ema:
+                # EMA variables for stable training
+                self.ema_cluster_size = self.variable(
+                    'ema_stats', 'cluster_size',
+                    lambda: jnp.zeros(self.config.codebook_size)
+                )
+                self.ema_embedding_avg = self.variable(
+                    'ema_stats', 'embedding_avg',
+                    lambda: jnp.zeros_like(self.codebook)
+                )
+        
+        def __call__(self, inputs: jnp.ndarray, training: bool = True) -> Tuple[jnp.ndarray, jnp.ndarray, Dict[str, Any]]:
+            """
+            Forward pass of VQbit layer.
+            
+            Args:
+                inputs: Input embeddings [batch, ..., embedding_dim]
+                training: Whether in training mode
+                
+            Returns:
+                quantized: Quantized embeddings
+                indices: Codebook indices
+                metrics: Quantization metrics
+            """
+            
+            input_shape = inputs.shape
+            flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+            
+            if self.config.use_product_quantization:
+                quantized, indices, metrics = self._product_quantize(flat_inputs, training)
+            else:
+                quantized, indices, metrics = self._standard_quantize(flat_inputs, training)
+            
+            # Reshape back to original shape
+            quantized = quantized.reshape(input_shape)
+            indices = indices.reshape(input_shape[:-1])
+            
+            return quantized, indices, metrics
+        
+        def _standard_quantize(self, flat_inputs: jnp.ndarray, training: bool) -> Tuple[jnp.ndarray, jnp.ndarray, Dict[str, Any]]:
+            """Standard vector quantization."""
+            # Compute distances to codebook
+            distances = jnp.linalg.norm(
+                flat_inputs[:, None, :] - self.codebook[None, :, :], 
+                axis=2
+            )
+            
+            # Find nearest codebook entries
+            indices = jnp.argmin(distances, axis=1)
+            quantized = self.codebook[indices]
+            
+            # Compute losses
+            commitment_loss = jnp.mean((jax.lax.stop_gradient(quantized) - flat_inputs) ** 2)
+            codebook_loss = jnp.mean((quantized - jax.lax.stop_gradient(flat_inputs)) ** 2)
+            
+            # Straight-through estimator
+            quantized = flat_inputs + jax.lax.stop_gradient(quantized - flat_inputs)
+            
+            # Update EMA statistics if training
+            if training and self.config.use_ema:
+                self._update_ema_stats(flat_inputs, indices)
+            
+            # Compute metrics
+            metrics = self._compute_metrics(flat_inputs, quantized, indices, commitment_loss, codebook_loss)
+            
+            return quantized, indices, metrics
+        
+        def _product_quantize(self, flat_inputs: jnp.ndarray, training: bool) -> Tuple[jnp.ndarray, jnp.ndarray, Dict[str, Any]]:
+            """Product quantization for memory efficiency (vectorized, no Python loops)."""
+            batch_size = flat_inputs.shape[0]
+            subspace_dim = self.config.embedding_dim // self.config.num_subspaces
+            num_subspaces = self.config.num_subspaces
+
+            # Reshape for product quantization: [batch, num_subspaces, subspace_dim]
+            inputs_reshaped = flat_inputs.reshape(batch_size, num_subspaces, subspace_dim)
+
+            # Compute distances for all subspaces at once (vectorized)
+            # inputs_reshaped: [batch, num_subspaces, subspace_dim]
+            # self.codebook: [num_subspaces, codebook_size, subspace_dim]
+            # Expand dims for broadcasting:
+            # inputs: [batch, num_subspaces, 1, subspace_dim]
+            # codebook: [1, num_subspaces, codebook_size, subspace_dim]
+            distances = jnp.linalg.norm(
+                inputs_reshaped[:, :, None, :] - self.codebook[None, :, :, :],
+                axis=-1
+            )  # [batch, num_subspaces, codebook_size]
+
+            # Get indices for all subspaces at once
+            indices = jnp.argmin(distances, axis=-1)  # [batch, num_subspaces]
+
+            # Gather quantized values (vectorized)
+            # Use advanced indexing: for each (batch, subspace), get codebook[subspace, indices[batch, subspace]]
+            batch_idx = jnp.arange(batch_size)[:, None]  # [batch, 1]
+            subspace_idx = jnp.arange(num_subspaces)[None, :]  # [1, num_subspaces]
+            quantized_subspaces = self.codebook[subspace_idx, indices]  # [batch, num_subspaces, subspace_dim]
+
+            # Compute losses (vectorized over all subspaces)
+            commitment_loss = jnp.mean((jax.lax.stop_gradient(quantized_subspaces) - inputs_reshaped) ** 2)
+            codebook_loss = jnp.mean((quantized_subspaces - jax.lax.stop_gradient(inputs_reshaped)) ** 2)
+
+            # Straight-through estimator
+            quantized_subspaces = inputs_reshaped + jax.lax.stop_gradient(quantized_subspaces - inputs_reshaped)
+
+            # Reshape back: [batch, num_subspaces * subspace_dim]
+            quantized = quantized_subspaces.reshape(batch_size, -1)
+            
+            # Compute metrics
+            metrics = self._compute_metrics(flat_inputs, quantized, indices, commitment_loss, codebook_loss)
+            
+            return quantized, indices, metrics
+        
+        def _update_ema_stats(self, flat_inputs: jnp.ndarray, indices: jnp.ndarray):
+            """Update EMA statistics for stable training."""
+            # Update cluster sizes
+            one_hot = jax.nn.one_hot(indices, self.config.codebook_size)
+            cluster_size = jnp.sum(one_hot, axis=0)
+            
+            self.ema_cluster_size.value = (
+                self.config.ema_decay * self.ema_cluster_size.value +
+                (1 - self.config.ema_decay) * cluster_size
+            )
+            
+            # Update embedding averages
+            embedding_sum = jnp.dot(one_hot.T, flat_inputs)
+            self.ema_embedding_avg.value = (
+                self.config.ema_decay * self.ema_embedding_avg.value +
+                (1 - self.config.ema_decay) * embedding_sum
+            )
+        
+        def _compute_metrics(self, inputs: jnp.ndarray, quantized: jnp.ndarray, 
+                           indices: jnp.ndarray, commitment_loss: float, 
+                           codebook_loss: float) -> Dict[str, Any]:
+            """Compute quantization metrics."""
+            
+            # Basic metrics
+            mse = jnp.mean((inputs - quantized) ** 2)
+            
+            # Codebook usage
+            unique_indices = len(jnp.unique(indices))
+            codebook_usage = unique_indices / self.config.codebook_size
+            
+            # Perplexity
+            avg_probs = jnp.mean(jax.nn.one_hot(indices, self.config.codebook_size), axis=0)
+            perplexity = jnp.exp(-jnp.sum(avg_probs * jnp.log(avg_probs + 1e-10)))
+            
+            # Compression ratio
+            original_bits = inputs.size * 32  # float32
+            quantized_bits = indices.size * math.ceil(math.log2(self.config.codebook_size))
+            compression_ratio = original_bits / quantized_bits
+            
+            return {
+                'commitment_loss': commitment_loss,
+                'codebook_loss': codebook_loss,
+                'mse': mse,
+                'codebook_usage': codebook_usage,
+                'perplexity': perplexity,
+                'compression_ratio': compression_ratio,
+                'unique_codes': unique_indices
+            }
+        
+        @property
+        def codebook_size(self) -> int:
+            """Get codebook size."""
+            return self.config.codebook_size
+
+elif TORCH_AVAILABLE:
+    class VQbitLayer(torch_nn.Module):
+        """
+        VQbit Layer - PyTorch implementation for CPU/GPU fallback.
+        """
+        
+        def __init__(self, config: Optional[VQbitConfig] = None, **kwargs):
+            super().__init__()
+            if config is None:
+                config = VQbitConfig(**kwargs)
+            self.config = config
+            
+            # Initialize codebook
+            if self.config.use_product_quantization:
+                subspace_dim = self.config.embedding_dim // self.config.num_subspaces
+                codebook_shape = (self.config.num_subspaces, self.config.codebook_size, subspace_dim)
+            else:
+                codebook_shape = (self.config.codebook_size, self.config.embedding_dim)
+                
+            self.codebook = torch_nn.Parameter(torch.randn(codebook_shape))
+            
+            if self.config.use_ema:
+                self.register_buffer('ema_cluster_size', torch.zeros(self.config.codebook_size))
+                self.register_buffer('ema_embedding_avg', torch.zeros_like(self.codebook))
+        
+        def forward(self, inputs: torch.Tensor, training: bool = True) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+            """Forward pass of VQbit layer."""
+            input_shape = inputs.shape
+            flat_inputs = inputs.view(-1, self.config.embedding_dim)
+            
+            if self.config.use_product_quantization:
+                quantized, indices, metrics = self._product_quantize(flat_inputs, training)
+            else:
+                quantized, indices, metrics = self._standard_quantize(flat_inputs, training)
+            
+            # Reshape back to original shape
+            quantized = quantized.view(input_shape)
+            indices = indices.view(input_shape[:-1])
+            
+            return quantized, indices, metrics
+        
+        def _standard_quantize(self, flat_inputs: torch.Tensor, training: bool) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+            """Standard vector quantization."""
+            # Compute distances to codebook
+            distances = torch.norm(
+                flat_inputs.unsqueeze(1) - self.codebook.unsqueeze(0),
+                dim=2
+            )
+            
+            # Find nearest codebook entries
+            indices = torch.argmin(distances, dim=1)
+            quantized = self.codebook[indices]
+            
+            # Compute losses
+            commitment_loss = F.mse_loss(quantized.detach(), flat_inputs)
+            codebook_loss = F.mse_loss(quantized, flat_inputs.detach())
+            
+            # Straight-through estimator
+            quantized = flat_inputs + (quantized - flat_inputs).detach()
+            
+            # Update EMA statistics if training
+            if training and self.config.use_ema:
+                self._update_ema_stats(flat_inputs, indices)
+            
+            # Compute metrics
+            metrics = self._compute_metrics(flat_inputs, quantized, indices, commitment_loss, codebook_loss)
+            
+            return quantized, indices, metrics
+        
+        def _product_quantize(self, flat_inputs: torch.Tensor, training: bool) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+            """Product quantization for memory efficiency (vectorized, no Python loops)."""
+            batch_size = flat_inputs.shape[0]
+            subspace_dim = self.config.embedding_dim // self.config.num_subspaces
+            num_subspaces = self.config.num_subspaces
+
+            # Reshape for product quantization: [batch, num_subspaces, subspace_dim]
+            inputs_reshaped = flat_inputs.view(batch_size, num_subspaces, subspace_dim)
+
+            # Compute distances for all subspaces at once (vectorized)
+            # inputs_reshaped: [batch, num_subspaces, subspace_dim]
+            # self.codebook: [num_subspaces, codebook_size, subspace_dim]
+            # Expand for broadcasting:
+            # inputs: [batch, num_subspaces, 1, subspace_dim]
+            # codebook: [1, num_subspaces, codebook_size, subspace_dim]
+            distances = torch.norm(
+                inputs_reshaped.unsqueeze(2) - self.codebook.unsqueeze(0),
+                dim=-1
+            )  # [batch, num_subspaces, codebook_size]
+
+            # Get indices for all subspaces at once
+            indices = torch.argmin(distances, dim=-1)  # [batch, num_subspaces]
+
+            # Gather quantized values (vectorized)
+            # Use gather: codebook[subspace, indices[batch, subspace]]
+            batch_idx = torch.arange(batch_size, device=flat_inputs.device)[:, None].expand(-1, num_subspaces)
+            subspace_idx = torch.arange(num_subspaces, device=flat_inputs.device)[None, :].expand(batch_size, -1)
+            quantized_subspaces = self.codebook[subspace_idx, indices]  # [batch, num_subspaces, subspace_dim]
+
+            # Compute losses (vectorized over all subspaces)
+            commitment_loss = F.mse_loss(quantized_subspaces.detach(), inputs_reshaped)
+            codebook_loss = F.mse_loss(quantized_subspaces, inputs_reshaped.detach())
+
+            # Straight-through estimator
+            quantized_subspaces = inputs_reshaped + (quantized_subspaces - inputs_reshaped).detach()
+
+            # Reshape back: [batch, num_subspaces * subspace_dim]
+            quantized = quantized_subspaces.view(batch_size, -1)
+
+            # Compute metrics
+            metrics = self._compute_metrics(flat_inputs, quantized, indices, commitment_loss, codebook_loss)
+
+            return quantized, indices, metrics
+        
+        def _update_ema_stats(self, flat_inputs: torch.Tensor, indices: torch.Tensor):
+            """Update EMA statistics for stable training."""
+            with torch.no_grad():
+                # Update cluster sizes
+                one_hot = F.one_hot(indices, self.config.codebook_size).float()
+                cluster_size = torch.sum(one_hot, dim=0)
+                
+                self.ema_cluster_size.mul_(self.config.ema_decay).add_(
+                    cluster_size, alpha=1 - self.config.ema_decay
+                )
+                
+                # Update embedding averages
+                embedding_sum = torch.matmul(one_hot.t(), flat_inputs)
+                self.ema_embedding_avg.mul_(self.config.ema_decay).add_(
+                    embedding_sum, alpha=1 - self.config.ema_decay
+                )
+        
+        def _compute_metrics(self, inputs: torch.Tensor, quantized: torch.Tensor,
+                           indices: torch.Tensor, commitment_loss: float,
+                           codebook_loss: float) -> Dict[str, Any]:
+            """Compute quantization metrics."""
+            
+            # Basic metrics
+            mse = F.mse_loss(inputs, quantized)
+            
+            # Codebook usage
+            unique_indices = len(torch.unique(indices))
+            codebook_usage = unique_indices / self.config.codebook_size
+            
+            # Perplexity
+            one_hot = F.one_hot(indices, self.config.codebook_size).float()
+            avg_probs = torch.mean(one_hot, dim=0)
+            perplexity = torch.exp(-torch.sum(avg_probs * torch.log(avg_probs + 1e-10)))
+            
+            # Compression ratio
+            original_bits = inputs.numel() * 32  # float32
+            quantized_bits = indices.numel() * math.ceil(math.log2(self.config.codebook_size))
+            compression_ratio = original_bits / quantized_bits
+            
+            return {
+                'commitment_loss': commitment_loss.item() if hasattr(commitment_loss, 'item') else float(commitment_loss),
+                'codebook_loss': codebook_loss.item() if hasattr(codebook_loss, 'item') else float(codebook_loss),
+                'mse': mse.item(),
+                'codebook_usage': codebook_usage.item(),
+                'perplexity': perplexity.item(),
+                'compression_ratio': compression_ratio,
+                'unique_codes': unique_indices
+            }
+        
+        @property
+        def codebook_size(self) -> int:
+            """Get codebook size."""
+            return self.config.codebook_size
+
+else:
+    # Fallback implementation using NumPy
+    class VQbitLayer:
+        """
+        VQbit Layer - NumPy fallback implementation.
+        """
+        
+        def __init__(self, config: Optional[VQbitConfig] = None, **kwargs):
+            if config is None:
+                config = VQbitConfig(**kwargs)
+            self.config = config
+            
+            # Initialize codebook
+            if self.config.use_product_quantization:
+                subspace_dim = self.config.embedding_dim // self.config.num_subspaces
+                codebook_shape = (self.config.num_subspaces, self.config.codebook_size, subspace_dim)
+            else:
+                codebook_shape = (self.config.codebook_size, self.config.embedding_dim)
+                
+            self.codebook = np.random.randn(*codebook_shape).astype(np.float32)
+            
+            if self.config.use_ema:
+                self.ema_cluster_size = np.zeros(self.config.codebook_size)
+                self.ema_embedding_avg = np.zeros_like(self.codebook)
+        
+        def __call__(self, inputs: np.ndarray, training: bool = True) -> Tuple[np.ndarray, np.ndarray, Dict[str, Any]]:
+            """Forward pass of VQbit layer."""
+            input_shape = inputs.shape
+            flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+            
+            # Standard quantization (simplified for NumPy)
+            distances = np.linalg.norm(
+                flat_inputs[:, None, :] - self.codebook[None, :, :],
+                axis=2
+            )
+            
+            indices = np.argmin(distances, axis=1)
+            quantized = self.codebook[indices]
+            
+            # Compute basic metrics
+            mse = np.mean((inputs.reshape(-1, self.config.embedding_dim) - quantized) ** 2)
+            unique_indices = len(np.unique(indices))
+            codebook_usage = unique_indices / self.config.codebook_size
+            
+            metrics = {
+                'commitment_loss': 0.0,
+                'codebook_loss': 0.0,
+                'mse': float(mse),
+                'codebook_usage': float(codebook_usage),
+                'perplexity': float(unique_indices),
+                'compression_ratio': 32.0 / math.ceil(math.log2(self.config.codebook_size)),
+                'unique_codes': unique_indices
+            }
+            
+            # Reshape back
+            quantized = quantized.reshape(input_shape)
+            indices = indices.reshape(input_shape[:-1])
+            
+            return quantized, indices, metrics
+        
+        @property
+        def codebook_size(self) -> int:
+            """Get codebook size."""
+            return self.config.codebook_size
+
+
+# Factory function for easy creation
+def create_vqbit_layer(codebook_size: int = 64,
+                      embedding_dim: int = 768,
+                      use_tpu_optimizations: bool = True,
+                      commitment_weight: float = 0.25,
+                      diversity_regularization: bool = True,
+                      **kwargs) -> VQbitLayer:
+    """
+    Create a VQbit layer with the specified configuration.
+    
+    Args:
+        codebook_size: Number of codebook entries
+        embedding_dim: Dimension of embeddings
+        use_tpu_optimizations: Enable TPU optimizations
+        commitment_weight: Weight for commitment loss
+        diversity_regularization: Enable diversity regularization
+        **kwargs: Additional configuration options
+        
+    Returns:
+        VQbitLayer instance
+    """
+    config = VQbitConfig(
+        codebook_size=codebook_size,
+        embedding_dim=embedding_dim,
+        use_tpu_optimizations=use_tpu_optimizations,
+        commitment_weight=commitment_weight,
+        diversity_regularization=diversity_regularization,
+        **kwargs
+    )
+    
+    return VQbitLayer(config)
+
+
+# Alias for compatibility
+VQBitLayer = VQbitLayer
+
+logger.info(f"VQbit Layer initialized - JAX: {JAX_AVAILABLE}, PyTorch: {TORCH_AVAILABLE}")
+
+def main():
+    # Main function for this module.
+    logger.info("Module vqbit_layer.py starting")
+    return True
+
+if __name__ == "__main__":
+    main()

--- a/capibara/vq/vqbit/wrapper.py
+++ b/capibara/vq/vqbit/wrapper.py
@@ -1,0 +1,143 @@
+"""AdaptiveWrapper – v2.0
+================================================
+Mejoras key about la versión previa:
+*  **Config dataclass** for tipado estricto and valores by defect.
+*  `pjit`‑ready: parámetros with `param_with_axes`; output with la misma `PartitionSpec`.
+* ️ FFT usa `jnp.fft.rfft` (mitad de memory) and `jax.checkpoint`.
+* 🪶 Métricas se almacenan en collection `metrics` → mutables but outside de grad.
+*  Coherencia and entrelazamiento se calculan with aproximaciones lineales or(N) (without `outer`, without `svd`).
+*  `adaptive_attention` envuelto en `jax.checkpoint` for activate CSE + remat.
+* 🩹 Validaciones de type/forma and conversion a `dtype` en un only lugar.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+# Python standard library
+import logging
+from enum import Enum, auto
+from functools import partial
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+# Third party imports
+import jax
+from flax import linen as nn
+
+from capibara.jax.numpy import jnp
+# Local imports
+from capibara.core.kernels import tpu_kernel
+from flax.linen.partitioning import param_with_axes
+from capibara.jax.sharding import PartitionSpec as P
+
+# Setup paths
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(script_dir)
+if project_root not in sys.path:
+    pass  # Using proper imports instead of sys.path manipulation
+
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+
+class FFTMode(Enum):
+    STANDARD = auto()
+    PHASE_OPT = auto()
+    HYBRID = auto()
+
+@dataclass
+class AdaptiveWrapCfg:
+    fft_size: int = 1_024
+    phase_scale: float = 1.0
+    fft_mode: FFTMode = FFTMode.HYBRID
+    num_heads: int = 4
+    qkv_features: int = 256
+    out_features: int = 256
+    dropout: float = 0.1
+    dtype: str = "bfloat16"  # or float32/float16
+
+    @property
+    def jdtype(self):
+        return {
+            "bfloat16": jnp.bfloat16,
+            "float32": jnp.float32,
+            "float16": jnp.float16,
+        }[self.dtype]
+
+# -----------------------------------------------------------------------------
+# Module
+# -----------------------------------------------------------------------------
+
+class AdaptiveWrapper(nn.Module):
+    cfg: AdaptiveWrapCfg
+    shard_axis: Tuple[str, str] = ("batch", "embed")
+
+    def setup(self):
+        ax = ("batch", "embed")
+        self.attn = nn.MultiHeadDotProductAttention(
+            num_heads=self.cfg.num_heads,
+            qkv_features=self.cfg.qkv_features,
+            out_features=self.cfg.out_features,
+            dropout_rate=self.cfg.dropout,
+            kernel_axes=(ax, ax),
+            dtype=self.cfg.jdtype,
+        )
+        self.norm = nn.LayerNorm(axis=-1, dtype=self.cfg.jdtype, param_axes={"scale": "embed", "bias": "embed"})
+        # metric buffers in separate collection; ring of 1k
+        self.metric_len = 1_000
+
+    # ------------------------------------------------------------------
+    def _pad(self, x):
+        need = self.cfg.fft_size - x.shape[-1]
+        return jnp.pad(x, [(0,0)]*(x.ndim-1)+[(0, max(0, need))])[:, : self.cfg.fft_size]
+
+    @partial(jax.checkpoint, prevent_cse=True)
+    def _fft(self, x):
+        xr = self._pad(x).astype(self.cfg.jdtype)
+        
+        # use FFT optimizada for tpu v4
+        fft = tpu_kernel.optimized_fft(xr)
+        
+        if self.cfg.fft_mode is FFTMode.PHASE_OPT:
+            phase = tpu_kernel.compute_phase(fft)
+            fft *= jnp.tanh(self.cfg.phase_scale * phase)
+        elif self.cfg.fft_mode is FFTMode.HYBRID:
+            mag, phase = tpu_kernel.compute_magnitude_phase(fft)
+            fft = mag * jnp.exp(1j * jnp.tanh(self.cfg.phase_scale * phase))
+        
+        return fft.astype(self.cfg.jdtype)
+
+    # ------------------------------------------------------------------
+    def _fast_metrics(self, x, y):
+        # coherence via cosine similarity
+        c = jnp.mean(jnp.cos(x) * jnp.cos(y) + jnp.sin(x) * jnp.sin(y))
+        # fidelity via normalized inner product
+        xn, yn = x / (jnp.linalg.norm(x)+1e-6), y / (jnp.linalg.norm(y)+1e-6)
+        f = (jnp.abs(jnp.vdot(xn, yn)) ** 2).real
+        # entanglement approximation: variance of log magnitude spectrum
+        ent = jnp.var(jnp.log(jnp.abs(y)+1e-6))
+        # phase variance
+        pvar = jnp.var(jnp.angle(y))
+        return c, f, ent, pvar
+
+    # ------------------------------------------------------------------
+    @nn.compact
+    def __call__(self, x: jnp.ndarray, *, deterministic=True):
+        if x.ndim != 2:
+            raise ValueError("AdaptiveWrapper expects (B, D) tensor")
+        x = x.astype(self.cfg.jdtype)
+
+        fft = self._fft(x)
+        attn = jax.checkpoint(self.attn)(inputs_q=fft, inputs_kv=fft, deterministic=deterministic)
+        out = self.norm(fft + attn)
+
+        c, f, e, pv = self._fast_metrics(x, out)
+        self.sow("metrics", "coherence", c)
+        self.sow("metrics", "fidelity", f)
+        self.sow("metrics", "entanglement", e)
+        self.sow("metrics", "phase_var", pv)
+
+        return {"output": out, "metrics": {"coherence": c, "fidelity": f, "entanglement": e, "phase_var": pv}} 

--- a/capibara/vq/vqbit_layer.py
+++ b/capibara/vq/vqbit_layer.py
@@ -1,0 +1,314 @@
+"""
+VQbit Layer implementation for CapibaraGPT.
+"""
+
+import numpy as np
+from typing import Any, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass
+from enum import Enum
+
+# Try to import JAX
+try:
+    import jax.numpy as jnp
+    from jax import random, jit, vmap, lax
+    HAS_JAX = True
+except ImportError:
+    import numpy as jnp
+    HAS_JAX = False
+    lax = None
+
+    def random(*args, **kwargs):
+        return None
+
+    def jit(fn):
+        return fn
+
+    def vmap(fn):
+        return fn
+
+    def stop_gradient(x):
+        return x
+
+class VQCompressionMode(Enum):
+    """vector quantization compression modes."""
+    STANDARD = "standard"
+    ADAPTIVE = "adaptive"
+    HIERARCHICAL = "hierarchical"
+    RESIDUAL = "residual"
+    PRODUCT = "product"
+
+@dataclass
+class VQbitConfig:
+    """Configuration for VQbit layer."""
+    
+    # Basic VQ parameters
+    codebook_size: int = 512
+    embedding_dim: int = 64
+    commitment_cost: float = 0.25
+    decay: float = 0.99
+    
+    # Compression settings
+    compression_mode: VQCompressionMode = VQCompressionMode.STANDARD
+    compression_ratio: float = 0.1
+    
+    # Adaptive features
+    enable_adaptive_codebook: bool = True
+    adaptation_rate: float = 0.01
+    
+    # Multi-level quantization
+    num_levels: int = 1
+    level_weights: List[float] = None
+    
+    # Advanced features
+    enable_ema_update: bool = True
+    enable_straight_through: bool = True
+    enable_commitment_loss: bool = True
+    
+    def __post_init__(self):
+        if self.level_weights is None:
+            self.level_weights = [1.0] * self.num_levels
+
+class VQbitLayer:
+    """vector Quantization with bit-level compression layer."""
+    
+    def __init__(self, config: VQbitConfig):
+        self.config = config
+        self.codebook = None
+        self.codebook_usage = None
+        self.initialized = False
+        
+    def _initialize_codebook(self, input_shape: Tuple[int, ...], key: Any = None):
+        """Initialize the codebook."""
+        if HAS_JAX and key is not None:
+            # JAX initialization
+            self.codebook = random.normal(
+                key, 
+                (self.config.codebook_size, self.config.embedding_dim)
+            ) * 0.1
+        else:
+            # Numpy fallback
+            np.random.seed(42)
+            self.codebook = np.random.normal(
+                0, 0.1, 
+                (self.config.codebook_size, self.config.embedding_dim)
+            ).astype(np.float32)
+        
+        # Initialize usage tracking
+        self.codebook_usage = jnp.ones(self.config.codebook_size)
+        self.initialized = True
+    
+    def quantize(self, inputs: Any, key: Any = None) -> Tuple[Any, Dict[str, Any]]:
+        """Quantize input vectors."""
+        if not self.initialized:
+            self._initialize_codebook(inputs.shape, key)
+        
+        # Flatten inputs for quantization
+        input_shape = inputs.shape
+        flat_inputs = inputs.reshape(-1, self.config.embedding_dim)
+        
+        # Compute distances to codebook
+        distances = self._compute_distances(flat_inputs, self.codebook)
+        
+        # Find closest codebook entries
+        encoding_indices = jnp.argmin(distances, axis=1)
+        
+        # Get quantized vectors
+        quantized = self.codebook[encoding_indices]
+        
+        # Reshape back
+        quantized = quantized.reshape(input_shape)
+        
+        # Compute losses
+        stop_grad = lax.stop_gradient if HAS_JAX and lax is not None else stop_gradient
+        commitment_loss = jnp.mean((inputs - stop_grad(quantized)) ** 2)
+        codebook_loss = jnp.mean((stop_grad(inputs) - quantized) ** 2)
+        
+        # Straight-through estimator
+        if self.config.enable_straight_through and HAS_JAX and lax is not None:
+            quantized = inputs + stop_grad(quantized - inputs)
+        
+        # Update codebook usage
+        if self.config.enable_ema_update:
+            self._update_codebook_ema(flat_inputs, encoding_indices)
+        
+        info = {
+            'encoding_indices': encoding_indices.reshape(input_shape[:-1]),
+            'commitment_loss': commitment_loss,
+            'codebook_loss': codebook_loss,
+            'perplexity': self._compute_perplexity(encoding_indices),
+            'codebook_usage': self.codebook_usage
+        }
+        
+        return quantized, info
+    
+    def _compute_distances(self, inputs: Any, codebook: Any) -> Any:
+        """Compute distances between inputs and codebook."""
+        # L2 distance
+        input_norm = jnp.sum(inputs**2, axis=1, keepdims=True)
+        codebook_norm = jnp.sum(codebook**2, axis=1)
+        dot_product = jnp.dot(inputs, codebook.T)
+        
+        distances = input_norm + codebook_norm - 2 * dot_product
+        return distances
+    
+    def _update_codebook_ema(self, inputs: Any, indices: Any):
+        """Update codebook using exponential moving average."""
+        # This would typically be done with proper JAX state management
+        # For now, we'll skip the current update in this mock implementation
+        pass
+    
+    def _compute_perplexity(self, indices: Any) -> float:
+        """Compute perplexity of the encoding distribution."""
+        # Count usage of each codebook entry
+        if HAS_JAX:
+            counts = jnp.bincount(indices, length=self.config.codebook_size)
+        else:
+            counts = jnp.bincount(indices, minlength=self.config.codebook_size)
+        probs = counts / jnp.sum(counts)
+        
+        # Avoid log(0)
+        probs = jnp.where(probs > 0, probs, 1e-10)
+        
+        # Compute perplexity
+        entropy = -jnp.sum(probs * jnp.log(probs))
+        perplexity = jnp.exp(entropy)
+        
+        return float(perplexity)
+    
+    def compress(self, inputs: Any, target_ratio: Optional[float] = None) -> Tuple[Any, Dict[str, Any]]:
+        """Compress inputs using VQ compression."""
+        if target_ratio is None:
+            target_ratio = self.config.compression_ratio
+        
+        # Apply quantization
+        quantized, info = self.quantize(inputs)
+        
+        # Apply compression based on mode
+        if self.config.compression_mode == VQCompressionMode.ADAPTIVE:
+            compressed = self._adaptive_compress(quantized, target_ratio)
+        elif self.config.compression_mode == VQCompressionMode.HIERARCHICAL:
+            compressed = self._hierarchical_compress(quantized, target_ratio)
+        elif self.config.compression_mode == VQCompressionMode.RESIDUAL:
+            compressed = self._residual_compress(inputs, quantized, target_ratio)
+        else:
+            compressed = quantized
+        
+        compression_info = {
+            'compression_ratio': self._compute_compression_ratio(inputs, compressed),
+            'original_size': inputs.size,
+            'compressed_size': compressed.size if hasattr(compressed, 'size') else len(compressed)
+        }
+        
+        info.update(compression_info)
+        return compressed, info
+    
+    def _adaptive_compress(self, quantized: Any, target_ratio: float) -> Any:
+        """Adaptive compression based on importance."""
+        # simple importance-based compression (mock implementation)
+        importance = jnp.abs(quantized)
+        threshold = jnp.percentile(importance, (1 - target_ratio) * 100)
+        compressed = jnp.where(importance > threshold, quantized, 0)
+        return compressed
+    
+    def _hierarchical_compress(self, quantized: Any, target_ratio: float) -> Any:
+        """Hierarchical compression with multiple levels."""
+        # Multi-level quantization using JAX fori_loop for JIT compatibility
+        level_ratio = target_ratio ** (1 / self.config.num_levels)
+
+        if HAS_JAX and lax is not None:
+            # Use lax.fori_loop for JIT compilation
+            def body_fn(_, compressed):
+                return self._adaptive_compress(compressed, level_ratio)
+            return lax.fori_loop(0, self.config.num_levels, body_fn, quantized)
+        else:
+            # Fallback for non-JAX
+            compressed = quantized
+            for _ in range(self.config.num_levels):
+                compressed = self._adaptive_compress(compressed, level_ratio)
+            return compressed
+    
+    def _residual_compress(self, original: Any, quantized: Any, target_ratio: float) -> Any:
+        """Residual compression of quantization error."""
+        residual = original - quantized
+        compressed_residual = self._adaptive_compress(residual, target_ratio)
+        return quantized + compressed_residual
+    
+    def _compute_compression_ratio(self, original: Any, compressed: Any) -> float:
+        """Compute current compression ratio achieved."""
+        if hasattr(compressed, 'size') and hasattr(original, 'size'):
+            return compressed.size / original.size
+        return 1.0
+    
+    def decompress(self, compressed: Any, original_shape: Optional[Tuple[int, ...]] = None) -> Any:
+        """Decompress VQ-compressed data."""
+        # For this mock implementation, just return the compressed data
+        # In a real implementation, this would reconstruct from indices
+        if original_shape is not None and hasattr(compressed, 'reshape'):
+            return compressed.reshape(original_shape)
+        return compressed
+    
+    def get_codebook_stats(self) -> Dict[str, Any]:
+        """Get statistics about the codebook."""
+        if not self.initialized:
+            return {}
+        
+        return {
+            'codebook_size': self.config.codebook_size,
+            'embedding_dim': self.config.embedding_dim,
+            'usage_mean': float(jnp.mean(self.codebook_usage)),
+            'usage_std': float(jnp.std(self.codebook_usage)),
+            'usage_min': float(jnp.min(self.codebook_usage)),
+            'usage_max': float(jnp.max(self.codebook_usage)),
+            'active_entries': int(jnp.sum(self.codebook_usage > 0))
+        }
+
+# Factory functions
+def create_vqbit_layer(
+    codebook_size: int = 512,
+    embedding_dim: int = 64,
+    compression_mode: str = "standard",
+    **kwargs
+) -> VQbitLayer:
+    """Create a VQbit layer with specified configuration."""
+    
+    config = VQbitConfig(
+        codebook_size=codebook_size,
+        embedding_dim=embedding_dim,
+        compression_mode=VQCompressionMode(compression_mode),
+        **kwargs
+    )
+    
+    return VQbitLayer(config)
+
+def create_ultra_vqbit_layer(**kwargs) -> VQbitLayer:
+    """Create an ultra-compressed VQbit layer."""
+    
+    ultra_config = VQbitConfig(
+        codebook_size=1024,
+        embedding_dim=128,
+        compression_mode=VQCompressionMode.HIERARCHICAL,
+        compression_ratio=0.05,
+        enable_adaptive_codebook=True,
+        num_levels=3,
+        **kwargs
+    )
+    
+    return VQbitLayer(ultra_config)
+
+# Utility functions
+if HAS_JAX:
+    quantize_jit = jit(lambda layer, inputs: layer.quantize(inputs))
+    compress_jit = jit(lambda layer, inputs: layer.compress(inputs))
+else:
+    quantize_jit = lambda layer, inputs: layer.quantize(inputs)
+    compress_jit = lambda layer, inputs: layer.compress(inputs)
+
+__all__ = [
+    'VQbitLayer',
+    'VQbitConfig', 
+    'VQCompressionMode',
+    'create_vqbit_layer',
+    'create_ultra_vqbit_layer',
+    'quantize_jit',
+    'compress_jit'
+]


### PR DESCRIPTION
Carpeta eliminada por error en e164e01 'Delete capibara directory'. Contenia ~14.600 lineas de codigo unico en VQ/SSM/mvp_api que NO estaba duplicado en core/ ni sub_models/:

- capibara/vq/ completo (VQBit, VIM-VQ, ARM Axion, orquestador)
- capibara/mvp_api.py
- capibara/ssm/ssm_tpu.py
- capibara/optimizations/tpu_v6e.py (distinto del de core/tpu/)

Solo tres archivos SI tenian duplicado fuera de capibara/:
- self_modifying_router.py (tambien en core/)
- spike_ssm.py (tambien en sub_models/experimental/)
- tpu_v6e.py (tambien en core/tpu/)

Este commit restaura el subtree capibara/ sobre main HEAD.