### PR TITLE
chore(gitignore): unignore .github/ so workflows & templates are tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,8 @@ training/cython_kernels/*.c
 
 # Generated files
 _version.py
-.github/
+# .github/ was previously ignored which silently dropped workflows,
+# dependabot config and issue templates. Tracked again.
 # Benchmark outputs
 benchmark_results/
 


### PR DESCRIPTION
Line 59 of .gitignore had a blanket ".github/" pattern. That silently prevented any NEW file under .github/ (issue templates, dependabot config, additional workflows) from being added by git. Existing workflows (docs.yml, python-app.yml) kept working only because they were already tracked before the ignore was added; they were an accident waiting for a "git add -f" bandaid.

Removing the pattern + short explanatory comment so future contributors do not re-add it.