### PR TITLE
fix(BACKLOG-003): remove simulated execution from services/automation

### DIFF
--- a/services/automation/agent_executor.py
+++ b/services/automation/agent_executor.py
@@ -25,6 +25,14 @@ from .models import (
     ExecutionResult, WorkflowSpec, WorkflowNode
 )
 
+# Optional aiohttp for real HTTP-request nodes. Falls back cleanly when absent.
+try:
+    import aiohttp  # type: ignore
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional runtime dep
+    aiohttp = None  # type: ignore
+    AIOHTTP_AVAILABLE = False
+
 # Import existing Capibara agents
 try:
     from ...agents.capibara_agent import CapibaraTool
@@ -474,33 +482,133 @@ Please execute this node and return the output data.
             return await self._fallback_agent_execution(agent, node_prompt, node_context)
     
     async def _execute_node_standard(
-        self, 
-        node: WorkflowNode, 
+        self,
+        node: WorkflowNode,
         context: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Execute a node in standard n8n mode (simulated)."""
-        # This is a simulation of n8n node execution
-        # In a real implementation, this would interface with the n8n API
-        
-        result = {
+        """Execute a node in standard n8n mode.
+
+        This path is taken when the workflow is not using agent-based or
+        sandbox execution. We replace the previous hard-coded "simulated
+        response" / "Simulated output for <type>" strings with either a real
+        effect (HTTP requests, Set / Webhook pass-through) or an explicit
+        ``status="unsupported"`` marker so the caller knows the node was not
+        actually executed. Nothing is ever fabricated silently.
+        """
+        result: Dict[str, Any] = {
             "node_id": node.id,
             "node_name": node.name,
             "node_type": node.type,
             "executed_at": datetime.utcnow().isoformat(),
             "parameters": node.parameters,
-            "status": "completed"
+            "status": "completed",
         }
-        
-        # Simulate different node behaviors
-        if node.type == "n8n-nodes-base.set":
-            result["data"] = node.parameters
-        elif node.type == "n8n-nodes-base.httpRequest":
-            result["response"] = {"status": 200, "data": "simulated response"}
-        elif node.type == "n8n-nodes-base.webhook":
+
+        node_type = getattr(node.type, "value", node.type)
+
+        if node_type == "n8n-nodes-base.set":
+            # Pass-through: Set nodes materialise their parameters as
+            # the output data. Documented n8n behaviour.
+            result["data"] = dict(node.parameters)
+            return result
+
+        if node_type == "n8n-nodes-base.webhook":
+            # Webhook nodes expose the input payload received from the
+            # triggering caller - no synthetic response.
             result["webhook_data"] = context.get("input_data", {})
-        else:
-            result["output"] = f"Simulated output for {node.type}"
-        
+            return result
+
+        if node_type == "n8n-nodes-base.httpRequest":
+            return await self._execute_http_request_node(node, result)
+
+        # Unknown / unsupported node type: declare it truthfully instead of
+        # returning a fake string. The orchestrator can escalate this to
+        # an agent or fail the workflow.
+        result["status"] = "unsupported"
+        result["error"] = (
+            f"Node type {node_type!r} has no standard-mode executor. "
+            "Route the workflow through AGENT_BASED / HYBRID mode or add "
+            "a dedicated handler."
+        )
+        return result
+
+    async def _execute_http_request_node(
+        self,
+        node: WorkflowNode,
+        result: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Perform a real HTTP request for ``n8n-nodes-base.httpRequest``.
+
+        The n8n schema carries the method/url/headers/body on
+        ``node.parameters``. If any required piece is missing or aiohttp is
+        not installed we mark the node as failed with a descriptive error
+        instead of returning a fake 200 response.
+        """
+        params = node.parameters or {}
+        url = params.get("url") or params.get("uri")
+        method = str(params.get("method", "GET")).upper()
+
+        if not url:
+            result["status"] = "failed"
+            result["error"] = "httpRequest node missing required 'url' parameter"
+            return result
+
+        if not AIOHTTP_AVAILABLE or aiohttp is None:
+            result["status"] = "failed"
+            result["error"] = (
+                "aiohttp not installed - cannot execute real HTTP request "
+                "for httpRequest node. Install with: pip install aiohttp"
+            )
+            return result
+
+        headers = params.get("headers") or params.get("headerParameters") or {}
+        # n8n encodes headers as [{"name": "X", "value": "Y"}] - normalise.
+        if isinstance(headers, list):
+            headers = {
+                entry.get("name", ""): entry.get("value", "")
+                for entry in headers
+                if isinstance(entry, dict) and entry.get("name")
+            }
+
+        body = params.get("body") or params.get("bodyParameters")
+        timeout_s = float(params.get("timeout", 30))
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=timeout_s)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                request_kwargs: Dict[str, Any] = {"headers": headers}
+                if body is not None and method not in ("GET", "HEAD"):
+                    if isinstance(body, (dict, list)):
+                        request_kwargs["json"] = body
+                    else:
+                        request_kwargs["data"] = body
+
+                async with session.request(method, url, **request_kwargs) as response:
+                    content_type = response.headers.get("Content-Type", "")
+                    if "application/json" in content_type.lower():
+                        try:
+                            payload: Any = await response.json(content_type=None)
+                        except Exception:
+                            payload = await response.text()
+                    else:
+                        payload = await response.text()
+
+                    result["response"] = {
+                        "status": response.status,
+                        "headers": dict(response.headers),
+                        "data": payload,
+                        "url": str(response.url),
+                    }
+                    if response.status >= 400:
+                        result["status"] = "failed"
+                        result["error"] = f"HTTP {response.status} from {url}"
+        except asyncio.TimeoutError:
+            result["status"] = "failed"
+            result["error"] = f"HTTP request to {url} timed out after {timeout_s}s"
+        except Exception as exc:  # pragma: no cover - depends on network
+            result["status"] = "failed"
+            result["error"] = f"HTTP request to {url} failed: {exc}"
+
         return result
     
     async def _get_agent_workflow_analysis(
@@ -618,4 +726,4 @@ Please execute this node and return the output data.
         if session_id:
             self._agent_memory.pop(session_id, None)
         else:
-            self._agent_memory.clear()
+            self._agent_memory.clear()

--- a/services/automation/n8n_service.py
+++ b/services/automation/n8n_service.py
@@ -570,39 +570,119 @@ class CapibaraN8nAutomationService:
         input_data: Dict[str, Any],
         session_id: Optional[str]
     ) -> ExecutionResult:
-        """Execute workflow using standard n8n API."""
-        try:
-            # This would execute via n8n API
-            # For now, simulate execution
-            
-            execution_id = f"n8n_{uuid.uuid4().hex[:8]}"
-            start_time = datetime.utcnow()
-            
-            # Simulate processing time
-            await asyncio.sleep(0.1)
-            
+        """Execute workflow using the real n8n REST API.
+
+        Previously this method returned a fabricated success result after
+        ``asyncio.sleep(0.1)``. That hid real connectivity issues with n8n
+        and made the ``workflows_executed`` counters meaningless.
+
+        The new behaviour:
+
+        - If no aiohttp session is configured (aiohttp missing or the
+          service never ran ``startup``), the call fails fast with an
+          explicit ``n8n_api_not_configured`` marker.
+        - Otherwise we create the workflow in n8n (if it is not already
+          registered) and trigger it via
+          ``POST /api/v1/workflows/{id}/execute`` with the provided
+          ``input_data``.
+        - The HTTP status code drives the ``ExecutionResult.status`` field
+          so callers can distinguish transport/API failures from in-
+          workflow failures.
+        """
+        start_time = datetime.utcnow()
+        execution_id = f"n8n_{uuid.uuid4().hex[:8]}"
+
+        if self._http_session is None:
             end_time = datetime.utcnow()
-            duration = (end_time - start_time).total_seconds() * 1000
-            
             return ExecutionResult(
                 workflow_id=workflow_spec.name,
                 execution_id=execution_id,
-                status="success",
-                output_data={"message": "Executed via n8n", "nodes_executed": len(workflow_spec.nodes)},
+                status="failed",
+                output_data={
+                    "reason": "n8n_api_not_configured",
+                    "nodes_executed": 0,
+                },
+                error_message=(
+                    "n8n HTTP session not initialised. Ensure aiohttp is "
+                    "installed and CapibaraN8nAutomationService.startup() has "
+                    "been awaited before executing workflows in standard mode."
+                ),
                 started_at=start_time,
                 finished_at=end_time,
-                duration_ms=int(duration)
+                duration_ms=int((end_time - start_time).total_seconds() * 1000),
             )
-            
-        except Exception as e:
+
+        try:
+            # Make sure the workflow exists on the n8n side - if creation
+            # fails (e.g. because the server rejects the payload) we surface
+            # that as the execution error rather than faking success.
+            n8n_workflow_id = await self._create_n8n_workflow(workflow_spec)
+            if not n8n_workflow_id:
+                end_time = datetime.utcnow()
+                return ExecutionResult(
+                    workflow_id=workflow_spec.name,
+                    execution_id=execution_id,
+                    status="failed",
+                    output_data={"reason": "workflow_registration_failed"},
+                    error_message="Could not create workflow on the n8n server.",
+                    started_at=start_time,
+                    finished_at=end_time,
+                    duration_ms=int((end_time - start_time).total_seconds() * 1000),
+                )
+
+            base_url = self.n8n_config.get("base_url", "").rstrip("/")
+            execute_url = f"{base_url}/api/v1/workflows/{n8n_workflow_id}/execute"
+            payload = {"workflowData": {"input": input_data or {}}}
+
+            async with self._http_session.post(execute_url, json=payload) as response:
+                try:
+                    body = await response.json()
+                except Exception:
+                    body = {"raw": await response.text()}
+
+                end_time = datetime.utcnow()
+                duration = (end_time - start_time).total_seconds() * 1000
+                ok = 200 <= response.status < 300
+
+                return ExecutionResult(
+                    workflow_id=workflow_spec.name,
+                    execution_id=body.get("executionId", execution_id) if isinstance(body, dict) else execution_id,
+                    status="success" if ok else "failed",
+                    output_data={
+                        "n8n_workflow_id": n8n_workflow_id,
+                        "http_status": response.status,
+                        "nodes_executed": len(workflow_spec.nodes),
+                        "response": body,
+                    },
+                    error_message=None if ok else f"n8n API returned HTTP {response.status}",
+                    started_at=start_time,
+                    finished_at=end_time,
+                    duration_ms=int(duration),
+                )
+
+        except asyncio.TimeoutError:
+            end_time = datetime.utcnow()
             return ExecutionResult(
                 workflow_id=workflow_spec.name,
-                execution_id=f"failed_{uuid.uuid4().hex[:8]}",
+                execution_id=execution_id,
                 status="failed",
+                output_data={"reason": "n8n_api_timeout"},
+                error_message="Timed out while calling the n8n execute endpoint.",
+                started_at=start_time,
+                finished_at=end_time,
+                duration_ms=int((end_time - start_time).total_seconds() * 1000),
+            )
+        except Exception as e:
+            end_time = datetime.utcnow()
+            return ExecutionResult(
+                workflow_id=workflow_spec.name,
+                execution_id=execution_id,
+                status="failed",
+                output_data={"reason": "n8n_api_error"},
                 error_message=str(e),
-                started_at=datetime.utcnow(),
-                finished_at=datetime.utcnow(),
-                duration_ms=0
+                started_at=start_time,
+                finished_at=end_time,
+                duration_ms=int((end_time - start_time).total_seconds() * 1000),
             )
     
     async def _create_n8n_workflow(self, workflow_spec: WorkflowSpec) -> Optional[str]:

--- a/tests/integration/test_automation_no_simulation.py
+++ b/tests/integration/test_automation_no_simulation.py
@@ -1,0 +1,202 @@
+"""Non-regression tests for BACKLOG ISSUE-003.
+
+These tests verify that ``services/automation`` no longer returns fabricated
+success results from its "standard" execution paths. Specifically:
+
+- ``AgentExecutor._execute_node_standard`` must not return the hard-coded
+  ``"simulated response"`` / ``f"Simulated output for {node.type}"`` strings,
+  and must delegate real HTTP requests to a dedicated helper.
+- ``CapibaraN8nAutomationService._execute_standard_n8n`` must not fabricate
+  success via ``await asyncio.sleep(0.1)`` + ``"Executed via n8n"``. When the
+  HTTP session is missing it must surface an explicit
+  ``n8n_api_not_configured`` marker; otherwise it must call the real n8n
+  ``/api/v1/workflows/{id}/execute`` endpoint.
+
+These checks run on the source AST instead of importing the module so they
+stay portable across CI runners that do not have FastAPI / aiohttp / torch
+installed.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_EXECUTOR = REPO_ROOT / "services" / "automation" / "agent_executor.py"
+N8N_SERVICE = REPO_ROOT / "services" / "automation" / "n8n_service.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_func(tree: ast.Module, name: str) -> ast.AsyncFunctionDef | ast.FunctionDef:
+    """Return the first (possibly nested) function with the given name."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found in AST")
+
+
+def _source_slice(src: str, node: ast.AST) -> str:
+    lines = src.splitlines(keepends=True)
+    return "".join(lines[node.lineno - 1 : node.end_lineno])
+
+
+def _strip_docstrings(src: str) -> str:
+    stripped = re.sub(r'"""[\s\S]*?"""', "", src)
+    stripped = re.sub(r"'''[\s\S]*?'''", "", stripped)
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Parseability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", [AGENT_EXECUTOR, N8N_SERVICE])
+def test_module_parses(path: Path) -> None:
+    """Both touched modules must still parse cleanly."""
+    assert path.exists(), f"missing file: {path}"
+    ast.parse(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# No forbidden simulation strings in executable code
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN = (
+    "simulated response",
+    "Simulated output for",
+    "Executed via n8n",
+)
+
+
+@pytest.mark.parametrize("path", [AGENT_EXECUTOR, N8N_SERVICE])
+def test_no_live_simulation_strings(path: Path) -> None:
+    """Forbidden placeholder strings must not appear outside docstrings."""
+    src = path.read_text(encoding="utf-8")
+    live = _strip_docstrings(src)
+    offenders = [needle for needle in _FORBIDDEN if needle in live]
+    assert not offenders, (
+        f"{path.name}: live simulation string(s) still present: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AgentExecutor._execute_node_standard replacement logic
+# ---------------------------------------------------------------------------
+
+
+def test_execute_node_standard_has_real_dispatch() -> None:
+    """``_execute_node_standard`` must dispatch to real handlers or emit an
+    explicit ``unsupported`` marker - never a fake ``Simulated output``."""
+    src = AGENT_EXECUTOR.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = _find_func(tree, "_execute_node_standard")
+    body = _source_slice(src, func)
+
+    # Delegates real HTTP to a named helper so the test also catches accidental
+    # revert to an inline simulation.
+    assert "_execute_http_request_node" in body, (
+        "standard-mode executor should delegate httpRequest nodes to "
+        "_execute_http_request_node"
+    )
+    assert '"n8n-nodes-base.set"' in body, "set node branch lost"
+    assert '"n8n-nodes-base.webhook"' in body, "webhook node branch lost"
+    assert '"unsupported"' in body, (
+        "unknown node types must be tagged status='unsupported' instead of "
+        "returning a fake 'Simulated output' string"
+    )
+
+    # No live reference to the old fake payload.
+    stripped = _strip_docstrings(body)
+    assert '"simulated response"' not in stripped
+    assert 'f"Simulated output for' not in stripped
+
+
+def test_http_request_helper_exists_and_uses_aiohttp() -> None:
+    """The HTTP-request helper must be defined and actually use aiohttp."""
+    src = AGENT_EXECUTOR.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = _find_func(tree, "_execute_http_request_node")
+    body = _source_slice(src, func)
+
+    assert "aiohttp.ClientSession" in body, (
+        "_execute_http_request_node should open a real aiohttp ClientSession"
+    )
+    assert "session.request(" in body, (
+        "_execute_http_request_node should issue a real HTTP request"
+    )
+    assert "AIOHTTP_AVAILABLE" in body, (
+        "_execute_http_request_node should guard the aiohttp-missing case"
+    )
+
+    # Module must expose the feature flag (it is set inside a try/except at
+    # import time, so the line is indented by four spaces).
+    assert re.search(r"^\s*AIOHTTP_AVAILABLE\s*=\s*True", src, re.MULTILINE), (
+        "agent_executor.py should set AIOHTTP_AVAILABLE = True when aiohttp "
+        "imports cleanly so callers can decide whether real HTTP is viable"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CapibaraN8nAutomationService._execute_standard_n8n replacement logic
+# ---------------------------------------------------------------------------
+
+
+def test_execute_standard_n8n_no_fake_sleep_success() -> None:
+    """``_execute_standard_n8n`` must no longer return a fake success built
+    around ``asyncio.sleep(0.1)`` + ``Executed via n8n``."""
+    src = N8N_SERVICE.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = _find_func(tree, "_execute_standard_n8n")
+    body = _source_slice(src, func)
+    # Strip docstrings so we only inspect executable code - the new
+    # implementation explains what it replaced and that prose may legitimately
+    # reference the old identifiers.
+    live = _strip_docstrings(body)
+
+    assert "asyncio.sleep(0.1)" not in live, (
+        "fake sleep-based success path still present in _execute_standard_n8n"
+    )
+    assert "Executed via n8n" not in live, (
+        "hard-coded 'Executed via n8n' message still present"
+    )
+
+
+def test_execute_standard_n8n_hits_real_api() -> None:
+    """``_execute_standard_n8n`` must call the real n8n execute endpoint and
+    expose the ``n8n_api_not_configured`` marker when it cannot."""
+    src = N8N_SERVICE.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = _find_func(tree, "_execute_standard_n8n")
+    body = _source_slice(src, func)
+
+    # Real API path: must build an /execute URL and use the aiohttp session.
+    assert "/execute" in body, (
+        "_execute_standard_n8n should target the n8n /execute endpoint"
+    )
+    assert "self._http_session.post" in body, (
+        "_execute_standard_n8n should POST via the aiohttp session"
+    )
+
+    # Fail-fast markers.
+    assert '"n8n_api_not_configured"' in body, (
+        "missing explicit n8n_api_not_configured marker when HTTP session is "
+        "unavailable"
+    )
+    assert '"workflow_registration_failed"' in body, (
+        "missing workflow_registration_failed marker when create step fails"
+    )
+
+    # Status must be derived from the real HTTP response, not hard-coded.
+    assert "response.status" in body, (
+        "status should be derived from response.status, not constants"
+    )


### PR DESCRIPTION
AgentExecutor._execute_node_standard now dispatches real set/webhook/ httpRequest handlers (the last via _execute_http_request_node using aiohttp). Unknown node types return status="unsupported". CapibaraN8nAutomationService._execute_standard_n8n posts to real /api/v1/workflows/{id}/execute; missing HTTP session emits n8n_api_not_configured marker. See BACKLOG-003.

Validation: tests/integration/test_automation_no_simulation.py (8/8).