### PR TITLE
fix(BACKLOG-004): real parameter loading in inference engines

### DIFF
--- a/inference/engines/advanced_quantized_engine.py
+++ b/inference/engines/advanced_quantized_engine.py
@@ -60,6 +60,29 @@ class QuantizedInferenceConfig:
     benchmark_iterations: int = 100
 
 
+
+def _unflatten_param_tree(flat: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn a flat {"layer.sub.weight": arr} dict into a nested dict.
+
+    ``np.load``/``safetensors`` both yield a flat dict. Our consumers
+    (quantizer + attention / MLP kernels) expect a nested structure with
+    ``embedding``, ``transformer_layer_N``, ``output`` groups. This helper
+    splits keys on ``.`` and builds the nested tree; leaves are numpy
+    arrays, so ``astype(np.float32)`` is applied for consistency.
+    """
+    nested: Dict[str, Any] = {}
+    for key, arr in flat.items():
+        parts = key.split(".")
+        cursor = nested
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        value = np.asarray(arr)
+        if value.dtype != np.float32:
+            value = value.astype(np.float32)
+        cursor[parts[-1]] = value
+    return nested
+
+
 class QuantizedInferenceEngine:
     """High-performance quantized inference engine."""
     
@@ -175,38 +198,61 @@ class QuantizedInferenceEngine:
         return await self._dynamic_batched_inference(batch_inputs, batch_masks)
     
     async def _load_model_params(self, model_path: str) -> Dict[str, Any]:
-        """Load model parameters from file."""
-        # Mock implementation - in real scenario, load from checkpoint
-        logger.info(" Loading model parameters...")
-        
-        # Simulate loading different layer types
-        params = {}
-        
-        # Embedding layers
-        params['embedding'] = {
-            'weight': np.random.randn(50000, 768).astype(np.float32)
-        }
-        
-        # Transformer layers
-        for layer_idx in range(12):
-            layer_name = f'transformer_layer_{layer_idx}'
-            params[layer_name] = {
-                'attention_weight': np.random.randn(768, 768).astype(np.float32),
-                'attention_bias': np.random.randn(768).astype(np.float32),
-                'mlp_weight': np.random.randn(768, 3072).astype(np.float32),
-                'mlp_bias': np.random.randn(3072).astype(np.float32),
-                'layer_norm_weight': np.random.randn(768).astype(np.float32),
-                'layer_norm_bias': np.random.randn(768).astype(np.float32)
-            }
-        
-        # Output layer
-        params['output'] = {
-            'weight': np.random.randn(768, 50000).astype(np.float32),
-            'bias': np.random.randn(50000).astype(np.float32)
-        }
-        
-        await asyncio.sleep(0.1)  # Simulate I/O delay
-        return params
+        """Load model parameters from a real checkpoint.
+
+        Supported formats, tried in order:
+
+        - ``<model_path>`` as ``.npz`` (numpy archive, preferred).
+        - ``<model_path>`` as ``.safetensors`` when ``safetensors`` is
+          importable.
+        - ``<model_path>`` as a pickle (only when the caller marks it
+          trusted by passing a ``.pkl`` extension).
+
+        The previous implementation hard-coded a 12-layer transformer with
+        ``np.random.randn(...)`` tensors regardless of the requested path,
+        which meant quantization calibration and inference ran on purely
+        synthetic weights. That fallback has been removed - missing
+        checkpoints now raise ``FileNotFoundError`` so callers can decide
+        whether to download, train, or abort.
+        """
+        logger.info("Loading model parameters from %s", model_path)
+        path = Path(model_path)
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Model checkpoint not found at {model_path!r}. "
+                "Refusing to fabricate random parameters."
+            )
+
+        suffix = path.suffix.lower()
+        if suffix == ".npz":
+            with np.load(path, allow_pickle=False) as archive:
+                params = {name: archive[name] for name in archive.files}
+            return _unflatten_param_tree(params)
+
+        if suffix == ".safetensors":
+            try:
+                from safetensors.numpy import load_file  # type: ignore
+            except ImportError as exc:
+                raise RuntimeError(
+                    "safetensors checkpoint requested but the "
+                    "safetensors package is not installed."
+                ) from exc
+            flat = load_file(str(path))
+            return _unflatten_param_tree(flat)
+
+        if suffix == ".pkl":
+            import pickle
+            logger.warning(
+                "Loading pickle checkpoint %s - ensure trusted source",
+                path,
+            )
+            with open(path, "rb") as f:
+                return pickle.load(f)  # nosec B301 - opt-in by extension
+
+        raise ValueError(
+            f"Unsupported checkpoint format {suffix!r} for {model_path!r}. "
+            "Use .npz, .safetensors or .pkl."
+        )
     
     async def _generate_calibration_data(self) -> np.ndarray:
         """Generate calibration data for quantization."""
@@ -472,9 +518,21 @@ class QuantizedInferenceEngine:
         return 0.5 * x * (1 + np.tanh(np.sqrt(2 / np.pi) * (x + 0.044715 * x**3)))
     
     def _get_memory_usage(self) -> float:
-        """Get current memory usage in MB."""
-        # Mock implementation - in real scenario, measure actual memory usage
-        return 512.0  # MB
+        """Return the current RSS of this process in MB via psutil.
+
+        Returns ``-1.0`` when psutil is not installed so callers can tell
+        real measurements apart from the previous hard-coded ``512.0``
+        placeholder.
+        """
+        try:
+            import psutil  # type: ignore
+        except ImportError:  # pragma: no cover - optional dep
+            return -1.0
+        try:
+            rss_bytes = psutil.Process().memory_info().rss
+        except Exception:  # pragma: no cover - platform edge
+            return -1.0
+        return float(rss_bytes) / (1024.0 * 1024.0)
     
     def get_performance_stats(self) -> Dict[str, Any]:
         """Get comprehensive performance statistics."""

--- a/inference/hybrid_inference_engine.py
+++ b/inference/hybrid_inference_engine.py
@@ -155,34 +155,106 @@ class TPUv6eInferenceEngine:
             raise
     
     def _load_model_params(self):
-        """Load model parameters from checkpoint."""
-        # In a real implementation, this would load from a JAX/Flax checkpoint
-        # For now, we simulate the structure
-        checkpoint_path = Path(self.model_path) / "checkpoint.pkl"
-        if checkpoint_path.exists():
-            logger.warning("Loading pickle checkpoint from %s — ensure trusted source", checkpoint_path)
-            with open(checkpoint_path, 'rb') as f:
-                self.model_params = pickle.load(f)  # nosec B301 — trusted checkpoint
-        else:
-            # Create mock parameters for demo
-            logger.warning("Using mock parameters for demo")
-            self.model_params = {"dummy": jnp.array([1.0])}
+        """Load model parameters from a real JAX/Flax checkpoint.
+
+        The previous behaviour silently fell back to
+        ``{"dummy": jnp.array([1.0])}`` when no checkpoint file was
+        present, which meant downstream generation ran on fabricated
+        parameters without any signal to the caller. We now:
+
+        - Try the documented pickle path (``checkpoint.pkl``).
+        - Try flax.serialization msgpack (``checkpoint.msgpack`` or
+          ``params.msgpack``) when flax is importable.
+        - Try orbax (``checkpoint/`` directory) when orbax is importable.
+        - Raise ``FileNotFoundError`` if none of those are usable. No
+          synthetic fallback is ever returned.
+        """
+        base = Path(self.model_path)
+        pickle_path = base / "checkpoint.pkl"
+        if pickle_path.exists():
+            logger.warning(
+                "Loading pickle checkpoint from %s - ensure trusted source",
+                pickle_path,
+            )
+            with open(pickle_path, "rb") as f:
+                self.model_params = pickle.load(f)  # nosec B301 - trusted checkpoint
+            return
+
+        # Flax msgpack (primary portable format)
+        try:
+            from flax import serialization  # type: ignore
+        except Exception:  # pragma: no cover - optional dep path
+            serialization = None  # type: ignore
+
+        if serialization is not None:
+            for name in ("checkpoint.msgpack", "params.msgpack"):
+                msgpack_path = base / name
+                if msgpack_path.exists():
+                    logger.info("Loading flax msgpack checkpoint from %s", msgpack_path)
+                    with open(msgpack_path, "rb") as f:
+                        self.model_params = serialization.msgpack_restore(f.read())
+                    return
+
+        # Orbax directory checkpoint (modern JAX format)
+        orbax_dir = base / "checkpoint"
+        if orbax_dir.is_dir():
+            try:
+                import orbax.checkpoint as ocp  # type: ignore
+                logger.info("Loading orbax checkpoint from %s", orbax_dir)
+                ckptr = ocp.StandardCheckpointer()
+                self.model_params = ckptr.restore(orbax_dir.resolve())
+                return
+            except Exception as exc:  # pragma: no cover - optional dep path
+                logger.warning("orbax restore failed for %s: %s", orbax_dir, exc)
+
+        # No real checkpoint available. Refuse to fabricate parameters.
+        raise FileNotFoundError(
+            f"No model checkpoint found under {self.model_path!r}. "
+            "Expected one of: checkpoint.pkl, checkpoint.msgpack, "
+              "params.msgpack, or an orbax checkpoint/ directory. "
+            "Aborting instead of returning mock parameters."
+        )
     
     def _compile_generation_function(self):
-        """Compile optimized generation function."""
+        """Compile a real JAX generation step when a Flax module is wired.
+
+        The engine exposes an optional ``self.model_module`` attribute
+        (a Flax ``nn.Module`` callable as ``module.apply(params, input_ids,
+        position)`` and returning logits). If it is present, we JIT-compile
+        the real forward pass. Otherwise we leave
+        ``self.compiled_generate = None`` so the ``generate`` path can
+        fail fast with a clear message instead of producing logits made of
+        ``jnp.ones(...)``.
+        """
+        module = getattr(self, "model_module", None)
+        if module is None or self.model_params is None:
+            self.compiled_generate = None
+            logger.warning(
+                "No Flax model_module attached to %s; generate() will fail "
+                "fast until a real module is provided.",
+                type(self).__name__,
+            )
+            return
+
         @jax.jit
         def generate_step(params, input_ids, position):
-            # Simulation of forward pass
-            # In a real implementation, this would be the complete JAX/Flax model
-            logits = jnp.ones((input_ids.shape[0], input_ids.shape[1], 32000))
-            return logits
-        
+            # Real forward pass: the attached module returns logits.
+            return module.apply(params, input_ids, position)
+
         self.compiled_generate = generate_step
     
     async def generate(self, prompt: str, **kwargs) -> InferenceResult:
         """Generate text using TPU v6e."""
         if not self.loaded:
             self.load_model()
+
+        if self.compiled_generate is None:
+            raise RuntimeError(
+                "TPU inference engine has no compiled generation "
+                "function. Attach a Flax ``model_module`` before "
+                "calling generate(); the previous mock fallback has "
+                "been removed (BACKLOG-004)."
+            )
 
         start_time = time.time()
 
@@ -578,4 +650,4 @@ async def benchmark_backends(prompt: str, model_path: str, rounds: int = 3) -> D
             logger.warning(f"Benchmark failed for {backend.value}: {e}")
             results[backend.value] = {'error': str(e)}
     
-    return results
+    return results

--- a/tests/integration/test_engines_no_mock_params.py
+++ b/tests/integration/test_engines_no_mock_params.py
@@ -1,0 +1,193 @@
+"""Non-regression tests for BACKLOG ISSUE-004.
+
+Verifies that the two production inference engines no longer ship the
+fabricated parameter / forward-pass placeholders documented in ``BACKLOG.md``:
+
+- ``inference/hybrid_inference_engine.py``:
+    * ``_load_model_params`` used to fall back to
+      ``{"dummy": jnp.array([1.0])}`` when no checkpoint file was found.
+    * ``_compile_generation_function`` used to return logits made of
+      ``jnp.ones((batch, seq, 32000))``.
+- ``inference/engines/advanced_quantized_engine.py``:
+    * ``_load_model_params`` built a full 12-layer transformer out of
+      ``np.random.randn(...)`` arrays regardless of ``model_path``.
+    * ``_get_memory_usage`` returned the hard-coded constant ``512.0`` MB.
+
+All checks run on the source AST + regex inspection so the tests remain
+usable on CI environments without torch / flax / psutil installed.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HYBRID = REPO_ROOT / "inference" / "hybrid_inference_engine.py"
+ADVANCED = REPO_ROOT / "inference" / "engines" / "advanced_quantized_engine.py"
+
+
+def _find_func(tree: ast.Module, name: str) -> ast.AsyncFunctionDef | ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found in AST")
+
+
+def _source_slice(src: str, node: ast.AST) -> str:
+    lines = src.splitlines(keepends=True)
+    return "".join(lines[node.lineno - 1 : node.end_lineno])
+
+
+def _strip_docstrings(src: str) -> str:
+    stripped = re.sub(r'"""[\s\S]*?"""', "", src)
+    stripped = re.sub(r"'''[\s\S]*?'''", "", stripped)
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Parseability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", [HYBRID, ADVANCED])
+def test_module_parses(path: Path) -> None:
+    assert path.exists(), f"missing file: {path}"
+    ast.parse(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# hybrid_inference_engine.py
+# ---------------------------------------------------------------------------
+
+
+def test_hybrid_load_model_params_raises_without_checkpoint() -> None:
+    src = HYBRID.read_text(encoding="utf-8")
+    func = _find_func(ast.parse(src), "_load_model_params")
+    body = _source_slice(src, func)
+    live = _strip_docstrings(body)
+
+    # Mock fallback must be gone in executable code.
+    assert 'jnp.array([1.0])' not in live, (
+        "dummy jnp.array([1.0]) fallback still present in _load_model_params"
+    )
+    assert '"dummy"' not in live, "'dummy' key fabrication still present"
+    assert "Using mock parameters" not in live, (
+        "mock-parameter log message still present"
+    )
+    # Must raise FileNotFoundError when nothing loads.
+    assert "raise FileNotFoundError" in live, (
+        "_load_model_params must raise FileNotFoundError when no checkpoint "
+        "is available instead of returning synthetic params"
+    )
+    # Must try the real formats.
+    assert "checkpoint.pkl" in body, "pickle path probe missing"
+    assert "msgpack" in body.lower(), "flax msgpack probe missing"
+    assert "orbax" in body.lower(), "orbax probe missing"
+
+
+def test_hybrid_compile_generation_uses_real_module() -> None:
+    src = HYBRID.read_text(encoding="utf-8")
+    func = _find_func(ast.parse(src), "_compile_generation_function")
+    body = _source_slice(src, func)
+    live = _strip_docstrings(body)
+
+    # The fake ones-logits tensor must be gone from executable code.
+    assert "jnp.ones(" not in live, (
+        "fake jnp.ones logits still produced by _compile_generation_function"
+    )
+    # Must consult a real attached module.
+    assert 'getattr(self, "model_module"' in body, (
+        "compile step should consult a real model_module attribute"
+    )
+    assert "module.apply(" in body, (
+        "compile step should delegate the forward pass to module.apply(...)"
+    )
+    # When no module is attached the engine must refuse to generate.
+    assert "self.compiled_generate = None" in body, (
+        "compile step should leave compiled_generate = None when no real "
+        "module is wired"
+    )
+
+
+def test_hybrid_generate_fails_fast_without_compiled_fn() -> None:
+    src = HYBRID.read_text(encoding="utf-8")
+    func = _find_func(ast.parse(src), "generate")
+    body = _source_slice(src, func)
+
+    assert "compiled_generate is None" in body, (
+        "generate() must fail fast when no compiled function is available "
+        "instead of crashing or producing fake tokens"
+    )
+    assert "BACKLOG-004" in body, (
+        "generate() guard should reference BACKLOG-004 so future readers "
+        "understand the removal"
+    )
+
+
+# ---------------------------------------------------------------------------
+# advanced_quantized_engine.py
+# ---------------------------------------------------------------------------
+
+
+def test_advanced_load_model_params_no_random_weights() -> None:
+    src = ADVANCED.read_text(encoding="utf-8")
+    func = _find_func(ast.parse(src), "_load_model_params")
+    body = _source_slice(src, func)
+    live = _strip_docstrings(body)
+
+    # Forbidden synthetic-weights identifiers.
+    forbidden = [
+        "np.random.randn(50000",
+        "np.random.randn(768",
+        "transformer_layer_",  # only inside the loop that fabricates params
+    ]
+    # transformer_layer_ may legitimately appear elsewhere; we only check the
+    # _load_model_params body.
+    assert "np.random.randn" not in live, (
+        "_load_model_params still fabricates weights via np.random.randn"
+    )
+    assert "transformer_layer_" not in live, (
+        "_load_model_params still hard-codes a 12-layer random transformer"
+    )
+    # Must raise when checkpoint is absent.
+    assert "raise FileNotFoundError" in live
+    # Must accept at least .npz / .safetensors / .pkl branches.
+    assert '".npz"' in body
+    assert '".safetensors"' in body
+    assert '".pkl"' in body
+
+
+def test_advanced_has_unflatten_helper() -> None:
+    src = ADVANCED.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    # module-level helper
+    assert any(
+        isinstance(n, ast.FunctionDef) and n.name == "_unflatten_param_tree"
+        for n in tree.body
+    ), "_unflatten_param_tree module-level helper missing"
+
+
+def test_advanced_get_memory_usage_uses_psutil() -> None:
+    src = ADVANCED.read_text(encoding="utf-8")
+    func = _find_func(ast.parse(src), "_get_memory_usage")
+    body = _source_slice(src, func)
+    live = _strip_docstrings(body)
+
+    assert "return 512.0" not in live, (
+        "_get_memory_usage still returns the hard-coded 512.0 MB placeholder"
+    )
+    assert "psutil" in body, (
+        "_get_memory_usage should query real memory usage via psutil"
+    )
+    assert "memory_info().rss" in body, (
+        "_get_memory_usage should read .memory_info().rss from psutil"
+    )
+    # Explicit sentinel when psutil is unavailable.
+    assert "-1.0" in body, (
+        "_get_memory_usage should return -1.0 when psutil is missing so "
+        "callers can distinguish real measurements from placeholder values"
+    )


### PR DESCRIPTION
hybrid_inference_engine._load_model_params probes pickle/msgpack/orbax and raises FileNotFoundError (no synthetic fallback). _compile_generation_function JITs only when a real Flax nn.Module is attached; otherwise generate() fails fast.
advanced_quantized_engine._load_model_params loads .npz/.safetensors/ .pkl with _unflatten_param_tree helper. _get_memory_usage reads RSS via psutil; returns -1.0 sentinel when psutil unavailable. See BACKLOG-004.

Validation: tests/integration/test_engines_no_mock_params.py (8/8).