### PR TITLE
fix(BACKLOG-005): isolate demo + remove runtime mock lineage

### DIFF
--- a/tests/integration/test_data_lineage_demo_isolated.py
+++ b/tests/integration/test_data_lineage_demo_isolated.py
@@ -1,0 +1,177 @@
+"""Non-regression tests for BACKLOG ISSUE-005.
+
+Verifies that ``training/data_lineage`` no longer ships runtime mocks nor
+leaks module-level logging configuration:
+
+1. ``InferenceSafeParameterController.create_dataset_mask_safe`` must NOT
+   fabricate a lineage of 1/3 of all parameters when a dataset has no
+   registered lineage. It must log a warning and return an empty
+   ``dataset_params`` list.
+2. ``training/data_lineage/demo_traceability_system.py`` must be demo-only:
+   - ``logging.basicConfig`` must not be invoked at module scope (it leaks
+     into every process that imports the package).
+   - The demo CLI must be gated by the ``CAPIBARA_DATA_LINEAGE_DEMO=1``
+     environment variable.
+   - The demo mock class must be private (``_DemoMockModel``) so
+     nothing outside the demo imports it by accident.
+
+These checks run on the source AST and do not import the modules, so they
+remain portable to CI runners lacking jax / aiohttp / torch.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ISPC = REPO_ROOT / "training" / "data_lineage" / "inference_safe_parameter_controller.py"
+DTS = REPO_ROOT / "training" / "data_lineage" / "demo_traceability_system.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_func(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError("function {0!r} not found".format(name))
+
+
+def _source_slice(src, node):
+    lines = src.splitlines(keepends=True)
+    return "".join(lines[node.lineno - 1 : node.end_lineno])
+
+
+def _strip_docstrings(src):
+    stripped = re.sub(r'"""[\s\S]*?"""', "", src)
+    stripped = re.sub(r"'''[\s\S]*?'''", "", stripped)
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Parseability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", [ISPC, DTS])
+def test_module_parses(path):
+    assert path.exists(), "missing file: {0}".format(path)
+    ast.parse(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# 1. inference_safe_parameter_controller: no mock lineage fallback
+# ---------------------------------------------------------------------------
+
+
+def test_create_dataset_mask_safe_has_no_mock_lineage():
+    src = ISPC.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = _find_func(tree, "create_dataset_mask_safe")
+    body = _source_slice(src, func)
+    live = _strip_docstrings(body)
+
+    # Old forbidden comment and code.
+    assert "Create mock lineage for testing" not in live, (
+        "old 'Create mock lineage for testing' comment still present"
+    )
+    assert "all_params[:len(all_params)//3]" not in live, (
+        "fabricated 1/3-of-parameters lineage still present"
+    )
+
+    # New behaviour: warn + empty list + BACKLOG-005 marker.
+    assert "BACKLOG-005" in body, (
+        "create_dataset_mask_safe should reference BACKLOG-005 in the "
+        "replacement comment"
+    )
+    assert "logger.warning" in live, (
+        "missing dataset should emit a logger.warning"
+    )
+    assert "dataset_params = []" in live, (
+        "missing dataset should yield an empty dataset_params list"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. demo_traceability_system: demo-only isolation
+# ---------------------------------------------------------------------------
+
+
+def test_demo_no_module_level_basicConfig():
+    """logging.basicConfig must not run at import time."""
+    src = DTS.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    # Walk top-level statements and reject any direct call to
+    # logging.basicConfig at module scope.
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            call = stmt.value
+            if (
+                isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "logging"
+                and call.func.attr == "basicConfig"
+            ):
+                raise AssertionError(
+                    "logging.basicConfig must not be called at module scope"
+                )
+
+
+def test_demo_has_configure_helper():
+    src = DTS.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = _find_func(tree, "_configure_demo_logging")
+    body = _source_slice(src, func)
+    assert "logging.basicConfig" in body, (
+        "_configure_demo_logging should call logging.basicConfig"
+    )
+
+
+def test_demo_cli_is_env_gated():
+    src = DTS.read_text(encoding="utf-8")
+    # Grab everything after the __main__ guard.
+    marker = 'if __name__ == "__main__":'
+    assert marker in src, "demo missing __main__ guard"
+    tail = src.split(marker, 1)[1]
+
+    assert "CAPIBARA_DATA_LINEAGE_DEMO" in tail, (
+        "demo CLI must be gated by CAPIBARA_DATA_LINEAGE_DEMO env var"
+    )
+    assert "_configure_demo_logging()" in tail, (
+        "demo CLI must configure logging before running"
+    )
+    assert "sys.exit" in tail, (
+        "demo CLI must exit when opt-in env var is missing"
+    )
+
+
+def test_demo_mock_model_is_private():
+    src = DTS.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    names = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef)
+    }
+    assert "_DemoMockModel" in names, (
+        "demo should expose a private _DemoMockModel class (BACKLOG-005)"
+    )
+    assert "MockModel" not in names, (
+        "public 'MockModel' class should be renamed to _DemoMockModel"
+    )
+
+    # No stray references to the old public name (word-boundary check so
+    # _DemoMockModel( is not a false positive).
+    live = _strip_docstrings(src)
+    assert not re.search(r"(?<![A-Za-z0-9_])MockModel\(", live), (
+        "live code still instantiates the old public MockModel"
+    )

--- a/training/data_lineage/demo_traceability_system.py
+++ b/training/data_lineage/demo_traceability_system.py
@@ -25,9 +25,19 @@ from pathlib import Path
 from typing import Dict, List, Any
 import jax.numpy as jnp
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+# BACKLOG-005: this file is a demo-only script. Do NOT configure the root
+# logger at import time - that side-effect leaks into any process that
+# imports the data_lineage package. Logging is configured only inside the
+# CLI entrypoint below.
 logger = logging.getLogger(__name__)
+
+
+def _configure_demo_logging() -> None:
+    """Configure root logging for the demo CLI only."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+    )
 
 try:
     from .blockchain_audit_log import (
@@ -43,8 +53,8 @@ except ImportError:
     logger.warning("️ Full lineage system not available - running mock demo")
     FULL_LINEAGE_AVAILABLE = False
 
-class MockModel:
-    """Mock model for demonstration purposes."""
+class _DemoMockModel:
+    """Private demo mock model (BACKLOG-005: not exported)."""
     
     def __init__(self, size: str = "300M"):
         self.size = size
@@ -90,7 +100,7 @@ class TraceabilitySystemDemo:
         # Initialize components
         self.audit_log = None
         self.parameter_controller = None
-        self.mock_model = MockModel("300M")
+        self.mock_model = _DemoMockModel("300M")
         
         # Demo datasets
         self.demo_datasets = {
@@ -364,4 +374,14 @@ def main():
     asyncio.run(demo.run_complete_demo())
 
 if __name__ == "__main__":
+    import os
+    import sys
+
+    if os.environ.get("CAPIBARA_DATA_LINEAGE_DEMO") != "1":
+        sys.stderr.write(
+            "demo_traceability_system.py is a demo-only script.\n"
+            "Set CAPIBARA_DATA_LINEAGE_DEMO=1 to opt in (BACKLOG-005).\n"
+        )
+        sys.exit(2)
+    _configure_demo_logging()
     main()

--- a/training/data_lineage/inference_safe_parameter_controller.py
+++ b/training/data_lineage/inference_safe_parameter_controller.py
@@ -302,16 +302,15 @@ class InferenceSafeParameterController:
         dataset_params = self.dataset_lineage.get(dataset_id, [])
         
         if not dataset_params:
-            # Create mock lineage for testing
-            all_params = list(self.base_parameters.keys())
-            dataset_params = all_params[:len(all_params)//3]  # Assign 1/3 of parameters
-            self.dataset_lineage[dataset_id] = dataset_params
-            
-            # Update reverse mapping
-            for param in dataset_params:
-                if param not in self.parameter_lineage:
-                    self.parameter_lineage[param] = []
-                self.parameter_lineage[param].append(dataset_id)
+            # BACKLOG-005: do NOT fabricate 1/3 of parameters as a fake lineage.
+            # Returning an empty parameter list makes the caller get an empty mask
+            # so downstream code cannot confuse 'unknown dataset' with 'real lineage'.
+            logger.warning(
+                "No lineage registered for dataset %s - returning empty mask "
+                "(BACKLOG-005: no mock fallback).",
+                dataset_id,
+            )
+            dataset_params = []
         
         # Create safe scale factors
         scale_factors = {}


### PR DESCRIPTION
create_dataset_mask_safe no longer fabricates 1/3 of base_parameters as a fake lineage - emits logger.warning and returns empty list. demo_traceability_system.py moves logging.basicConfig into _configure_demo_logging() called only from __main__. CLI gated by CAPIBARA_DATA_LINEAGE_DEMO=1. MockModel renamed to private _DemoMockModel. See BACKLOG-005.

Validation: tests/integration/test_data_lineage_demo_isolated.py (7/7).