### PR TITLE
feat(special-tokens): verify, plan, uncertain, search, lang, debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ python -m benchmarks run
 
 - `core/`: model/runtime components.
   - `core/think_anywhere/` — Think-Anywhere reasoning module (see below).
+  - `core/special_tokens/` — structured meta-token framework (see below).
 - `training/`: training systems and strategies.
 - `inference/`: inference engines and quantization paths.
 - `data/`: datasets, processing, and loading.
@@ -202,6 +203,75 @@ e_open, e_close = proc.initialize_special_token_embedding(
     tokenizer.get_input_embeddings().weight.detach().numpy(),
     token_ids={"think": t1, "any": t2, "where": t3, "<im_start>": t4, "<im_end>": t5},
 )
+```
+
+## Special-token framework
+
+`core/special_tokens/` generalizes the Think-Anywhere pattern into a reusable
+framework for any structured meta-token type. Each token has semantic-aware
+embedding initialization, a real-time streaming filter, and a global registry.
+
+### Built-in tokens
+
+| Token | strip? | Purpose |
+|---|---|---|
+| `<verify>` / `</verify>` | ✅ | Self-verification: model checks its output before continuing |
+| `<plan>` / `</plan>` | ✅ | Task decomposition: outline algorithm before writing code |
+| `<uncertain>` / `</uncertain>` | ❌ kept | Low-confidence marker: preserved for caller post-processing |
+| `<search>query</search>` | ✅ | On-demand RAG trigger at the exact token position needed |
+| `<lang:XX>` / `</lang>` | ✅ | Inline language switch (gl/pt/es/en/…) |
+| `<debug>` / `</debug>` | ✅ | Error diagnosis before writing a fix |
+
+### Quick usage
+
+```python
+from core.special_tokens import get_registry, SearchTokenHandler, LangTokenProcessor
+
+reg = get_registry()
+print(reg.list_tokens())  # ['verify', 'plan', 'uncertain', 'search', 'lang', 'debug']
+
+# Strip all strippable tokens from a model response
+clean = reg.strip_all(model_output)
+
+# <search> with RAG
+from rag.retriever import Retriever
+handler = SearchTokenHandler(retriever=Retriever(...))
+output = handler.process(model_output)  # <search>q</search> → [Retrieved: …]
+
+# <lang:XX> parsing
+proc = LangTokenProcessor()
+clean, blocks = proc.parse(model_output)
+# blocks = [("gl", "Ola mundo"), ("pt", "Olá mundo")]
+```
+
+### Inference integration
+
+`InferenceConfig.strip_special_tokens=True` (default) wires the registry into
+the inference engine — all strip tokens are removed from `generate()` output.
+`<uncertain>` is intentionally preserved so callers can detect low-confidence spans.
+
+```python
+from inference.hybrid_inference_engine import InferenceConfig, InferenceBackend
+
+config = InferenceConfig(
+    backend=InferenceBackend.AUTO,
+    think_anywhere_mode=True,     # strips <think> / <thinkanywhere>
+    strip_special_tokens=True,    # strips verify/plan/search/lang/debug
+)
+```
+
+### Adding a custom token
+
+```python
+from core.special_tokens import SpecialTokenConfig, register_token
+
+register_token(SpecialTokenConfig(
+    name="cite",
+    open_tag="<cite>",
+    close_tag="</cite>",
+    seed_tokens=["source", "reference", "citation"],
+    strip_from_output=False,  # keep citations in output
+))
 ```
 
 ## Limitations

--- a/core/special_tokens/__init__.py
+++ b/core/special_tokens/__init__.py
@@ -1,0 +1,39 @@
+"""
+Special-token framework for CapibaraGPT.
+
+Generalizes the Think-Anywhere pattern (arXiv:2603.29957) to support
+any number of structured meta-token types with:
+- semantic-aware embedding initialization
+- real-time streaming suppression
+- parse / strip / batch processing
+- global registry
+
+Token types registered on import:
+  verify, plan, uncertain, search, lang, debug
+"""
+
+from .base import SpecialTokenConfig, SpecialTokenProcessor, SpecialTokenStreamFilter, ParseResult
+from .registry import SpecialTokenRegistry, get_registry, register_token
+
+# Register all built-in token types
+from . import verify   # noqa: F401
+from . import plan     # noqa: F401
+from . import uncertain  # noqa: F401
+from . import search   # noqa: F401
+from . import lang     # noqa: F401
+from . import debug    # noqa: F401
+
+from .search import SearchTokenHandler
+from .lang import LangTokenProcessor
+
+__all__ = [
+    "SpecialTokenConfig",
+    "SpecialTokenProcessor",
+    "SpecialTokenStreamFilter",
+    "ParseResult",
+    "SpecialTokenRegistry",
+    "get_registry",
+    "register_token",
+    "SearchTokenHandler",
+    "LangTokenProcessor",
+]

--- a/core/special_tokens/base.py
+++ b/core/special_tokens/base.py
@@ -1,0 +1,148 @@
+"""
+Base classes for the special-token framework.
+
+Pattern mirrors Think-Anywhere (arXiv:2603.29957): each token type has
+a config, a processor (parse / strip / embedding-init), and a streaming
+filter that suppresses blocks in real-time without buffering the full response.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+try:
+    import numpy as np
+    _NP = True
+except ImportError:
+    _NP = False
+
+
+@dataclass
+class SpecialTokenConfig:
+    """Configuration for one special-token type."""
+    name: str
+    open_tag: str
+    close_tag: str
+    seed_tokens: List[str]
+    alpha: float = 0.5
+    boundary_token: str = "<im_start>"
+    strip_from_output: bool = True
+    description: str = ""
+
+
+@dataclass
+class ParseResult:
+    clean_text: str
+    blocks: List[str]
+
+    @property
+    def block_count(self) -> int:
+        return len(self.blocks)
+
+
+class SpecialTokenProcessor:
+    """Parse, strip, and embedding-initialize for a single token type."""
+
+    def __init__(self, config: SpecialTokenConfig) -> None:
+        self.config = config
+        open_esc = re.escape(config.open_tag)
+        close_esc = re.escape(config.close_tag)
+        self._pattern = re.compile(f"{open_esc}(.*?){close_esc}", re.DOTALL)
+
+    def parse(self, text: str) -> ParseResult:
+        blocks = self._pattern.findall(text)
+        clean = self._pattern.sub("", text).strip()
+        return ParseResult(clean_text=clean, blocks=blocks)
+
+    def strip(self, text: str) -> str:
+        return self._pattern.sub("", text).strip()
+
+    def initialize_embedding(
+        self,
+        embedding_matrix: "np.ndarray",
+        token_ids: dict,
+    ) -> "np.ndarray":
+        """Semantic-aware embedding init (Eqs. 5-6 from arXiv:2603.29957)."""
+        if not _NP:
+            raise ImportError("numpy required for embedding initialization")
+
+        seed_ids = [token_ids[t] for t in self.config.seed_tokens if t in token_ids]
+        if not seed_ids:
+            return embedding_matrix[0].copy()
+
+        semantic = embedding_matrix[seed_ids].mean(axis=0)
+        boundary_id = token_ids.get(self.config.boundary_token)
+        if boundary_id is not None:
+            boundary = embedding_matrix[boundary_id]
+            return self.config.alpha * semantic + (1.0 - self.config.alpha) * boundary
+        return semantic
+
+
+class SpecialTokenStreamFilter:
+    """
+    Real-time streaming filter for a single special-token type.
+
+    Suppresses open_tag…close_tag blocks token-by-token without buffering
+    the full response. Handles partial tags at chunk boundaries.
+    """
+
+    def __init__(self, config: SpecialTokenConfig) -> None:
+        self._open_tags = [config.open_tag]
+        self._close_tags = [config.close_tag]
+        self._max_open_len = max(len(t) for t in self._open_tags)
+        self._buf = ""
+        self._depth = 0
+
+    def feed(self, token: str) -> str:
+        self._buf += token
+        out: List[str] = []
+
+        while True:
+            if self._depth == 0:
+                earliest, earliest_tag = self._find_earliest(self._open_tags)
+                if earliest != -1:
+                    out.append(self._buf[:earliest])
+                    self._buf = self._buf[earliest + len(earliest_tag):]
+                    self._depth += 1
+                else:
+                    boundary = self._safe_boundary()
+                    out.append(self._buf[:boundary])
+                    self._buf = self._buf[boundary:]
+                    break
+            else:
+                earliest, earliest_tag = self._find_earliest(self._close_tags)
+                if earliest != -1:
+                    self._buf = self._buf[earliest + len(earliest_tag):]
+                    self._depth -= 1
+                else:
+                    break
+
+        return "".join(out)
+
+    def flush(self) -> str:
+        if self._depth == 0:
+            out = self._buf
+            self._buf = ""
+            return out
+        self._buf = ""
+        self._depth = 0
+        return ""
+
+    def _find_earliest(self, tags: List[str]):
+        earliest, earliest_tag = -1, ""
+        for tag in tags:
+            pos = self._buf.find(tag)
+            if pos != -1 and (earliest == -1 or pos < earliest):
+                earliest, earliest_tag = pos, tag
+        return earliest, earliest_tag
+
+    def _safe_boundary(self) -> int:
+        buf = self._buf
+        for suffix_len in range(min(self._max_open_len - 1, len(buf)), 0, -1):
+            suffix = buf[len(buf) - suffix_len:]
+            for tag in self._open_tags:
+                if tag.startswith(suffix):
+                    return len(buf) - suffix_len
+        return len(buf)

--- a/core/special_tokens/debug.py
+++ b/core/special_tokens/debug.py
@@ -1,0 +1,29 @@
+"""
+<debug> / </debug> — code-debugging reasoning blocks.
+
+The model inserts a <debug> block when it detects that previously
+generated code might be wrong — diagnosing the error (wrong index,
+off-by-one, missing edge case) before writing the corrected version.
+
+Complements <verify> (which checks correctness proactively) by
+addressing already-suspected errors reactively.
+
+Seed tokens: "error", "trace", "why", "bug", "fix", "wrong"
+Stripped from final output (strip_from_output=True).
+"""
+
+from .base import SpecialTokenConfig
+from .registry import register_token
+
+DEBUG_TOKEN = SpecialTokenConfig(
+    name="debug",
+    open_tag="<debug>",
+    close_tag="</debug>",
+    seed_tokens=["error", "trace", "why", "bug", "fix", "wrong"],
+    alpha=0.5,
+    boundary_token="<im_start>",
+    strip_from_output=True,
+    description="Debug reasoning block: model diagnoses why code is wrong before fixing it",
+)
+
+register_token(DEBUG_TOKEN)

--- a/core/special_tokens/lang.py
+++ b/core/special_tokens/lang.py
@@ -65,17 +65,23 @@ class LangTokenStreamFilter(SpecialTokenStreamFilter):
     """
     Streaming filter for <lang:XX>…</lang> with variable open tags.
 
-    Overrides _find_earliest to detect any <lang:??> opener dynamically
-    using a regex scan instead of exact string match.
+    Uses regex instead of exact string matching to handle the dynamic
+    language-code portion of the opener (<lang:gl>, <lang:pt>, …).
+    _safe_boundary_lang holds back any buffer suffix that could be the
+    start of a <lang:XX> tag, including the variable lang-code chars.
     """
 
     _OPEN_RE = re.compile(r"<lang:[a-z]{2,3}>", re.IGNORECASE)
+    # Matches any suffix that could be a partial <lang:XX> opener
+    _PARTIAL_RE = re.compile(
+        r"<(?:l(?:a(?:n(?:g(?::(?:[a-z]{0,3}>?)?)?)?)?)?)?$",
+        re.IGNORECASE,
+    )
 
     def __init__(self) -> None:
         super().__init__(LANG_TOKEN)
-        # Override: open tags are variable so we use regex in feed()
-        self._open_tags = []  # disable base class exact matching
-        self._max_open_len = 12  # len("<lang:XXX>") = 10, leave margin
+        self._open_tags = []   # disable base class exact matching
+        self._max_open_len = 12
 
     def feed(self, token: str) -> str:
         self._buf += token
@@ -105,9 +111,5 @@ class LangTokenStreamFilter(SpecialTokenStreamFilter):
 
     def _safe_boundary_lang(self) -> int:
         """Hold back any suffix that could be the start of <lang:XX>."""
-        buf = self._buf
-        prefix = "<lang:"
-        for suffix_len in range(min(len(prefix), len(buf)), 0, -1):
-            if prefix.startswith(buf[len(buf) - suffix_len:].lower()):
-                return len(buf) - suffix_len
-        return len(buf)
+        m = self._PARTIAL_RE.search(self._buf)
+        return m.start() if m else len(self._buf)

--- a/core/special_tokens/lang.py
+++ b/core/special_tokens/lang.py
@@ -1,0 +1,113 @@
+"""
+<lang:XX> / </lang> — inline language-switching blocks.
+
+The model inserts <lang:gl>…</lang> (or pt, es, en, …) to reason
+internally in a different language — useful for low-resource models
+like CUNCA-Hybrid where Galician reasoning may be more accurate than
+English reasoning for certain domains.
+
+The tag is dynamic: the language code is embedded in the opening tag.
+LangTokenStreamFilter handles partial-tag detection for the variable
+<lang:XX> opener.
+
+Seed tokens: "language", "translate", "speak", "text", "lingua"
+Stripped from final output (strip_from_output=True).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+from .base import SpecialTokenConfig, SpecialTokenStreamFilter
+from .registry import register_token
+
+# Base config used for registry + embedding init of the generic <lang:XX> token.
+LANG_TOKEN = SpecialTokenConfig(
+    name="lang",
+    open_tag="<lang:XX>",
+    close_tag="</lang>",
+    seed_tokens=["language", "translate", "speak", "text", "lingua"],
+    alpha=0.5,
+    boundary_token="<im_start>",
+    strip_from_output=True,
+    description="Language-switching block: inline reasoning in a different language",
+)
+
+register_token(LANG_TOKEN)
+
+_FULL_PATTERN = re.compile(
+    r"<lang:([a-z]{2,3})>(.*?)</lang>", re.DOTALL | re.IGNORECASE
+)
+_OPEN_PATTERN = re.compile(r"<lang:([a-z]{2,3})>", re.IGNORECASE)
+
+
+class LangTokenProcessor:
+    """Parser for dynamic <lang:XX>…</lang> blocks."""
+
+    def parse(self, text: str) -> Tuple[str, List[Tuple[str, str]]]:
+        """Return (clean_text, [(lang_code, block_content), …])."""
+        blocks = [(m.group(1).lower(), m.group(2).strip()) for m in _FULL_PATTERN.finditer(text)]
+        clean = _FULL_PATTERN.sub("", text).strip()
+        return clean, blocks
+
+    def strip(self, text: str) -> str:
+        return _FULL_PATTERN.sub("", text).strip()
+
+    def get_languages_used(self, text: str) -> List[str]:
+        return [m.group(1).lower() for m in _OPEN_PATTERN.finditer(text)]
+
+    def has_lang_block(self, text: str, lang_code: str) -> bool:
+        return any(code == lang_code.lower() for code, _ in self.parse(text)[1])
+
+
+class LangTokenStreamFilter(SpecialTokenStreamFilter):
+    """
+    Streaming filter for <lang:XX>…</lang> with variable open tags.
+
+    Overrides _find_earliest to detect any <lang:??> opener dynamically
+    using a regex scan instead of exact string match.
+    """
+
+    _OPEN_RE = re.compile(r"<lang:[a-z]{2,3}>", re.IGNORECASE)
+
+    def __init__(self) -> None:
+        super().__init__(LANG_TOKEN)
+        # Override: open tags are variable so we use regex in feed()
+        self._open_tags = []  # disable base class exact matching
+        self._max_open_len = 12  # len("<lang:XXX>") = 10, leave margin
+
+    def feed(self, token: str) -> str:
+        self._buf += token
+        out: List[str] = []
+
+        while True:
+            if self._depth == 0:
+                m = self._OPEN_RE.search(self._buf)
+                if m:
+                    out.append(self._buf[:m.start()])
+                    self._buf = self._buf[m.end():]
+                    self._depth += 1
+                else:
+                    boundary = self._safe_boundary_lang()
+                    out.append(self._buf[:boundary])
+                    self._buf = self._buf[boundary:]
+                    break
+            else:
+                pos = self._buf.find("</lang>")
+                if pos != -1:
+                    self._buf = self._buf[pos + len("</lang>"):]
+                    self._depth -= 1
+                else:
+                    break
+
+        return "".join(out)
+
+    def _safe_boundary_lang(self) -> int:
+        """Hold back any suffix that could be the start of <lang:XX>."""
+        buf = self._buf
+        prefix = "<lang:"
+        for suffix_len in range(min(len(prefix), len(buf)), 0, -1):
+            if prefix.startswith(buf[len(buf) - suffix_len:].lower()):
+                return len(buf) - suffix_len
+        return len(buf)

--- a/core/special_tokens/plan.py
+++ b/core/special_tokens/plan.py
@@ -1,0 +1,26 @@
+"""
+<plan> / </plan> — structured task-decomposition blocks.
+
+The model inserts a <plan> block before tackling a multi-step problem —
+outlining the approach (data structures, algorithm, edge cases) before
+writing any code. Analogous to chain-of-thought but position-flexible.
+
+Seed tokens: "step", "outline", "first", "plan", "approach"
+Stripped from final output (strip_from_output=True).
+"""
+
+from .base import SpecialTokenConfig
+from .registry import register_token
+
+PLAN_TOKEN = SpecialTokenConfig(
+    name="plan",
+    open_tag="<plan>",
+    close_tag="</plan>",
+    seed_tokens=["step", "outline", "first", "plan", "approach"],
+    alpha=0.5,
+    boundary_token="<im_start>",
+    strip_from_output=True,
+    description="Planning block: structured task decomposition before multi-step generation",
+)
+
+register_token(PLAN_TOKEN)

--- a/core/special_tokens/registry.py
+++ b/core/special_tokens/registry.py
@@ -1,0 +1,51 @@
+"""Global registry for special-token configurations."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .base import SpecialTokenConfig, SpecialTokenProcessor, SpecialTokenStreamFilter
+
+
+class SpecialTokenRegistry:
+    def __init__(self) -> None:
+        self._configs: Dict[str, SpecialTokenConfig] = {}
+        self._processors: Dict[str, SpecialTokenProcessor] = {}
+
+    def register(self, config: SpecialTokenConfig) -> None:
+        self._configs[config.name] = config
+        self._processors[config.name] = SpecialTokenProcessor(config)
+
+    def get_config(self, name: str) -> SpecialTokenConfig:
+        if name not in self._configs:
+            raise KeyError(f"Token '{name}' not registered. Available: {self.list_tokens()}")
+        return self._configs[name]
+
+    def get_processor(self, name: str) -> SpecialTokenProcessor:
+        if name not in self._processors:
+            raise KeyError(f"Token '{name}' not registered.")
+        return self._processors[name]
+
+    def get_stream_filter(self, name: str) -> SpecialTokenStreamFilter:
+        return SpecialTokenStreamFilter(self.get_config(name))
+
+    def list_tokens(self) -> List[str]:
+        return list(self._configs.keys())
+
+    def strip_all(self, text: str) -> str:
+        """Strip all registered tokens that have strip_from_output=True."""
+        for proc in self._processors.values():
+            if proc.config.strip_from_output:
+                text = proc.strip(text)
+        return text
+
+
+_registry = SpecialTokenRegistry()
+
+
+def get_registry() -> SpecialTokenRegistry:
+    return _registry
+
+
+def register_token(config: SpecialTokenConfig) -> None:
+    _registry.register(config)

--- a/core/special_tokens/search.py
+++ b/core/special_tokens/search.py
@@ -1,0 +1,82 @@
+"""
+<search> / </search> — on-demand RAG trigger.
+
+The model inserts <search>query</search> at the exact token position
+where it needs external knowledge — instead of retrieving context
+blindly at the start of every request.
+
+SearchTokenHandler integrates with rag.retriever.Retriever:
+  - parses all <search> blocks from generated text
+  - queries the retriever for each block's content
+  - replaces the block with [Retrieved: …] context inline
+  - strips the tags from the final output
+
+Seed tokens: "find", "lookup", "retrieve", "search", "query"
+Stripped from final output (strip_from_output=True).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Optional, Tuple
+
+from .base import SpecialTokenConfig, SpecialTokenProcessor
+from .registry import register_token
+
+SEARCH_TOKEN = SpecialTokenConfig(
+    name="search",
+    open_tag="<search>",
+    close_tag="</search>",
+    seed_tokens=["find", "lookup", "retrieve", "search", "query"],
+    alpha=0.5,
+    boundary_token="<im_start>",
+    strip_from_output=True,
+    description="Search/retrieval trigger: signals where the model needs external knowledge",
+)
+
+register_token(SEARCH_TOKEN)
+
+_FULL_PATTERN = re.compile(
+    re.escape(SEARCH_TOKEN.open_tag) + r"(.*?)" + re.escape(SEARCH_TOKEN.close_tag),
+    re.DOTALL,
+)
+
+
+class SearchTokenHandler:
+    """
+    Replace <search>query</search> blocks with retrieved context.
+
+    If no retriever is provided the blocks are simply stripped.
+    """
+
+    def __init__(self, retriever: Optional[Any] = None) -> None:
+        self._retriever = retriever
+        self._proc = SpecialTokenProcessor(SEARCH_TOKEN)
+
+    def process(self, text: str) -> str:
+        """
+        Replace each <search> block inline with retrieved context,
+        or strip the block if no retriever is configured.
+        """
+        if self._retriever is None:
+            return self._proc.strip(text)
+
+        def _replace(match: re.Match) -> str:
+            query = match.group(1).strip()
+            try:
+                results = self._retriever.retrieve(query)
+                if results:
+                    ctx = results[0] if isinstance(results, list) else results
+                    return f"[Retrieved: {ctx}]"
+            except Exception:
+                pass
+            return ""
+
+        return _FULL_PATTERN.sub(_replace, text).strip()
+
+    def extract_queries(self, text: str) -> List[str]:
+        """Return all query strings inside <search> blocks."""
+        return [m.strip() for m in _FULL_PATTERN.findall(text)]
+
+    def count_searches(self, text: str) -> int:
+        return len(_FULL_PATTERN.findall(text))

--- a/core/special_tokens/uncertain.py
+++ b/core/special_tokens/uncertain.py
@@ -1,0 +1,48 @@
+"""
+<uncertain> / </uncertain> — low-confidence region markers.
+
+Unlike the other tokens, <uncertain> blocks are NOT stripped from output
+by default (strip_from_output=False). They are preserved as structured
+metadata so callers can detect where the model is unsure and apply
+post-processing (e.g. highlight, re-sample, flag for human review).
+
+Seed tokens: "maybe", "unclear", "unsure", "perhaps", "might"
+Kept in final output (strip_from_output=False).
+"""
+
+from .base import SpecialTokenConfig, SpecialTokenProcessor, ParseResult
+from .registry import register_token
+
+UNCERTAIN_TOKEN = SpecialTokenConfig(
+    name="uncertain",
+    open_tag="<uncertain>",
+    close_tag="</uncertain>",
+    seed_tokens=["maybe", "unclear", "unsure", "perhaps", "might"],
+    alpha=0.5,
+    boundary_token="<im_end>",
+    strip_from_output=False,
+    description="Uncertainty marker: flags low-confidence regions; kept in output as metadata",
+)
+
+register_token(UNCERTAIN_TOKEN)
+
+
+class UncertainTokenExtractor:
+    """Extract uncertainty markers and the text they wrap."""
+
+    def __init__(self) -> None:
+        self._proc = SpecialTokenProcessor(UNCERTAIN_TOKEN)
+
+    def extract(self, text: str) -> ParseResult:
+        """Return (text_with_markers_intact, list_of_uncertain_spans)."""
+        return self._proc.parse(text)
+
+    def has_uncertainty(self, text: str) -> bool:
+        return UNCERTAIN_TOKEN.open_tag in text
+
+    def strip_markers(self, text: str) -> str:
+        """Remove tags but keep the wrapped text."""
+        import re
+        text = re.sub(re.escape(UNCERTAIN_TOKEN.open_tag), "", text)
+        text = re.sub(re.escape(UNCERTAIN_TOKEN.close_tag), "", text)
+        return text

--- a/core/special_tokens/verify.py
+++ b/core/special_tokens/verify.py
@@ -1,0 +1,26 @@
+"""
+<verify> / </verify> — self-verification blocks.
+
+The model inserts a <verify> block at any point to check its own
+output before continuing — e.g. confirming that a function's logic
+is correct before writing the next statement.
+
+Seed tokens: "check", "assert", "confirm", "correct", "valid"
+Stripped from final output (strip_from_output=True).
+"""
+
+from .base import SpecialTokenConfig
+from .registry import register_token
+
+VERIFY_TOKEN = SpecialTokenConfig(
+    name="verify",
+    open_tag="<verify>",
+    close_tag="</verify>",
+    seed_tokens=["check", "assert", "confirm", "correct", "valid"],
+    alpha=0.5,
+    boundary_token="<im_start>",
+    strip_from_output=True,
+    description="Self-verification block: model checks its own output before continuing",
+)
+
+register_token(VERIFY_TOKEN)

--- a/inference/hybrid_inference_engine.py
+++ b/inference/hybrid_inference_engine.py
@@ -66,6 +66,15 @@ except Exception:
     _ThinkStreamFilter = None  # type: ignore[assignment,misc]
     THINK_ANYWHERE_AVAILABLE = False
 
+# Special-token registry (verify/plan/uncertain/search/lang/debug)
+try:
+    from core.special_tokens import get_registry as _get_special_token_registry
+    _SPECIAL_TOKEN_REGISTRY = _get_special_token_registry()
+    SPECIAL_TOKENS_AVAILABLE = True
+except Exception:
+    _SPECIAL_TOKEN_REGISTRY = None  # type: ignore[assignment]
+    SPECIAL_TOKENS_AVAILABLE = False
+
 
 # Maps model_scale strings saved in CheckpointMetadata to TPUOptimizedSSM hidden_size.
 _SCALE_REGISTRY: dict = {
@@ -108,6 +117,11 @@ class InferenceConfig:
     # <think> and <thinkanywhere> blocks from the final output so callers
     # receive only the clean executable code / answer.
     think_anywhere_mode: bool = False
+
+    # Special-token stripping: when True, all registered meta-tokens with
+    # strip_from_output=True (verify/plan/search/lang/debug) are removed
+    # from the final output. Does not affect <uncertain> (kept by design).
+    strip_special_tokens: bool = True
 
 @dataclass
 class InferenceResult:
@@ -366,6 +380,10 @@ class TPUv6eInferenceEngine:
         # Strip Think-Anywhere thinking blocks when mode is enabled
         if self.config.think_anywhere_mode and THINK_ANYWHERE_AVAILABLE:
             generated_text = _TA_PROCESSOR.strip_thinking(generated_text)
+
+        # Strip registered special-token blocks (verify/plan/search/lang/debug)
+        if self.config.strip_special_tokens and SPECIAL_TOKENS_AVAILABLE:
+            generated_text = _SPECIAL_TOKEN_REGISTRY.strip_all(generated_text)
 
         end_time = time.time()
         time_taken = end_time - start_time

--- a/tests/unit/test_special_tokens.py
+++ b/tests/unit/test_special_tokens.py
@@ -1,0 +1,335 @@
+"""Tests for core/special_tokens — one test class per token type."""
+
+import pytest
+from core.special_tokens import (
+    get_registry,
+    SpecialTokenProcessor,
+    SpecialTokenStreamFilter,
+    ParseResult,
+    SearchTokenHandler,
+    LangTokenProcessor,
+)
+from core.special_tokens.base import SpecialTokenConfig
+from core.special_tokens.uncertain import UncertainTokenExtractor
+from core.special_tokens.lang import LangTokenStreamFilter
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    def test_all_tokens_registered(self):
+        reg = get_registry()
+        for name in ("verify", "plan", "uncertain", "search", "lang", "debug"):
+            assert name in reg.list_tokens()
+
+    def test_get_config_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_registry().get_config("nonexistent")
+
+    def test_strip_all_removes_strip_tokens(self):
+        reg = get_registry()
+        text = "<verify>ok</verify>hello<plan>step1</plan>world<debug>why</debug>"
+        result = reg.strip_all(text)
+        assert "hello" in result and "world" in result
+        assert "<verify>" not in result
+        assert "<plan>" not in result
+        assert "<debug>" not in result
+
+    def test_strip_all_keeps_uncertain(self):
+        reg = get_registry()
+        text = "maybe <uncertain>this part</uncertain> is wrong"
+        result = reg.strip_all(result := text)
+        assert "<uncertain>" in result   # uncertain has strip_from_output=False
+
+
+# ---------------------------------------------------------------------------
+# Base processor
+# ---------------------------------------------------------------------------
+
+class TestSpecialTokenProcessor:
+    def _make(self, name, open_tag, close_tag):
+        cfg = SpecialTokenConfig(
+            name=name, open_tag=open_tag, close_tag=close_tag,
+            seed_tokens=["foo"], strip_from_output=True,
+        )
+        return SpecialTokenProcessor(cfg)
+
+    def test_parse_extracts_blocks(self):
+        proc = self._make("x", "<x>", "</x>")
+        result = proc.parse("hello <x>block1</x> world <x>block2</x>")
+        assert result.clean_text == "hello  world"
+        assert result.blocks == ["block1", "block2"]
+        assert result.block_count == 2
+
+    def test_parse_no_blocks(self):
+        proc = self._make("x", "<x>", "</x>")
+        result = proc.parse("plain text")
+        assert result.clean_text == "plain text"
+        assert result.blocks == []
+
+    def test_strip(self):
+        proc = self._make("x", "<x>", "</x>")
+        assert proc.strip("pre<x>inner</x>post") == "prepost"
+
+    def test_multiline_block(self):
+        proc = self._make("x", "<x>", "</x>")
+        result = proc.parse("<x>\nline1\nline2\n</x>after")
+        assert "line1" in result.blocks[0]
+        assert result.clean_text == "after"
+
+
+# ---------------------------------------------------------------------------
+# Streaming filter
+# ---------------------------------------------------------------------------
+
+class TestSpecialTokenStreamFilter:
+    def _filter_for(self, name, open_tag, close_tag):
+        cfg = SpecialTokenConfig(
+            name=name, open_tag=open_tag, close_tag=close_tag,
+            seed_tokens=[], strip_from_output=True,
+        )
+        return SpecialTokenStreamFilter(cfg)
+
+    def _feed_all(self, f, tokens):
+        return "".join(f.feed(t) for t in tokens) + f.flush()
+
+    def test_passthrough_no_tags(self):
+        f = self._filter_for("v", "<verify>", "</verify>")
+        assert self._feed_all(f, ["hello", " world"]) == "hello world"
+
+    def test_strips_complete_block(self):
+        f = self._filter_for("v", "<verify>", "</verify>")
+        tokens = list("pre<verify>inner</verify>post")
+        assert self._feed_all(f, tokens) == "prepost"
+
+    def test_partial_tag_held(self):
+        f = self._filter_for("v", "<verify>", "</verify>")
+        out = f.feed("<veri")
+        assert out == ""  # partial open tag held in buffer
+
+    def test_partial_tag_completes(self):
+        f = self._filter_for("v", "<verify>", "</verify>")
+        f.feed("<veri")
+        f.feed("fy>inner</verify>")
+        assert f.flush() == ""  # block stripped
+
+    def test_flush_yields_partial_tag_buffer(self):
+        f = self._filter_for("v", "<verify>", "</verify>")
+        out = f.feed("<veri")
+        assert out == ""        # held back: could be start of <verify>
+        assert f.flush() == "<veri"  # not a complete tag, released on flush
+
+    def test_unclosed_block_discarded_on_flush(self):
+        f = self._filter_for("v", "<verify>", "</verify>")
+        f.feed("<verify>unclosed content")
+        assert f.flush() == ""
+
+
+# ---------------------------------------------------------------------------
+# <verify> token
+# ---------------------------------------------------------------------------
+
+class TestVerifyToken:
+    def setup_method(self):
+        self.proc = get_registry().get_processor("verify")
+
+    def test_strips_verify_block(self):
+        result = self.proc.parse("code<verify>this looks right</verify>more")
+        assert result.clean_text == "codemore"
+        assert result.blocks == ["this looks right"]
+
+    def test_config(self):
+        cfg = get_registry().get_config("verify")
+        assert cfg.open_tag == "<verify>"
+        assert cfg.strip_from_output is True
+
+
+# ---------------------------------------------------------------------------
+# <plan> token
+# ---------------------------------------------------------------------------
+
+class TestPlanToken:
+    def setup_method(self):
+        self.proc = get_registry().get_processor("plan")
+
+    def test_strips_plan_block(self):
+        result = self.proc.parse("<plan>step1\nstep2</plan>def foo(): ...")
+        assert "step1" in result.blocks[0]
+        assert "def foo" in result.clean_text
+
+    def test_config(self):
+        cfg = get_registry().get_config("plan")
+        assert cfg.open_tag == "<plan>"
+        assert cfg.strip_from_output is True
+
+
+# ---------------------------------------------------------------------------
+# <uncertain> token
+# ---------------------------------------------------------------------------
+
+class TestUncertainToken:
+    def test_not_stripped_by_default(self):
+        cfg = get_registry().get_config("uncertain")
+        assert cfg.strip_from_output is False
+
+    def test_kept_in_strip_all(self):
+        text = "I think <uncertain>maybe not</uncertain> correct"
+        result = get_registry().strip_all(text)
+        assert "<uncertain>" in result
+
+    def test_extractor_detects_uncertainty(self):
+        ext = UncertainTokenExtractor()
+        assert ext.has_uncertainty("x <uncertain>y</uncertain>")
+        assert not ext.has_uncertainty("plain text")
+
+    def test_extractor_strips_markers_keeps_text(self):
+        ext = UncertainTokenExtractor()
+        out = ext.strip_markers("hello <uncertain>world</uncertain>!")
+        assert out == "hello world!"
+        assert "<uncertain>" not in out
+
+    def test_extractor_extracts_spans(self):
+        ext = UncertainTokenExtractor()
+        result = ext.extract("x<uncertain>span1</uncertain>y<uncertain>span2</uncertain>")
+        assert result.blocks == ["span1", "span2"]
+
+
+# ---------------------------------------------------------------------------
+# <search> token
+# ---------------------------------------------------------------------------
+
+class TestSearchToken:
+    def test_strips_when_no_retriever(self):
+        handler = SearchTokenHandler()
+        text = "before<search>my query</search>after"
+        assert handler.process(text) == "beforeafter"
+
+    def test_extracts_queries(self):
+        handler = SearchTokenHandler()
+        queries = handler.extract_queries("a<search>q1</search>b<search>q2</search>")
+        assert queries == ["q1", "q2"]
+
+    def test_count_searches(self):
+        handler = SearchTokenHandler()
+        assert handler.count_searches("<search>a</search><search>b</search>") == 2
+
+    def test_retriever_called(self):
+        class FakeRetriever:
+            def retrieve(self, query):
+                return [f"result for {query}"]
+
+        handler = SearchTokenHandler(retriever=FakeRetriever())
+        out = handler.process("answer: <search>capital of France</search> end")
+        assert "result for capital of France" in out
+        assert "<search>" not in out
+
+    def test_retriever_exception_strips(self):
+        class BrokenRetriever:
+            def retrieve(self, query):
+                raise RuntimeError("down")
+
+        handler = SearchTokenHandler(retriever=BrokenRetriever())
+        out = handler.process("x<search>q</search>y")
+        assert "<search>" not in out
+
+
+# ---------------------------------------------------------------------------
+# <lang:XX> token
+# ---------------------------------------------------------------------------
+
+class TestLangToken:
+    def setup_method(self):
+        self.proc = LangTokenProcessor()
+
+    def test_parse_returns_lang_and_block(self):
+        text = "Hello <lang:gl>Ola mundo</lang> world"
+        clean, blocks = self.proc.parse(text)
+        assert clean == "Hello  world"
+        assert blocks == [("gl", "Ola mundo")]
+
+    def test_multiple_languages(self):
+        text = "<lang:gl>Ola</lang> and <lang:pt>Olá</lang>"
+        clean, blocks = self.proc.parse(text)
+        assert len(blocks) == 2
+        assert blocks[0][0] == "gl"
+        assert blocks[1][0] == "pt"
+
+    def test_get_languages_used(self):
+        langs = self.proc.get_languages_used("<lang:gl>x</lang><lang:es>y</lang>")
+        assert langs == ["gl", "es"]
+
+    def test_has_lang_block(self):
+        assert self.proc.has_lang_block("<lang:gl>hola</lang>", "gl")
+        assert not self.proc.has_lang_block("<lang:gl>hola</lang>", "pt")
+
+    def test_strip(self):
+        out = self.proc.strip("before<lang:gl>Ola</lang>after")
+        assert out == "beforeafter"
+
+    def test_stream_filter_strips_lang_block(self):
+        f = LangTokenStreamFilter()
+        tokens = list("hi<lang:gl>Ola mundo</lang>bye")
+        out = "".join(f.feed(t) for t in tokens) + f.flush()
+        assert out == "hibye"
+
+    def test_stream_filter_partial_tag_held(self):
+        f = LangTokenStreamFilter()
+        out = f.feed("<lang")
+        assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# <debug> token
+# ---------------------------------------------------------------------------
+
+class TestDebugToken:
+    def setup_method(self):
+        self.proc = get_registry().get_processor("debug")
+
+    def test_strips_debug_block(self):
+        text = "result<debug>off by one: i should be i-1</debug>fix"
+        result = self.proc.parse(text)
+        assert result.clean_text == "resultfix"
+        assert "off by one" in result.blocks[0]
+
+    def test_config(self):
+        cfg = get_registry().get_config("debug")
+        assert cfg.open_tag == "<debug>"
+        assert cfg.strip_from_output is True
+
+
+# ---------------------------------------------------------------------------
+# Embedding initialization (requires numpy)
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingInit:
+    def test_embedding_init_runs(self):
+        pytest.importorskip("numpy")
+        import numpy as np
+        cfg = SpecialTokenConfig(
+            name="test_tok",
+            open_tag="<test>",
+            close_tag="</test>",
+            seed_tokens=["check", "assert"],
+            alpha=0.5,
+            boundary_token="<im_start>",
+        )
+        proc = SpecialTokenProcessor(cfg)
+        vocab_size, hidden = 100, 16
+        E = np.random.randn(vocab_size, hidden).astype(np.float32)
+        token_ids = {"check": 5, "assert": 10, "<im_start>": 1}
+        emb = proc.initialize_embedding(E, token_ids)
+        assert emb.shape == (hidden,)
+
+    def test_missing_seed_tokens_fallback(self):
+        pytest.importorskip("numpy")
+        import numpy as np
+        cfg = SpecialTokenConfig(
+            name="t2", open_tag="<t2>", close_tag="</t2>",
+            seed_tokens=["zzz_unknown"],
+        )
+        proc = SpecialTokenProcessor(cfg)
+        E = np.random.randn(50, 8).astype(np.float32)
+        emb = proc.initialize_embedding(E, {})
+        assert emb.shape == (8,)


### PR DESCRIPTION
## Summary

Generalizes the Think-Anywhere pattern (arXiv:2603.29957) into a reusable special-token framework and adds 6 new meta-token types, each as a separate commit.

### New module: `core/special_tokens/`

| Commit | Token | Purpose | strip? |
|---|---|---|---|
| `7919925` | `<verify>` | Self-verification before continuing | ✅ |
| `0fdaa09` | `<plan>` | Task decomposition before multi-step code | ✅ |
| `a40de78` | `<uncertain>` | Low-confidence region marker | ❌ kept as metadata |
| `fd27e34` | `<search>` | On-demand RAG trigger at token position | ✅ |
| `3bdcb5b` | `<lang:XX>` | Inline language switching (gl/pt/es/en/…) | ✅ |
| `f1b98f3` | `<debug>` | Code-error diagnosis before fix | ✅ |

### Framework (`616d98d`)

- `SpecialTokenConfig` — tags, seed tokens, alpha, strip flag
- `SpecialTokenProcessor` — parse / strip / semantic embedding init (Eqs. 5-6)
- `SpecialTokenStreamFilter` — real-time partial-tag suppression (same algorithm as ThinkAnywhereStreamFilter)
- `SpecialTokenRegistry` — global registry with `strip_all()`

### Notable design decisions

- `<uncertain>` has `strip_from_output=False` — preserved in output so callers can detect low-confidence spans, highlight them in UI, or trigger resampling.
- `<search>` includes `SearchTokenHandler` that integrates with `rag.retriever.Retriever` — replaces blocks inline with `[Retrieved: …]` context. Falls back to stripping when no retriever is configured.
- `<lang:XX>` uses a regex-based `LangTokenStreamFilter` (variable opener) with `_PARTIAL_RE` covering the language-code chars — character-by-character streaming tested and passing.
- `InferenceConfig.strip_special_tokens=True` (default) wires the registry into `HybridInferenceEngine.generate()`.

### Tests

39 tests in `tests/unit/test_special_tokens.py` — all passing:
- Registry, base processor/stream-filter
- Per-token: parse, strip, config flags
- `SearchTokenHandler` with mock retriever and exception handling
- `LangTokenStreamFilter` character-level streaming
- `UncertainTokenExtractor` span extraction
- Embedding initialization (numpy)

## Test plan

- [ ] `python -m pytest tests/unit/test_special_tokens.py -v` → 39 passed
- [ ] `python -c "from core.special_tokens import get_registry; print(get_registry().list_tokens())"` → 6 tokens
- [ ] Verify `<uncertain>` is NOT stripped by `strip_all()`
- [ ] Verify `SearchTokenHandler` with a real `rag.retriever.Retriever` instance

https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX)_