### PR TITLE
fix(inference): define ARM_INFERENCE_AVAILABLE before first use

### DIFF
--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -38,6 +38,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # Component availability flags
+ARM_INFERENCE_AVAILABLE = False
 QUANTIZED_INFERENCE_AVAILABLE = False
 QUANTIZATION_SYSTEM_AVAILABLE = False
 


### PR DESCRIPTION
## Summary

- Fixes `NameError: name 'ARM_INFERENCE_AVAILABLE' is not defined` in `inference/__init__.py` — the flag was referenced in the conditional `__all__` block at the bottom of the file but was never initialised, causing an import crash on any code path that imported `inference.hybrid_inference_engine`.

## Test plan

- [ ] `python -c "from inference.hybrid_inference_engine import InferenceConfig, THINK_ANYWHERE_AVAILABLE, SPECIAL_TOKENS_AVAILABLE"` — no error
- [ ] `python -m pytest tests/unit/test_think_anywhere.py tests/unit/test_special_tokens.py -q` → 72 passed

https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX)_