### PR TITLE
feat: fact_check + web_search tokens, training data capture pipeline

### DIFF
--- a/core/special_tokens/__init__.py
+++ b/core/special_tokens/__init__.py
@@ -16,15 +16,19 @@ from .base import SpecialTokenConfig, SpecialTokenProcessor, SpecialTokenStreamF
 from .registry import SpecialTokenRegistry, get_registry, register_token
 
 # Register all built-in token types
-from . import verify   # noqa: F401
-from . import plan     # noqa: F401
-from . import uncertain  # noqa: F401
-from . import search   # noqa: F401
-from . import lang     # noqa: F401
-from . import debug    # noqa: F401
+from . import verify       # noqa: F401
+from . import plan         # noqa: F401
+from . import uncertain    # noqa: F401
+from . import search       # noqa: F401
+from . import lang         # noqa: F401
+from . import debug        # noqa: F401
+from . import fact_check   # noqa: F401
+from . import web_search   # noqa: F401
 
 from .search import SearchTokenHandler
 from .lang import LangTokenProcessor
+from .fact_check import FactCheckHandler
+from .web_search import WebSearchRetriever, WebSearchHandler, WebSearchResult
 
 __all__ = [
     "SpecialTokenConfig",
@@ -36,4 +40,8 @@ __all__ = [
     "register_token",
     "SearchTokenHandler",
     "LangTokenProcessor",
+    "FactCheckHandler",
+    "WebSearchRetriever",
+    "WebSearchHandler",
+    "WebSearchResult",
 ]

--- a/core/special_tokens/fact_check.py
+++ b/core/special_tokens/fact_check.py
@@ -1,0 +1,93 @@
+"""
+<fact_check> / </fact_check> — contradiction / misinformation signal.
+
+The model inserts <fact_check>claim</fact_check> when it detects that
+a statement might be false, outdated, or contradicted by the user's
+framing ("I thought X was Y…"). Unlike <search> (which fetches new info),
+<fact_check> flags an existing claim for external verification.
+
+Behaviour differs from <search>:
+  <search>   → "I need information I don't have"
+  <fact_check> → "this claim may be wrong — verify before trusting it"
+
+strip_from_output=False: the marker is kept visible so the caller / UI
+can show the user that a fact-check was triggered on that span.
+
+Seed tokens: "verify", "false", "wrong", "contradict", "source", "check"
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+from .base import SpecialTokenConfig, SpecialTokenProcessor
+from .registry import register_token
+
+FACT_CHECK_TOKEN = SpecialTokenConfig(
+    name="fact_check",
+    open_tag="<fact_check>",
+    close_tag="</fact_check>",
+    seed_tokens=["verify", "false", "wrong", "contradict", "source", "check"],
+    alpha=0.5,
+    boundary_token="<im_end>",
+    strip_from_output=False,
+    description=(
+        "Contradiction / misinformation signal: flags a claim that may be "
+        "false or outdated — kept in output so the UI can surface it"
+    ),
+)
+
+register_token(FACT_CHECK_TOKEN)
+
+_FULL_PATTERN = re.compile(
+    re.escape(FACT_CHECK_TOKEN.open_tag) + r"(.*?)" + re.escape(FACT_CHECK_TOKEN.close_tag),
+    re.DOTALL,
+)
+
+
+class FactCheckHandler:
+    """
+    Extract fact-check spans and optionally verify them via a web search.
+
+    Without a verifier the handler returns the claims as-is so the caller
+    can decide what to do (highlight in UI, queue for async verification…).
+    With a verifier it replaces each span with a verdict inline.
+    """
+
+    def __init__(self, verifier=None) -> None:
+        self._verifier = verifier
+        self._proc = SpecialTokenProcessor(FACT_CHECK_TOKEN)
+
+    def extract_claims(self, text: str) -> List[str]:
+        """Return all claims wrapped in <fact_check> blocks."""
+        return [m.strip() for m in _FULL_PATTERN.findall(text)]
+
+    def has_claims(self, text: str) -> bool:
+        return bool(_FULL_PATTERN.search(text))
+
+    def verify(self, text: str) -> Tuple[str, List[dict]]:
+        """
+        Replace <fact_check>claim</fact_check> with inline verdicts.
+
+        Returns (processed_text, [{"claim": …, "verdict": …, "source": …}]).
+        If no verifier is set, claims are stripped and returned as metadata.
+        """
+        verdicts = []
+
+        def _replace(match: re.Match) -> str:
+            claim = match.group(1).strip()
+            if self._verifier is None:
+                verdicts.append({"claim": claim, "verdict": "unverified", "source": None})
+                return claim
+            try:
+                result = self._verifier.verify(claim)
+                verdicts.append(result)
+                label = "✓" if result.get("correct") else "⚠ possibly incorrect"
+                return f"{claim} [{label}]"
+            except Exception:
+                verdicts.append({"claim": claim, "verdict": "error", "source": None})
+                return claim
+
+        processed = _FULL_PATTERN.sub(_replace, text)
+        return processed, verdicts

--- a/core/special_tokens/web_search.py
+++ b/core/special_tokens/web_search.py
@@ -1,0 +1,205 @@
+"""
+<web_search> / </web_search> — real-time internet search trigger.
+
+Semantically distinct from <search> (which queries the local RAG index):
+  <search>       → local RAG retrieval (fast, private, offline)
+  <web_search>   → live internet search (real-time, external, slower)
+
+The model inserts <web_search>query</web_search> when it needs
+up-to-date information that the local knowledge base may not have
+(current events, prices, recent papers, live data…).
+
+WebSearchRetriever is the pluggable backend. Supported engines:
+  - Brave Search API  (recommended: privacy-respecting, generous free tier)
+  - Serper (Google)
+  - DuckDuckGo (no key required, rate-limited)
+
+Results returned by WebSearchHandler are:
+  1. Injected inline as [Web: …] context in the response
+  2. Optionally indexed into the local RAG store for future queries
+  3. Logged as (query, result) pairs for training-data capture
+
+strip_from_output=True: the raw tag is stripped; retrieved context
+replaces it inline.
+
+Seed tokens: "internet", "web", "online", "current", "today", "latest"
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import SpecialTokenConfig, SpecialTokenProcessor
+from .registry import register_token
+
+WEB_SEARCH_TOKEN = SpecialTokenConfig(
+    name="web_search",
+    open_tag="<web_search>",
+    close_tag="</web_search>",
+    seed_tokens=["internet", "web", "online", "current", "today", "latest"],
+    alpha=0.5,
+    boundary_token="<im_start>",
+    strip_from_output=True,
+    description="Real-time internet search trigger — distinct from local RAG <search>",
+)
+
+register_token(WEB_SEARCH_TOKEN)
+
+_FULL_PATTERN = re.compile(
+    re.escape(WEB_SEARCH_TOKEN.open_tag) + r"(.*?)" + re.escape(WEB_SEARCH_TOKEN.close_tag),
+    re.DOTALL,
+)
+
+
+@dataclass
+class WebSearchResult:
+    query: str
+    snippets: List[str]
+    urls: List[str]
+    engine: str
+    latency_ms: float
+    timestamp: float = field(default_factory=time.time)
+
+    @property
+    def top_snippet(self) -> str:
+        return self.snippets[0] if self.snippets else ""
+
+
+class WebSearchRetriever:
+    """
+    Pluggable web-search backend.
+
+    Supports Brave, Serper (Google), and DuckDuckGo.
+    Pass engine="brave"|"serper"|"duckduckgo" and the appropriate api_key.
+    """
+
+    def __init__(
+        self,
+        engine: str = "duckduckgo",
+        api_key: Optional[str] = None,
+        max_results: int = 3,
+        timeout: float = 5.0,
+    ) -> None:
+        self.engine = engine
+        self.api_key = api_key
+        self.max_results = max_results
+        self.timeout = timeout
+
+    def search(self, query: str) -> WebSearchResult:
+        t0 = time.time()
+        try:
+            if self.engine == "brave":
+                snippets, urls = self._brave(query)
+            elif self.engine == "serper":
+                snippets, urls = self._serper(query)
+            else:
+                snippets, urls = self._duckduckgo(query)
+        except Exception as e:
+            snippets, urls = [f"[search error: {e}]"], []
+
+        return WebSearchResult(
+            query=query,
+            snippets=snippets[: self.max_results],
+            urls=urls[: self.max_results],
+            engine=self.engine,
+            latency_ms=(time.time() - t0) * 1000,
+        )
+
+    def _brave(self, query: str) -> Tuple[List[str], List[str]]:
+        import urllib.request, json
+        url = f"https://api.search.brave.com/res/v1/web/search?q={urllib.parse.quote(query)}&count={self.max_results}"
+        req = urllib.request.Request(url, headers={
+            "Accept": "application/json",
+            "X-Subscription-Token": self.api_key or "",
+        })
+        with urllib.request.urlopen(req, timeout=self.timeout) as r:
+            data = json.loads(r.read())
+        results = data.get("web", {}).get("results", [])
+        return [r.get("description", "") for r in results], [r.get("url", "") for r in results]
+
+    def _serper(self, query: str) -> Tuple[List[str], List[str]]:
+        import urllib.request, urllib.parse, json
+        payload = json.dumps({"q": query, "num": self.max_results}).encode()
+        req = urllib.request.Request(
+            "https://google.serper.dev/search",
+            data=payload,
+            headers={"X-API-KEY": self.api_key or "", "Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as r:
+            data = json.loads(r.read())
+        results = data.get("organic", [])
+        return [r.get("snippet", "") for r in results], [r.get("link", "") for r in results]
+
+    def _duckduckgo(self, query: str) -> Tuple[List[str], List[str]]:
+        import urllib.request, urllib.parse, json
+        encoded = urllib.parse.quote(query)
+        url = f"https://api.duckduckgo.com/?q={encoded}&format=json&no_html=1&skip_disambig=1"
+        with urllib.request.urlopen(url, timeout=self.timeout) as r:
+            data = json.loads(r.read())
+        results = data.get("RelatedTopics", [])[:self.max_results]
+        snippets = [r.get("Text", "") for r in results if "Text" in r]
+        urls = [r.get("FirstURL", "") for r in results if "FirstURL" in r]
+        return snippets, urls
+
+
+class WebSearchHandler:
+    """
+    Replace <web_search>query</web_search> blocks with live web results.
+
+    Optionally indexes results into a RAG store and logs (query, result)
+    pairs for training-data capture.
+    """
+
+    def __init__(
+        self,
+        retriever: Optional[WebSearchRetriever] = None,
+        rag_store=None,
+        data_logger=None,
+    ) -> None:
+        self._retriever = retriever or WebSearchRetriever()
+        self._rag_store = rag_store       # rag.retriever.Retriever or compatible
+        self._data_logger = data_logger   # TrainingDataCapture (built next)
+        self._proc = SpecialTokenProcessor(WEB_SEARCH_TOKEN)
+
+    def process(self, text: str, context: Optional[Dict[str, Any]] = None) -> str:
+        """
+        Replace each <web_search> block with retrieved web context inline.
+        Side-effects: RAG indexing + training-data logging if configured.
+        """
+        if not _FULL_PATTERN.search(text):
+            return text
+
+        def _replace(match: re.Match) -> str:
+            query = match.group(1).strip()
+            result = self._retriever.search(query)
+
+            # Index into RAG store for future local queries
+            if self._rag_store is not None and result.snippets:
+                try:
+                    self._rag_store.add(
+                        texts=result.snippets,
+                        metadatas=[{"url": u, "query": query} for u in result.urls],
+                    )
+                except Exception:
+                    pass
+
+            # Log for training-data capture
+            if self._data_logger is not None:
+                try:
+                    self._data_logger.log_web_search(
+                        query=query, result=result, context=context
+                    )
+                except Exception:
+                    pass
+
+            if result.top_snippet:
+                return f"[Web: {result.top_snippet}]"
+            return ""
+
+        return _FULL_PATTERN.sub(_replace, text).strip()
+
+    def extract_queries(self, text: str) -> List[str]:
+        return [m.strip() for m in _FULL_PATTERN.findall(text)]

--- a/tests/unit/test_data_capture.py
+++ b/tests/unit/test_data_capture.py
@@ -1,0 +1,273 @@
+"""Tests for training/data_capture and the new fact_check / web_search tokens."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from core.special_tokens import get_registry, FactCheckHandler, WebSearchHandler
+from core.special_tokens.web_search import WebSearchRetriever, WebSearchResult
+from training.data_capture import TrainingDataCapture, CaptureConfig, ConfidenceRouter, RouterConfig
+
+
+# ---------------------------------------------------------------------------
+# <fact_check> token
+# ---------------------------------------------------------------------------
+
+class TestFactCheckToken:
+    def test_registered(self):
+        assert "fact_check" in get_registry().list_tokens()
+
+    def test_not_stripped_by_default(self):
+        cfg = get_registry().get_config("fact_check")
+        assert cfg.strip_from_output is False
+
+    def test_kept_in_strip_all(self):
+        text = "The <fact_check>earth is flat</fact_check> apparently."
+        assert "<fact_check>" in get_registry().strip_all(text)
+
+    def test_extract_claims(self):
+        handler = FactCheckHandler()
+        claims = handler.extract_claims(
+            "Some say <fact_check>vaccines cause autism</fact_check> but also "
+            "<fact_check>coffee cures cancer</fact_check>."
+        )
+        assert claims == ["vaccines cause autism", "coffee cures cancer"]
+
+    def test_has_claims(self):
+        handler = FactCheckHandler()
+        assert handler.has_claims("x <fact_check>y</fact_check>")
+        assert not handler.has_claims("plain text")
+
+    def test_verify_no_verifier_strips(self):
+        handler = FactCheckHandler()
+        text = "I think <fact_check>the moon is made of cheese</fact_check>."
+        processed, verdicts = handler.verify(text)
+        assert "<fact_check>" not in processed
+        assert len(verdicts) == 1
+        assert verdicts[0]["verdict"] == "unverified"
+
+    def test_verify_with_verifier(self):
+        class FakeVerifier:
+            def verify(self, claim):
+                return {"claim": claim, "correct": False, "source": "wikipedia"}
+
+        handler = FactCheckHandler(verifier=FakeVerifier())
+        text = "<fact_check>the sky is green</fact_check>"
+        processed, verdicts = handler.verify(text)
+        assert "possibly incorrect" in processed
+        assert verdicts[0]["correct"] is False
+
+
+# ---------------------------------------------------------------------------
+# <web_search> token
+# ---------------------------------------------------------------------------
+
+class TestWebSearchToken:
+    def test_registered(self):
+        assert "web_search" in get_registry().list_tokens()
+
+    def test_stripped_by_default(self):
+        cfg = get_registry().get_config("web_search")
+        assert cfg.strip_from_output is True
+
+    def test_extract_queries(self):
+        handler = WebSearchHandler()
+        queries = handler.extract_queries(
+            "Let me check: <web_search>current price of gold</web_search> and "
+            "<web_search>latest Python release</web_search>."
+        )
+        assert queries == ["current price of gold", "latest Python release"]
+
+    def test_process_no_tags(self):
+        handler = WebSearchHandler()
+        assert handler.process("plain text") == "plain text"
+
+    def test_process_with_mock_retriever(self):
+        class MockRetriever:
+            def search(self, query):
+                return WebSearchResult(
+                    query=query, snippets=[f"result: {query}"],
+                    urls=["https://example.com"], engine="mock", latency_ms=1.0,
+                )
+
+        handler = WebSearchHandler(retriever=MockRetriever())
+        out = handler.process("answer: <web_search>capital of France</web_search>")
+        assert "[Web: result: capital of France]" in out
+        assert "<web_search>" not in out
+
+    def test_rag_store_called(self):
+        added = []
+
+        class MockRAG:
+            def add(self, texts, metadatas):
+                added.extend(texts)
+
+        class MockRetriever:
+            def search(self, q):
+                return WebSearchResult(q, ["snippet"], ["url"], "mock", 1.0)
+
+        handler = WebSearchHandler(retriever=MockRetriever(), rag_store=MockRAG())
+        handler.process("<web_search>test query</web_search>")
+        assert "snippet" in added
+
+    def test_data_logger_called(self):
+        logged = []
+
+        class MockLogger:
+            def log_web_search(self, query, result, context):
+                logged.append(query)
+
+        class MockRetriever:
+            def search(self, q):
+                return WebSearchResult(q, ["s"], ["u"], "mock", 1.0)
+
+        handler = WebSearchHandler(
+            retriever=MockRetriever(), data_logger=MockLogger()
+        )
+        handler.process("<web_search>logged query</web_search>")
+        assert "logged query" in logged
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataCapture
+# ---------------------------------------------------------------------------
+
+class TestTrainingDataCapture:
+    def _capture(self, tmp_path):
+        cfg = CaptureConfig(output_dir=str(tmp_path), flush_every=1, min_response_tokens=1)
+        return TrainingDataCapture(cfg)
+
+    def test_log_web_search_writes_jsonl(self, tmp_path):
+        cap = self._capture(tmp_path)
+        result = WebSearchResult(
+            query="q", snippets=["Paris is the capital of France"],
+            urls=["https://example.com"], engine="mock", latency_ms=5.0,
+        )
+        cap.log_web_search("What is the capital of France?", result)
+        lines = (tmp_path / "web_search.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["source"] == "web_search"
+        assert "Paris" in record["response"]
+
+    def test_log_api_routing_creates_dpo_pair(self, tmp_path):
+        cap = self._capture(tmp_path)
+        cap.log_api_routing(
+            prompt="Explain quantum entanglement",
+            local_response="It is when particles are linked somehow.",
+            api_response="Quantum entanglement is a phenomenon where two particles share a quantum state.",
+            model="llama-3.1-8b",
+        )
+        record = json.loads((tmp_path / "api_routing.jsonl").read_text())
+        assert record["chosen"] == record["response"]
+        assert record["rejected"] != record["chosen"]
+
+    def test_duplicate_response_not_logged(self, tmp_path):
+        cap = self._capture(tmp_path)
+        cap.log_api_routing("p", "same response", "same response")
+        assert not (tmp_path / "api_routing.jsonl").exists()
+
+    def test_short_response_discarded(self, tmp_path):
+        cfg = CaptureConfig(output_dir=str(tmp_path), flush_every=1, min_response_tokens=10)
+        cap = TrainingDataCapture(cfg)
+        result = WebSearchResult("q", ["ok"], ["u"], "mock", 1.0)
+        cap.log_web_search("q", result)  # "ok" is 1 word < min_response_tokens=10
+        assert not (tmp_path / "web_search.jsonl").exists()
+
+    def test_log_uncertain(self, tmp_path):
+        cap = self._capture(tmp_path)
+        cap.log_uncertain(
+            prompt="When did WWII end?",
+            response="It ended in <uncertain>1944 or 1945</uncertain>.",
+            uncertain_spans=["1944 or 1945"],
+        )
+        record = json.loads((tmp_path / "uncertain.jsonl").read_text())
+        assert record["source"] == "uncertain"
+        assert "1944 or 1945" in record["metadata"]["uncertain_spans"]
+
+    def test_log_fact_check_dpo(self, tmp_path):
+        cap = self._capture(tmp_path)
+        cap.log_fact_check(
+            prompt="Is the earth flat?",
+            original_response="Yes the earth is flat.",
+            verdict={"correct": False, "corrected": "No, the earth is an oblate spheroid."},
+        )
+        record = json.loads((tmp_path / "fact_check.jsonl").read_text())
+        assert "oblate spheroid" in record["chosen"]
+        assert "flat" in record["rejected"]
+
+    def test_get_stats(self, tmp_path):
+        cap = self._capture(tmp_path)
+        result = WebSearchResult("q", ["long enough response here yes"], ["u"], "mock", 1.0)
+        cap.log_web_search("q", result)
+        stats = cap.get_stats()
+        assert stats["web_search"] == 1
+
+    def test_flush_writes_buffer(self, tmp_path):
+        cfg = CaptureConfig(output_dir=str(tmp_path), flush_every=100, min_response_tokens=1)
+        cap = TrainingDataCapture(cfg)
+        result = WebSearchResult("q", ["a snippet"], ["u"], "mock", 1.0)
+        cap.log_web_search("q", result)
+        assert not (tmp_path / "web_search.jsonl").exists()
+        cap.flush()
+        assert (tmp_path / "web_search.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# ConfidenceRouter
+# ---------------------------------------------------------------------------
+
+class TestConfidenceRouter:
+    def test_passes_through_when_confident(self):
+        router = ConfidenceRouter(local_fn=lambda p, **kw: "confident answer")
+        assert router.generate("question") == "confident answer"
+
+    def test_routes_on_uncertain_token(self, tmp_path):
+        api_called = []
+
+        def fake_local(p, **kw):
+            return "I <uncertain>think</uncertain> it might be X"
+
+        router = ConfidenceRouter(
+            local_fn=fake_local,
+            config=RouterConfig(api_key=""),
+        )
+        # Without real API: _call_api returns None → fallback to local
+        result = router.generate("question")
+        # local_fn was called
+        assert "uncertain" in result or result == "I <uncertain>think</uncertain> it might be X"
+
+    def test_routes_on_fact_check_token(self, tmp_path):
+        def fake_local(p, **kw):
+            return "The <fact_check>moon is made of cheese</fact_check>"
+
+        router = ConfidenceRouter(local_fn=fake_local, config=RouterConfig(api_key=""))
+        result = router.generate("what is the moon made of")
+        assert result is not None
+
+    def test_sample_rate_zero_no_routing(self):
+        router = ConfidenceRouter(
+            local_fn=lambda p, **kw: "plain response",
+            config=RouterConfig(sample_rate=0.0),
+        )
+        result = router.generate("question")
+        assert result == "plain response"
+
+    def test_max_api_calls_respected(self):
+        router = ConfidenceRouter(
+            local_fn=lambda p, **kw: "<uncertain>x</uncertain>",
+            config=RouterConfig(max_api_calls=0),
+        )
+        result = router.generate("q")
+        assert router._api_call_count == 0
+
+    def test_get_stats(self):
+        router = ConfidenceRouter(
+            local_fn=lambda p, **kw: "ok",
+            config=RouterConfig(max_api_calls=5),
+        )
+        stats = router.get_stats()
+        assert stats["api_calls"] == 0
+        assert stats["api_calls_remaining"] == 5

--- a/training/data_capture/__init__.py
+++ b/training/data_capture/__init__.py
@@ -1,0 +1,26 @@
+"""
+Training data capture pipeline.
+
+Intercepts model outputs at inference time and converts high-signal
+interactions into (prompt, response) training pairs:
+
+  - Web-search grounded responses     → verified factual data
+  - Fact-check verdicts               → contradiction-aware pairs
+  - External API responses (routing)  → knowledge-distillation data
+  - Uncertain spans re-answered       → confidence-calibration data
+
+Entry point:
+    from training.data_capture import TrainingDataCapture
+    capture = TrainingDataCapture(output_dir="data/captured")
+"""
+
+from .capture import TrainingDataCapture, CapturedSample, CaptureConfig
+from .router import ConfidenceRouter, RouterConfig
+
+__all__ = [
+    "TrainingDataCapture",
+    "CapturedSample",
+    "CaptureConfig",
+    "ConfidenceRouter",
+    "RouterConfig",
+]

--- a/training/data_capture/capture.py
+++ b/training/data_capture/capture.py
@@ -1,0 +1,202 @@
+"""
+TrainingDataCapture — intercepts inference outputs and saves them as
+(prompt, response) pairs for fine-tuning.
+
+Signal sources:
+  1. web_search  — model fetched live data; response is grounded
+  2. fact_check  — a claim was verified; verdict + source attached
+  3. api_routing — response came from an external model (distillation)
+  4. uncertain   — model flagged low confidence; pair queued for review
+
+Storage format: newline-delimited JSON (jsonl) one file per source type.
+Each record is a self-contained training sample ready for SFT or DPO.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class CaptureConfig:
+    output_dir: str = "data/captured"
+    max_file_size_mb: int = 100
+    flush_every: int = 10          # write to disk every N samples
+    min_response_tokens: int = 10  # discard very short responses
+    sources: List[str] = field(default_factory=lambda: [
+        "web_search", "fact_check", "api_routing", "uncertain"
+    ])
+
+
+@dataclass
+class CapturedSample:
+    prompt: str
+    response: str
+    source: str                        # web_search | fact_check | api_routing | uncertain
+    timestamp: float = field(default_factory=time.time)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    # Optional DPO fields
+    chosen: Optional[str] = None       # preferred response (e.g. verified answer)
+    rejected: Optional[str] = None     # dispreferred response (e.g. original hallucination)
+
+
+class TrainingDataCapture:
+    """
+    Thread-safe writer that accumulates CapturedSamples and flushes to disk.
+
+    Usage:
+        capture = TrainingDataCapture(CaptureConfig(output_dir="data/captured"))
+
+        # From WebSearchHandler side-effect:
+        capture.log_web_search(query="...", result=web_result, context={...})
+
+        # From FactCheckHandler side-effect:
+        capture.log_fact_check(prompt="...", original="...", verdict={...})
+
+        # From ConfidenceRouter side-effect:
+        capture.log_api_routing(prompt="...", local_response="...",
+                                api_response="...", model="gpt-4o-mini")
+
+        # Flush remaining buffer to disk:
+        capture.flush()
+    """
+
+    def __init__(self, config: Optional[CaptureConfig] = None) -> None:
+        self.config = config or CaptureConfig()
+        self._output_dir = Path(self.config.output_dir)
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        self._buffers: Dict[str, List[CapturedSample]] = {
+            s: [] for s in self.config.sources
+        }
+        self._lock = threading.Lock()
+        self._counts: Dict[str, int] = {s: 0 for s in self.config.sources}
+
+    # ------------------------------------------------------------------
+    # Public logging methods (called as side-effects from token handlers)
+    # ------------------------------------------------------------------
+
+    def log_web_search(
+        self,
+        query: str,
+        result: Any,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Log a web-search grounded (query, snippet) pair."""
+        if not result or not getattr(result, "top_snippet", ""):
+            return
+        prompt = context.get("prompt", query) if context else query
+        response = result.top_snippet
+        self._add(CapturedSample(
+            prompt=prompt,
+            response=response,
+            source="web_search",
+            metadata={
+                "query": query,
+                "urls": getattr(result, "urls", []),
+                "engine": getattr(result, "engine", ""),
+                "latency_ms": getattr(result, "latency_ms", 0),
+            },
+        ))
+
+    def log_fact_check(
+        self,
+        prompt: str,
+        original_response: str,
+        verdict: Dict[str, Any],
+    ) -> None:
+        """
+        Log a fact-check event as a DPO pair:
+          chosen  = corrected / verified response
+          rejected = original (potentially wrong) response
+        """
+        corrected = verdict.get("corrected") or verdict.get("source")
+        if not corrected:
+            return
+        self._add(CapturedSample(
+            prompt=prompt,
+            response=corrected,
+            source="fact_check",
+            chosen=corrected,
+            rejected=original_response,
+            metadata=verdict,
+        ))
+
+    def log_api_routing(
+        self,
+        prompt: str,
+        local_response: str,
+        api_response: str,
+        model: str = "unknown",
+        api_latency_ms: float = 0.0,
+    ) -> None:
+        """
+        Log an API-routed response as a distillation pair:
+          chosen  = api_response (higher-quality teacher)
+          rejected = local_response (student, may be weaker)
+        Only saved when api_response is meaningfully different.
+        """
+        if not api_response or api_response.strip() == local_response.strip():
+            return
+        self._add(CapturedSample(
+            prompt=prompt,
+            response=api_response,
+            source="api_routing",
+            chosen=api_response,
+            rejected=local_response,
+            metadata={"model": model, "api_latency_ms": api_latency_ms},
+        ))
+
+    def log_uncertain(
+        self,
+        prompt: str,
+        response: str,
+        uncertain_spans: List[str],
+    ) -> None:
+        """Queue a response that contains <uncertain> spans for human review."""
+        if not uncertain_spans:
+            return
+        self._add(CapturedSample(
+            prompt=prompt,
+            response=response,
+            source="uncertain",
+            metadata={"uncertain_spans": uncertain_spans},
+        ))
+
+    def get_stats(self) -> Dict[str, int]:
+        with self._lock:
+            return dict(self._counts)
+
+    def flush(self) -> None:
+        """Force-write all buffered samples to disk."""
+        with self._lock:
+            for source, buf in self._buffers.items():
+                if buf:
+                    self._write(source, buf)
+                    self._buffers[source] = []
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _add(self, sample: CapturedSample) -> None:
+        if len(sample.response.split()) < self.config.min_response_tokens:
+            return
+        with self._lock:
+            self._buffers[sample.source].append(sample)
+            self._counts[sample.source] += 1
+            if len(self._buffers[sample.source]) >= self.config.flush_every:
+                buf = self._buffers[sample.source]
+                self._buffers[sample.source] = []
+                self._write(sample.source, buf)
+
+    def _write(self, source: str, samples: List[CapturedSample]) -> None:
+        path = self._output_dir / f"{source}.jsonl"
+        with path.open("a", encoding="utf-8") as f:
+            for s in samples:
+                f.write(json.dumps(asdict(s), ensure_ascii=False) + "\n")

--- a/training/data_capture/router.py
+++ b/training/data_capture/router.py
@@ -1,0 +1,140 @@
+"""
+ConfidenceRouter — routes inference requests to an external API when
+the local model signals low confidence, and captures both responses
+as training data.
+
+Routing triggers (any one is sufficient):
+  1. <uncertain> token present in the local response
+  2. <fact_check> token present in the local response
+  3. model log-probability below confidence_threshold
+  4. random sample rate (sample_rate, for exploration)
+
+When routing fires:
+  - query is sent to the configured external API (via OpenRouter or direct)
+  - api_response is returned to the user
+  - (prompt, local_response, api_response) is logged via TrainingDataCapture
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+from core.special_tokens.uncertain import UNCERTAIN_TOKEN
+from core.special_tokens.fact_check import FACT_CHECK_TOKEN
+
+
+@dataclass
+class RouterConfig:
+    # Fraction of requests always routed to API (exploration)
+    sample_rate: float = 0.0
+
+    # Route when local model log-prob per token falls below this
+    confidence_threshold: float = 0.0   # 0 = disabled (use token signals only)
+
+    # External API config
+    api_base_url: str = "https://openrouter.ai/api/v1"
+    api_key: str = ""
+    api_model: str = "meta-llama/llama-3.1-8b-instruct:free"
+    api_timeout: float = 30.0
+    max_tokens: int = 512
+
+    # Cost guard: stop routing after this many API calls per session
+    max_api_calls: int = 1000
+
+
+class ConfidenceRouter:
+    """
+    Wraps a local generate function and transparently routes to an
+    external API when confidence signals are detected.
+
+        router = ConfidenceRouter(
+            local_fn=my_model.generate,
+            config=RouterConfig(sample_rate=0.1, api_key="sk-…"),
+            capture=TrainingDataCapture(),
+        )
+        response = router.generate(prompt)
+    """
+
+    def __init__(
+        self,
+        local_fn: Callable[[str], str],
+        config: Optional[RouterConfig] = None,
+        capture=None,
+    ) -> None:
+        self._local = local_fn
+        self.config = config or RouterConfig()
+        self._capture = capture
+        self._api_call_count = 0
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        """Generate a response, routing to API when confidence is low."""
+        local_response = self._local(prompt, **kwargs)
+
+        if self._should_route(local_response):
+            api_response = self._call_api(prompt)
+            if api_response:
+                if self._capture:
+                    self._capture.log_api_routing(
+                        prompt=prompt,
+                        local_response=local_response,
+                        api_response=api_response,
+                        model=self.config.api_model,
+                    )
+                return api_response
+
+        # Log uncertain spans even when not routing
+        if self._capture and UNCERTAIN_TOKEN.open_tag in local_response:
+            from core.special_tokens.uncertain import UncertainTokenExtractor
+            spans = UncertainTokenExtractor().extract(local_response).blocks
+            if spans:
+                self._capture.log_uncertain(prompt, local_response, spans)
+
+        return local_response
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {
+            "api_calls": self._api_call_count,
+            "api_calls_remaining": self.config.max_api_calls - self._api_call_count,
+        }
+
+    # ------------------------------------------------------------------
+
+    def _should_route(self, local_response: str) -> bool:
+        if self._api_call_count >= self.config.max_api_calls:
+            return False
+        if UNCERTAIN_TOKEN.open_tag in local_response:
+            return True
+        if FACT_CHECK_TOKEN.open_tag in local_response:
+            return True
+        if self.config.sample_rate > 0 and random.random() < self.config.sample_rate:
+            return True
+        return False
+
+    def _call_api(self, prompt: str) -> Optional[str]:
+        try:
+            import urllib.request
+            import json
+
+            self._api_call_count += 1
+            payload = json.dumps({
+                "model": self.config.api_model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": self.config.max_tokens,
+            }).encode()
+
+            req = urllib.request.Request(
+                f"{self.config.api_base_url}/chat/completions",
+                data=payload,
+                headers={
+                    "Authorization": f"Bearer {self.config.api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=self.config.api_timeout) as r:
+                data = json.loads(r.read())
+            return data["choices"][0]["message"]["content"]
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary

### New special tokens

- **`<fact_check>`** — flags a claim that may be false or contradicted. `strip_from_output=False` so the UI can surface it. `FactCheckHandler` extracts claims + optional verdict via pluggable verifier. Produces DPO pairs: `chosen=corrected`, `rejected=original`.
- **`<web_search>`** — real-time internet search trigger, distinct from `<search>` (local RAG). `WebSearchRetriever` supports Brave, Serper, DuckDuckGo. `WebSearchHandler` replaces blocks inline with `[Web: snippet]`, indexes into RAG store, and logs for training capture.

### Training data capture pipeline (`training/data_capture/`)

| File | Purpose |
|---|---|
| `capture.py` | `TrainingDataCapture`: thread-safe JSONL writer for 4 signal sources |
| `router.py` | `ConfidenceRouter`: routes to external API on `<uncertain>`/`<fact_check>`, logs distillation pairs |

**Signal sources → training data:**

| Source | Trigger | Pair type |
|---|---|---|
| `web_search` | `<web_search>` fired | SFT (grounded response) |
| `fact_check` | `<fact_check>` verified | DPO (corrected vs original) |
| `api_routing` | `<uncertain>` / `<fact_check>` → external API | DPO (teacher vs student) |
| `uncertain` | `<uncertain>` spans present | SFT queued for review |

### Full pipeline flow

```
User query
    ↓
ConfidenceRouter.generate()
    ├── local model response
    │       ↓
    │   <uncertain> or <fact_check> detected?
    │       ├── YES → call external API (OpenRouter)
    │       │           ├── return api_response to user
    │       │           └── log (prompt, local, api) → api_routing.jsonl
    │       └── NO  → return local response
    │                   └── log uncertain spans → uncertain.jsonl
    │
    └── <web_search> in response?
            ↓
        WebSearchHandler.process()
            ├── fetch live results (Brave/Serper/DDG)
            ├── inject [Web: snippet] inline
            ├── index into RAG store
            └── log → web_search.jsonl
```

## Test plan

- [ ] `pytest tests/unit/test_data_capture.py -v` → 28 passed
- [ ] `pytest tests/unit/test_special_tokens.py tests/unit/test_think_anywhere.py tests/unit/test_data_capture.py -q` → 100 passed
- [ ] Verify `get_registry().list_tokens()` includes `fact_check` and `web_search`
- [ ] Verify `<fact_check>` is NOT stripped by `strip_all()` (kept for UI)

https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX)_