### PR TITLE
docs: TOON integration documentation + BACKLOG ISSUE-007

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -131,6 +131,38 @@ Coverage ratio is roughly one test file per 3,800 LOC and ~0.85 test functions p
 
 ---
 
+## ISSUE-007 — `core/special_tokens`: validate TOON context parsing on 3B base model
+
+**Labels:** `inference`, `toon`, `fine-tuning`, `quality`
+
+**Scope**
+
+- `core/special_tokens/search.py` — `SearchTokenHandler(use_toon=True)`
+- `core/special_tokens/web_search.py` — `WebSearchHandler(use_toon=True)`
+- Fine-tuning pipeline that prepares training data for the 3B model
+
+**Problem**
+
+TOON tabular format reduces RAG/web-search prompt tokens by ~30–40%, but
+a 3B base model trained before TOON existed (pre-Nov 2025) has not seen
+this format during pretraining. When context is dense (many results, long
+snippets), the model may misparse tabular rows or ignore them, degrading
+response quality. The `use_toon=False` fallback exists but has not been
+empirically evaluated on the target model.
+
+**Exit criteria**
+
+- Benchmark: compare accuracy with `use_toon=True` vs `False` on a
+  held-out RAG-dependent eval set (min 200 examples).
+- If accuracy drops >2 points: add TOON-formatted examples to fine-tuning
+  data via `training/data_capture` pipeline and re-evaluate after one
+  fine-tuning run.
+- If accuracy is equivalent or better: document as validated in this entry.
+- Once validated, confirm `use_toon=True` as default or flip to `False`
+  and defer TOON fine-tuning to a later milestone.
+
+---
+
 ## Resolved
 
 - **Sanitize per-folder TODO documentation** — removed all 20 per-folder `TODOs.md`, the two global aggregators (`TODOs.md`, `TODOs_PRIORITIZED.md`) and the generator script `scripts/clean_todos.py`. Pending work now lives only in this file.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,40 @@ register_token(SpecialTokenConfig(
 ))
 ```
 
+### TOON context compression
+
+`SearchTokenHandler` and `WebSearchHandler` serialize multi-result context
+using **TOON (Token-Oriented Object Notation)** before injecting it into
+the prompt — reducing input token overhead by ~30–40% for uniform arrays.
+
+```
+# Before (JSON-style, ~40 tokens):
+[Retrieved: {"text": "Paris is the capital", "score": "0.9"}]
+[Retrieved: {"text": "Population 2M", "score": "0.8"}]
+
+# After (TOON, ~25 tokens):
+[Retrieved:
+results[2]{text,score}:
+  Paris is the capital,0.9
+  Population 2M,0.8]
+```
+
+**Impact:**
+- ~30–40% fewer input tokens for RAG / web-search context injections
+- Direct cost saving on external API calls (`ConfidenceRouter`) charged per input token
+- Larger effective context window: more results fit in the same token budget → better quality
+
+**Known limitation:** a 3B base model without TOON fine-tuning may misparse
+dense tabular context. Disable with `use_toon=False` if accuracy degrades,
+and track via `BACKLOG.md ISSUE-007`. Single-result queries always fall back
+to plain text regardless of this setting.
+
+```python
+# Opt out if the model struggles with TOON context
+handler = SearchTokenHandler(retriever=my_rag, use_toon=False)
+handler = WebSearchHandler(retriever=my_web, use_toon=False)
+```
+
 ## Training data capture
 
 `training/data_capture/` intercepts high-signal inference interactions and


### PR DESCRIPTION
## Summary

Documents the TOON integration added in #141 and registers the known limitation as a trackable backlog item.

**README** — new "TOON context compression" subsection:
- Before/after token comparison (~40 → ~25 tokens for 2 results)
- Economic impact: ~30–40% fewer input tokens on external API calls
- Context-window benefit: more results fit in same token budget
- Known limitation: 3B base model without TOON fine-tuning may misparse dense tabular context
- `use_toon=False` opt-out documented with code example

**BACKLOG** — new ISSUE-007:
- Scope: `SearchTokenHandler` and `WebSearchHandler` with `use_toon=True`
- Problem: 3B model predates TOON (Nov 2025), no empirical validation done yet
- Exit criteria: 200-example benchmark; conditional fine-tuning via `training/data_capture` if accuracy drops >2 points

https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvmLvAMUhzi2nwdN1XPXyX)_